### PR TITLE
Fix configurator crash?

### DIFF
--- a/configurator/MegaMolConf/Form1.cs
+++ b/configurator/MegaMolConf/Form1.cs
@@ -847,7 +847,7 @@ namespace MegaMolConf {
             {
                 foreach (var parameterValue in gm.ParameterValues)
                 {
-                     mmii.SendUpdate(parameterValue.Key.Name, parameterValue.Value);
+                     mmii.SendUpdate(gm, parameterValue.Key.Name, parameterValue.Value);
                 }
             }
         }
@@ -1794,7 +1794,7 @@ in PowerShell:
             RefreshCurrent();
             MegaMolInstanceInfo mmii = tabViews.SelectedTab.Tag as MegaMolInstanceInfo;
             if (mmii != null) {
-                mmii.SendUpdate(e.ChangedItem.Label, e.ChangedItem.Value.ToString());
+                mmii.SendUpdate(Form1.selectedModule, e.ChangedItem.Label, e.ChangedItem.Value.ToString());
             }
         }
 

--- a/configurator/MegaMolConf/MegaMolInstanceInfo.cs
+++ b/configurator/MegaMolConf/MegaMolInstanceInfo.cs
@@ -251,7 +251,6 @@ namespace MegaMolConf {
             }
             while (!stopQueued) {
                 System.Threading.Thread.Sleep(1000);
-                GraphicalModule gm = Form1.selectedModule;
                 // check current tab (is the correct instance controlled)
                 if (stopQueued) {
                     break;
@@ -324,6 +323,8 @@ namespace MegaMolConf {
                         connectionDeletions.Clear();
                     }
 
+                    // what the hell?
+                    GraphicalModule gm = Form1.selectedModule;
                     if (gm != null) {
 #if true
                         if (stopQueued)
@@ -415,8 +416,7 @@ namespace MegaMolConf {
             }
         }
 
-        internal void SendUpdate(string p, string v) {
-            GraphicalModule gm = Form1.selectedModule;
+        internal void SendUpdate(GraphicalModule gm, string p, string v) {
             if (gm != null) {
                 string prefix = $"{ParentForm.TabInstantiation(TabPage)}::{gm.Name}::";
                 string ans = null;
@@ -427,6 +427,10 @@ namespace MegaMolConf {
         }
 
         bool TryGetAnswer(ref string answer, ref string err) {
+            if (Connection == null)
+            {
+                return false;
+            }
             Communication.Response r = new Response();
             bool good = Connection.TryReceive(ref r, ref err);
             if (r != null) {


### PR DESCRIPTION
Exception von Tobi:
```
************* Exception Text *************
System.NullReferenceException: Object reference not set to an instance of an object.
   at MegaMolConf.MegaMolInstanceInfo.TryGetAnswer(String& answer, String& err)
   at MegaMolConf.MegaMolInstanceInfo.GetAnswer(String& answer)
   at MegaMolConf.MegaMolInstanceInfo.SendUpdate(String p, String v)
   at MegaMolConf.Form1.propertyGrid1_PropertyValueChanged(Object s, PropertyValueChangedEventArgs e)
   at System.Windows.Forms.PropertyGrid.OnPropertyValueChanged(PropertyValueChangedEventArgs e)
   at System.Windows.Forms.PropertyGridInternal.PropertyGridView.CommitValue(GridEntry ipeCur, Object value)
   at System.Windows.Forms.PropertyGridInternal.PropertyGridView.Commit()
   at System.Windows.Forms.PropertyGridInternal.PropertyGridView.UnfocusSelection()
   at System.Windows.Forms.PropertyGridInternal.PropertyGridView.GridViewEdit.ProcessDialogKey(Keys keyData)
   at System.Windows.Forms.Control.PreProcessMessage(Message& msg)
   at System.Windows.Forms.Control.PreProcessControlMessageInternal(Control target, Message& msg)
   at System.Windows.Forms.Application.ThreadContext.PreTranslateMessage(MSG& msg)
```

Ich hab keine Ahnung ob das Probleme behebt, weil ich den Crash nicht reproduzieren kann und weil `Form1` ganz wild in MegaMolInstanceInfo verwendet wird - Trennung von Modell und Rest: Fehlanzeige :(