### PR TITLE
NuGet.Config hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(check_mmdep)
 include(ClangFormat)
 
 # NuGet
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/NuGet.config ${CMAKE_CURRENT_BINARY_DIR}/NuGet.config COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/NuGet.Config ${CMAKE_CURRENT_BINARY_DIR}/NuGet.Config COPYONLY)
 
 ###############################
 # Vislib


### PR DESCRIPTION
Because Linux is case sensitive