### PR TITLE
GUI: Minor Usability Changes

### DIFF
--- a/console/src/ButtonParamUILayer.cpp
+++ b/console/src/ButtonParamUILayer.cpp
@@ -30,6 +30,7 @@ bool ButtonParamUILayer::Enabled() {
 }
 
 bool ButtonParamUILayer::OnKey(core::view::Key key, core::view::KeyAction action, core::view::Modifiers mods) {
+
     if ((std::chrono::system_clock::now() - last_update) > std::chrono::seconds(1)) {
         // update list periodically
         updateHotkeyList();
@@ -40,7 +41,7 @@ bool ButtonParamUILayer::OnKey(core::view::Key key, core::view::KeyAction action
 
     core::view::KeyCode keyCode(key, mods);
 
-    auto hotkey = hotkeys.find(keyCode);
+    auto hotkey = hotkeys.find(keyCode.ToString());
     if (hotkey == hotkeys.end()) return false;
 
     CoreHandle hParam;
@@ -56,7 +57,7 @@ namespace {
     struct enumData {
         void *hCore;
         void *hView;
-        std::map<core::view::KeyCode, vislib::TString> hotKeys;
+        std::map<std::string, vislib::TString> hotKeys;
     };
 
     void MEGAMOLCORE_CALLBACK enumParameters(const TCHAR *name, struct enumData *data) {
@@ -85,7 +86,7 @@ namespace {
 
         // store param handle as part of the key codes
         core::view::KeyCode keyCode(static_cast<core::view::Key>(static_cast<int>(key)), core::view::Modifiers(static_cast<int>(mods)));
-        data->hotKeys[keyCode] = name;
+        data->hotKeys[keyCode.ToString()] = name;
     }
 
 }

--- a/console/src/ButtonParamUILayer.h
+++ b/console/src/ButtonParamUILayer.h
@@ -36,7 +36,7 @@ namespace console {
         void *hView; // handle memory is owned by Window
 
         std::chrono::system_clock::time_point last_update;
-        std::map<core::view::KeyCode, vislib::TString> hotkeys;
+        std::map<std::string, vislib::TString> hotkeys;
         AbstractUILayer *maskingLayer;
     };
 

--- a/console/src/WindowManager.cpp
+++ b/console/src/WindowManager.cpp
@@ -238,11 +238,14 @@ bool megamol::console::WindowManager::InstantiatePendingView(void *hCore) {
 
     w->AddUILayer(std::make_shared<ViewUILayer>(*w.get(), w->Handle()));
 
-#ifdef HAS_ANTTWEAKBAR
     std::shared_ptr<ButtonParamUILayer> btnLayer = std::make_shared<ButtonParamUILayer>(*w.get(), hCore, w->Handle());
     w->AddUILayer(btnLayer);
 
-    btnLayer->SetMaskingLayer(atbLayer.get());
+#ifdef HAS_ANTTWEAKBAR
+    // Mask ButtonParamUILayer only if AntTweakBar is enabled
+    if (atbLayer->Enabled()) {
+        btnLayer->SetMaskingLayer(atbLayer.get());
+    }
 #endif /* HAS_ANTTWEAKBAR */
 
     w->AddUILayer(std::make_shared<gl::WindowEscapeHotKeysUILayer>(*w.get())); // add as last. This allows MegaMol module buttons to use 'q' (and 'ESC') as hotkeys, overriding this hotkey

--- a/console/src/gl/ATBUILayer.cpp
+++ b/console/src/gl/ATBUILayer.cpp
@@ -118,148 +118,144 @@ bool gl::ATBUILayer::OnKey(core::view::Key key, core::view::KeyAction action, co
         atbKeyMod |= TW_KMOD_ALT;
     }
 
-
     // Process key pressed
     if (action == core::view::KeyAction::PRESS || action == core::view::KeyAction::REPEAT) {
+
         bool testkp = ((atbKeyMod & TW_KMOD_CTRL) || (atbKeyMod & TW_KMOD_ALT)) ? true : false;
 
+        int k = 0;
+        switch (key) {
+        case core::view::Key::KEY_SPACE: k = TW_KEY_SPACE; break;
+        case core::view::Key::KEY_APOSTROPHE: k = '\''; break;
+        case core::view::Key::KEY_COMMA: k = ','; break;
+        case core::view::Key::KEY_MINUS: k = '-'; break;
+        case core::view::Key::KEY_PERIOD: k = '.'; break;
+        case core::view::Key::KEY_SLASH: k = '/'; break;
+        case core::view::Key::KEY_0: k = '0'; break;
+        case core::view::Key::KEY_1: k = '1'; break;
+        case core::view::Key::KEY_2: k = '2'; break;
+        case core::view::Key::KEY_3: k = '3'; break;
+        case core::view::Key::KEY_4: k = '4'; break;
+        case core::view::Key::KEY_5: k = '5'; break;
+        case core::view::Key::KEY_6: k = '6'; break;
+        case core::view::Key::KEY_7: k = '7'; break;
+        case core::view::Key::KEY_8: k = '8'; break;
+        case core::view::Key::KEY_9: k = '9'; break;
+        case core::view::Key::KEY_SEMICOLON: k = ';'; break;
+        case core::view::Key::KEY_EQUAL: k = '='; break;
+        case core::view::Key::KEY_A: k = 'a'; break;
+        case core::view::Key::KEY_B: k = 'b'; break;
+        case core::view::Key::KEY_C: k = 'c'; break;
+        case core::view::Key::KEY_D: k = 'd'; break;
+        case core::view::Key::KEY_E: k = 'e'; break;
+        case core::view::Key::KEY_F: k = 'f'; break;
+        case core::view::Key::KEY_G: k = 'g'; break;
+        case core::view::Key::KEY_H: k = 'h'; break;
+        case core::view::Key::KEY_I: k = 'i'; break;
+        case core::view::Key::KEY_J: k = 'j'; break;
+        case core::view::Key::KEY_K: k = 'k'; break;
+        case core::view::Key::KEY_L: k = 'l'; break;
+        case core::view::Key::KEY_M: k = 'm'; break;
+        case core::view::Key::KEY_N: k = 'n'; break;
+        case core::view::Key::KEY_O: k = 'o'; break;
+        case core::view::Key::KEY_P: k = 'p'; break;
+        case core::view::Key::KEY_Q: k = 'q'; break;
+        case core::view::Key::KEY_R: k = 'r'; break;
+        case core::view::Key::KEY_S: k = 's'; break;
+        case core::view::Key::KEY_T: k = 't'; break;
+        case core::view::Key::KEY_U: k = 'u'; break;
+        case core::view::Key::KEY_V: k = 'v'; break;
+        case core::view::Key::KEY_W: k = 'w'; break;
+        case core::view::Key::KEY_X: k = 'x'; break;
+        case core::view::Key::KEY_Y: k = 'y'; break;
+        case core::view::Key::KEY_Z: k = 'z'; break;
+        case core::view::Key::KEY_LEFT_BRACKET: k = '('; break;
+        case core::view::Key::KEY_BACKSLASH: k = '\\'; break;
+        case core::view::Key::KEY_RIGHT_BRACKET: k = ')'; break;
+        case core::view::Key::KEY_GRAVE_ACCENT: k = '´'; break;
+        //case core::view::Key::KEY_WORLD_1: k = TW_KEY_WORLD_1; break;
+        //case core::view::Key::KEY_WORLD_2: k = TW_KEY_WORLD_2; break;
+        case core::view::Key::KEY_ESCAPE: k = TW_KEY_ESCAPE; break;
+        case core::view::Key::KEY_ENTER: k = TW_KEY_RETURN; break;
+        case core::view::Key::KEY_TAB: k = TW_KEY_TAB; break;
+        case core::view::Key::KEY_BACKSPACE: k = TW_KEY_BACKSPACE; break;
+        case core::view::Key::KEY_INSERT: k = TW_KEY_INSERT; break;
+        case core::view::Key::KEY_DELETE: k = TW_KEY_DELETE; break;
+        case core::view::Key::KEY_RIGHT: k = TW_KEY_RIGHT; break;
+        case core::view::Key::KEY_LEFT: k = TW_KEY_LEFT; break;
+        case core::view::Key::KEY_DOWN: k = TW_KEY_DOWN; break;
+        case core::view::Key::KEY_UP: k = TW_KEY_UP; break;
+        case core::view::Key::KEY_PAGE_UP: k = TW_KEY_PAGE_UP; break;
+        case core::view::Key::KEY_PAGE_DOWN: k = TW_KEY_PAGE_DOWN; break;
+        case core::view::Key::KEY_HOME: k = TW_KEY_HOME; break;
+        case core::view::Key::KEY_END: k = TW_KEY_END; break;
+        //case core::view::Key::KEY_CAPS_LOCK: k = TW_KEY_CAPS_LOCK; break;
+        //case core::view::Key::KEY_SCROLL_LOCK: k = TW_KEY_SCROLL_LOCK; break;
+        //case core::view::Key::KEY_NUM_LOCK: k = TW_KEY_NUM_LOCK; break;
+        //case core::view::Key::KEY_PRINT_SCREEN: k = TW_KEY_PRINT_SCREEN; break;
+        case core::view::Key::KEY_PAUSE: k = TW_KEY_PAUSE; break;
+        case core::view::Key::KEY_F1: k = TW_KEY_F1; break;
+        case core::view::Key::KEY_F2: k = TW_KEY_F2; break;
+        case core::view::Key::KEY_F3: k = TW_KEY_F3; break;
+        case core::view::Key::KEY_F4: k = TW_KEY_F4; break;
+        case core::view::Key::KEY_F5: k = TW_KEY_F5; break;
+        case core::view::Key::KEY_F6: k = TW_KEY_F6; break;
+        case core::view::Key::KEY_F7: k = TW_KEY_F7; break;
+        case core::view::Key::KEY_F8: k = TW_KEY_F8; break;
+        case core::view::Key::KEY_F9: k = TW_KEY_F9; break;
+        case core::view::Key::KEY_F10: k = TW_KEY_F10; break;
+        case core::view::Key::KEY_F11: k = TW_KEY_F11; break;
+        case core::view::Key::KEY_F12: k = TW_KEY_F12; break;
+        case core::view::Key::KEY_F13: k = TW_KEY_F13; break;
+        case core::view::Key::KEY_F14: k = TW_KEY_F14; break;
+        case core::view::Key::KEY_F15: k = TW_KEY_F15; break;
+        case core::view::Key::KEY_F16: k = TW_KEY_F10 + 6; break;
+        case core::view::Key::KEY_F17: k = TW_KEY_F10 + 7; break;
+        case core::view::Key::KEY_F18: k = TW_KEY_F10 + 8; break;
+        case core::view::Key::KEY_F19: k = TW_KEY_F10 + 9; break;
+        case core::view::Key::KEY_F20: k = TW_KEY_F10 + 10; break;
+        case core::view::Key::KEY_F21: k = TW_KEY_F10 + 11; break;
+        case core::view::Key::KEY_F22: k = TW_KEY_F10 + 12; break;
+        case core::view::Key::KEY_F23: k = TW_KEY_F10 + 13; break;
+        case core::view::Key::KEY_F24: k = TW_KEY_F10 + 14; break;
+        case core::view::Key::KEY_F25: k = TW_KEY_F10 + 15; break;
+        case core::view::Key::KEY_KP_0: if (testkp) k = '0'; break;
+        case core::view::Key::KEY_KP_1: if (testkp) k = '1'; break;
+        case core::view::Key::KEY_KP_2: if (testkp) k = '2'; break;
+        case core::view::Key::KEY_KP_3: if (testkp) k = '3'; break;
+        case core::view::Key::KEY_KP_4: if (testkp) k = '4'; break;
+        case core::view::Key::KEY_KP_5: if (testkp) k = '5'; break;
+        case core::view::Key::KEY_KP_6: if (testkp) k = '6'; break;
+        case core::view::Key::KEY_KP_7: if (testkp) k = '7'; break;
+        case core::view::Key::KEY_KP_8: if (testkp) k = '8'; break;
+        case core::view::Key::KEY_KP_9: if (testkp) k = '9'; break;
+        case core::view::Key::KEY_KP_DECIMAL: if (testkp) k = '.'; break;
+        case core::view::Key::KEY_KP_DIVIDE: if (testkp) k = '/'; break;
+        case core::view::Key::KEY_KP_MULTIPLY: if (testkp) k = '*'; break;
+        case core::view::Key::KEY_KP_SUBTRACT: if (testkp) k = '-'; break;
+        case core::view::Key::KEY_KP_ADD: if (testkp) k = '+'; break;
+        case core::view::Key::KEY_KP_ENTER: k = TW_KEY_RETURN; break;
+        case core::view::Key::KEY_KP_EQUAL: if (testkp) k = '='; break;
+        //case core::view::Key::KEY_LEFT_SHIFT: k = TW_KEY_LEFT_SHIFT; break;
+        //case core::view::Key::KEY_LEFT_CONTROL: k = TW_KEY_LEFT_CONTROL; break;
+        //case core::view::Key::KEY_LEFT_ALT: k = TW_KEY_LEFT_ALT; break;
+        //case core::view::Key::KEY_LEFT_SUPER: k = TW_KEY_LEFT_SUPER; break;
+        //case core::view::Key::KEY_RIGHT_SHIFT: k = TW_KEY_RIGHT_SHIFT; break;
+        //case core::view::Key::KEY_RIGHT_CONTROL: k = TW_KEY_RIGHT_CONTROL; break;
+        //case core::view::Key::KEY_RIGHT_ALT: k = TW_KEY_RIGHT_ALT; break;
+        //case core::view::Key::KEY_RIGHT_SUPER: k = TW_KEY_RIGHT_SUPER; break;
+        //case core::view::Key::KEY_MENU: k = TW_KEY_MENU; break;
+        default: break;
+        }
+
+        // Print CTRL cases
         if ((atbKeyMod == TW_KMOD_CTRL) && (key > static_cast<core::view::Key>(0)) && (key < core::view::Key::KEY_ESCAPE)) {
-            // CTRL cases
-            printf(" key %d + %d\n", key, atbKeyMod);
-            if (::TwKeyPressed(static_cast<int>(key), atbKeyMod)) {
+            printf(" key %d + %d\n", k, atbKeyMod);
+        }
+
+        if (k > 0) {
+            if (::TwKeyPressed(k, atbKeyMod)) {
                 return true;
-            }
-
-        } else if (key >= core::view::Key::KEY_ESCAPE) {
-            int k = 0;
-            switch (key) {
-            case core::view::Key::KEY_SPACE: k = TW_KEY_SPACE; break;
-            case core::view::Key::KEY_APOSTROPHE: k = '\''; break;
-            case core::view::Key::KEY_COMMA: k = ','; break;
-            case core::view::Key::KEY_MINUS: k = '-'; break;
-            case core::view::Key::KEY_PERIOD: k = '.'; break;
-            case core::view::Key::KEY_SLASH: k = '/'; break;
-            case core::view::Key::KEY_0: k = '0'; break;
-            case core::view::Key::KEY_1: k = '1'; break;
-            case core::view::Key::KEY_2: k = '2'; break;
-            case core::view::Key::KEY_3: k = '3'; break;
-            case core::view::Key::KEY_4: k = '4'; break;
-            case core::view::Key::KEY_5: k = '5'; break;
-            case core::view::Key::KEY_6: k = '6'; break;
-            case core::view::Key::KEY_7: k = '7'; break;
-            case core::view::Key::KEY_8: k = '8'; break;
-            case core::view::Key::KEY_9: k = '9'; break;
-            case core::view::Key::KEY_SEMICOLON: k = ';'; break;
-            case core::view::Key::KEY_EQUAL: k = '='; break;
-            case core::view::Key::KEY_A: k = 'a'; break;
-            case core::view::Key::KEY_B: k = 'b'; break;
-            case core::view::Key::KEY_C: k = 'c'; break;
-            case core::view::Key::KEY_D: k = 'd'; break;
-            case core::view::Key::KEY_E: k = 'e'; break;
-            case core::view::Key::KEY_F: k = 'f'; break;
-            case core::view::Key::KEY_G: k = 'g'; break;
-            case core::view::Key::KEY_H: k = 'h'; break;
-            case core::view::Key::KEY_I: k = 'i'; break;
-            case core::view::Key::KEY_J: k = 'j'; break;
-            case core::view::Key::KEY_K: k = 'k'; break;
-            case core::view::Key::KEY_L: k = 'l'; break;
-            case core::view::Key::KEY_M: k = 'm'; break;
-            case core::view::Key::KEY_N: k = 'n'; break;
-            case core::view::Key::KEY_O: k = 'o'; break;
-            case core::view::Key::KEY_P: k = 'p'; break;
-            case core::view::Key::KEY_Q: k = 'q'; break;
-            case core::view::Key::KEY_R: k = 'r'; break;
-            case core::view::Key::KEY_S: k = 's'; break;
-            case core::view::Key::KEY_T: k = 't'; break;
-            case core::view::Key::KEY_U: k = 'u'; break;
-            case core::view::Key::KEY_V: k = 'v'; break;
-            case core::view::Key::KEY_W: k = 'w'; break;
-            case core::view::Key::KEY_X: k = 'x'; break;
-            case core::view::Key::KEY_Y: k = 'y'; break;
-            case core::view::Key::KEY_Z: k = 'z'; break;
-            case core::view::Key::KEY_LEFT_BRACKET: k = '('; break;
-            case core::view::Key::KEY_BACKSLASH: k = '\\'; break;
-            case core::view::Key::KEY_RIGHT_BRACKET: k = ')'; break;
-            case core::view::Key::KEY_GRAVE_ACCENT: k = '´'; break;
-            //case core::view::Key::KEY_WORLD_1: k = TW_KEY_WORLD_1; break;
-            //case core::view::Key::KEY_WORLD_2: k = TW_KEY_WORLD_2; break;
-            case core::view::Key::KEY_ESCAPE: k = TW_KEY_ESCAPE; break;
-            case core::view::Key::KEY_ENTER: k = TW_KEY_RETURN; break;
-            case core::view::Key::KEY_TAB: k = TW_KEY_TAB; break;
-            case core::view::Key::KEY_BACKSPACE: k = TW_KEY_BACKSPACE; break;
-            case core::view::Key::KEY_INSERT: k = TW_KEY_INSERT; break;
-            case core::view::Key::KEY_DELETE: k = TW_KEY_DELETE; break;
-            case core::view::Key::KEY_RIGHT: k = TW_KEY_RIGHT; break;
-            case core::view::Key::KEY_LEFT: k = TW_KEY_LEFT; break;
-            case core::view::Key::KEY_DOWN: k = TW_KEY_DOWN; break;
-            case core::view::Key::KEY_UP: k = TW_KEY_UP; break;
-            case core::view::Key::KEY_PAGE_UP: k = TW_KEY_PAGE_UP; break;
-            case core::view::Key::KEY_PAGE_DOWN: k = TW_KEY_PAGE_DOWN; break;
-            case core::view::Key::KEY_HOME: k = TW_KEY_HOME; break;
-            case core::view::Key::KEY_END: k = TW_KEY_END; break;
-            //case core::view::Key::KEY_CAPS_LOCK: k = TW_KEY_CAPS_LOCK; break;
-            //case core::view::Key::KEY_SCROLL_LOCK: k = TW_KEY_SCROLL_LOCK; break;
-            //case core::view::Key::KEY_NUM_LOCK: k = TW_KEY_NUM_LOCK; break;
-            //case core::view::Key::KEY_PRINT_SCREEN: k = TW_KEY_PRINT_SCREEN; break;
-            case core::view::Key::KEY_PAUSE: k = TW_KEY_PAUSE; break;
-            case core::view::Key::KEY_F1: k = TW_KEY_F1; break;
-            case core::view::Key::KEY_F2: k = TW_KEY_F2; break;
-            case core::view::Key::KEY_F3: k = TW_KEY_F3; break;
-            case core::view::Key::KEY_F4: k = TW_KEY_F4; break;
-            case core::view::Key::KEY_F5: k = TW_KEY_F5; break;
-            case core::view::Key::KEY_F6: k = TW_KEY_F6; break;
-            case core::view::Key::KEY_F7: k = TW_KEY_F7; break;
-            case core::view::Key::KEY_F8: k = TW_KEY_F8; break;
-            case core::view::Key::KEY_F9: k = TW_KEY_F9; break;
-            case core::view::Key::KEY_F10: k = TW_KEY_F10; break;
-            case core::view::Key::KEY_F11: k = TW_KEY_F11; break;
-            case core::view::Key::KEY_F12: k = TW_KEY_F12; break;
-            case core::view::Key::KEY_F13: k = TW_KEY_F13; break;
-            case core::view::Key::KEY_F14: k = TW_KEY_F14; break;
-            case core::view::Key::KEY_F15: k = TW_KEY_F15; break;
-            case core::view::Key::KEY_F16: k = TW_KEY_F10 + 6; break;
-            case core::view::Key::KEY_F17: k = TW_KEY_F10 + 7; break;
-            case core::view::Key::KEY_F18: k = TW_KEY_F10 + 8; break;
-            case core::view::Key::KEY_F19: k = TW_KEY_F10 + 9; break;
-            case core::view::Key::KEY_F20: k = TW_KEY_F10 + 10; break;
-            case core::view::Key::KEY_F21: k = TW_KEY_F10 + 11; break;
-            case core::view::Key::KEY_F22: k = TW_KEY_F10 + 12; break;
-            case core::view::Key::KEY_F23: k = TW_KEY_F10 + 13; break;
-            case core::view::Key::KEY_F24: k = TW_KEY_F10 + 14; break;
-            case core::view::Key::KEY_F25: k = TW_KEY_F10 + 15; break;
-            case core::view::Key::KEY_KP_0: if (testkp) k = '0'; break;
-            case core::view::Key::KEY_KP_1: if (testkp) k = '1'; break;
-            case core::view::Key::KEY_KP_2: if (testkp) k = '2'; break;
-            case core::view::Key::KEY_KP_3: if (testkp) k = '3'; break;
-            case core::view::Key::KEY_KP_4: if (testkp) k = '4'; break;
-            case core::view::Key::KEY_KP_5: if (testkp) k = '5'; break;
-            case core::view::Key::KEY_KP_6: if (testkp) k = '6'; break;
-            case core::view::Key::KEY_KP_7: if (testkp) k = '7'; break;
-            case core::view::Key::KEY_KP_8: if (testkp) k = '8'; break;
-            case core::view::Key::KEY_KP_9: if (testkp) k = '9'; break;
-            case core::view::Key::KEY_KP_DECIMAL: if (testkp) k = '.'; break;
-            case core::view::Key::KEY_KP_DIVIDE: if (testkp) k = '/'; break;
-            case core::view::Key::KEY_KP_MULTIPLY: if (testkp) k = '*'; break;
-            case core::view::Key::KEY_KP_SUBTRACT: if (testkp) k = '-'; break;
-            case core::view::Key::KEY_KP_ADD: if (testkp) k = '+'; break;
-            case core::view::Key::KEY_KP_ENTER: k = TW_KEY_RETURN; break;
-            case core::view::Key::KEY_KP_EQUAL: if (testkp) k = '='; break;
-            //case core::view::Key::KEY_LEFT_SHIFT: k = TW_KEY_LEFT_SHIFT; break;
-            //case core::view::Key::KEY_LEFT_CONTROL: k = TW_KEY_LEFT_CONTROL; break;
-            //case core::view::Key::KEY_LEFT_ALT: k = TW_KEY_LEFT_ALT; break;
-            //case core::view::Key::KEY_LEFT_SUPER: k = TW_KEY_LEFT_SUPER; break;
-            //case core::view::Key::KEY_RIGHT_SHIFT: k = TW_KEY_RIGHT_SHIFT; break;
-            //case core::view::Key::KEY_RIGHT_CONTROL: k = TW_KEY_RIGHT_CONTROL; break;
-            //case core::view::Key::KEY_RIGHT_ALT: k = TW_KEY_RIGHT_ALT; break;
-            //case core::view::Key::KEY_RIGHT_SUPER: k = TW_KEY_RIGHT_SUPER; break;
-            //case core::view::Key::KEY_MENU: k = TW_KEY_MENU; break;
-            default: break;
-            }
-
-            if (k > 0) {
-                if (::TwKeyPressed(k, atbKeyMod)) {
-                    return true;
-                }
             }
         }
     }

--- a/core/include/mmcore/view/Input.h
+++ b/core/include/mmcore/view/Input.h
@@ -284,24 +284,15 @@ public:
     }
 
     /** Ctor. */
-    KeyCode(Key key, Modifiers mods) {
-        this->mods = mods;
-        this->key = key;
-    }
     KeyCode(Key key) {
         this->key = key;
         this->mods = core::view::Modifiers(core::view::Modifier::NONE);
     }
 
-    /// ONLY for map in ButtonParamUILayer ....
-    inline KeyCode& operator=(const KeyCode& rhs) {
-        this->key = rhs.key;
-        this->mods = rhs.mods;
-        return *this;
-    }
-    /// ONLY for map in ButtonParamUILayer ....
-    inline bool operator==(const KeyCode& rhs) const {
-        return ((this->key == rhs.key) && (this->mods.test(rhs.mods)));
+    /** Ctor. */
+    KeyCode(Key key, Modifiers mods) {
+        this->mods = mods;
+        this->key = key;
     }
 
     /**
@@ -312,6 +303,7 @@ public:
     std::string ToString(void) const {
 
         std::string msg;
+
         if (this->mods.test(core::view::Modifier::SHIFT)) msg += "SHIFT + ";
         if (this->mods.test(core::view::Modifier::CTRL)) msg += "CTRL + ";
         if (this->mods.test(core::view::Modifier::ALT)) msg += "ALT + ";
@@ -448,17 +440,6 @@ public:
         return msg;
     }
 };
-
-
-/// ONLY for map in ButtonParamUILayer ....
-inline bool operator<(KeyCode lhs, KeyCode rhs) {
-    return (((int)lhs.key < (int)rhs.key) && (lhs.mods.toInt() < rhs.mods.toInt()));
-}
-/// ONLY for map in ButtonParamUILayer ....
-inline bool operator>(KeyCode lhs, KeyCode rhs) {
-    return (((int)lhs.key > (int)rhs.key) && (lhs.mods.toInt() > rhs.mods.toInt()));
-}
-
 
 } /* end namespace view */
 } /* end namespace core */

--- a/core/include/mmcore/view/SplitView.h
+++ b/core/include/mmcore/view/SplitView.h
@@ -15,6 +15,7 @@
 #include "mmcore/param/ParamSlot.h"
 #include "mmcore/view/AbstractView.h"
 #include "mmcore/view/CallRenderView.h"
+#include "mmcore/param/ColorParam.h"
 #include "vislib/graphics/ColourRGBAu8.h"
 #include "vislib/graphics/gl/FramebufferObject.h"
 
@@ -242,7 +243,7 @@ private:
     param::ParamSlot splitColourSlot;
 
     /** The splitter colour */
-    vislib::graphics::ColourRGBAu8 splitColour;
+    param::ColorParam::ColorType splitColour;
 
     /** The override call */
     CallRenderView* overrideCall;

--- a/core/src/view/SplitView.cpp
+++ b/core/src/view/SplitView.cpp
@@ -25,15 +25,15 @@ using vislib::sys::Log;
  * view::SplitView::SplitView
  */
 view::SplitView::SplitView(void) : AbstractView(),
-        render1Slot("render1", "Connects to the view 1 (left or top)"),
-        render2Slot("render2", "Connects to the view 2 (right or bottom)"),
-        splitOriSlot("split.orientation", "The split orientation"),
-        splitSlot("split.pos", "The split position"),
-        splitWidthSlot("split.width", "The split border width"),
-        splitColourSlot("split.colour", "The split border colour"),
-        splitColour(192, 192, 192, 255), overrideCall(NULL),
-        clientArea(), client1Area(), client2Area(), fbo1(), fbo2(),
-        focus(0), mouseX(0.0f), mouseY(0.0f) {
+render1Slot("render1", "Connects to the view 1 (left or top)"),
+render2Slot("render2", "Connects to the view 2 (right or bottom)"),
+splitOriSlot("split.orientation", "The split orientation"),
+splitSlot("split.pos", "The split position"),
+splitWidthSlot("split.width", "The split border width"),
+splitColourSlot("split.colour", "The split border colour"),
+splitColour(192, 192, 192, 255), overrideCall(NULL),
+clientArea(), client1Area(), client2Area(), fbo1(), fbo2(),
+focus(0), mouseX(0.0f), mouseY(0.0f) {
 
     this->render1Slot.SetCompatibleCall<CallRenderViewDescription>();
     this->MakeSlotAvailable(&this->render1Slot);
@@ -123,18 +123,19 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
         ::glGetIntegerv(GL_VIEWPORT, vp);
         vpw = vp[2];
         vph = vp[3];
-    } else {
+    }
+    else {
         vpw = this->overrideCall->ViewportWidth();
         vph = this->overrideCall->ViewportHeight();
     }
 
     if (this->splitSlot.IsDirty()
-            || this->splitOriSlot.IsDirty()
-            || this->splitWidthSlot.IsDirty()
-            || !this->fbo1.IsValid()
-            || !this->fbo2.IsValid()
-            || !vislib::math::IsEqual(this->clientArea.Width(), static_cast<float>(vpw))
-            || !vislib::math::IsEqual(this->clientArea.Height(), static_cast<float>(vph)) ) {
+        || this->splitOriSlot.IsDirty()
+        || this->splitWidthSlot.IsDirty()
+        || !this->fbo1.IsValid()
+        || !this->fbo2.IsValid()
+        || !vislib::math::IsEqual(this->clientArea.Width(), static_cast<float>(vpw))
+        || !vislib::math::IsEqual(this->clientArea.Height(), static_cast<float>(vph))) {
 
         this->clientArea.SetWidth(static_cast<float>(vpw));
         this->clientArea.SetHeight(static_cast<float>(vph));
@@ -195,9 +196,9 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
     ::glPushMatrix();
 
     ::glViewport(
-        static_cast<int>(this->clientArea.Left()), 
-        static_cast<int>(this->clientArea.Bottom()), 
-        static_cast<int>(this->clientArea.Width()), 
+        static_cast<int>(this->clientArea.Left()),
+        static_cast<int>(this->clientArea.Bottom()),
+        static_cast<int>(this->clientArea.Width()),
         static_cast<int>(this->clientArea.Height()));
 
     ::glClearColor(0.0f, 0.0f, 0.0, 1.0f);
@@ -220,7 +221,8 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
         sx1 = this->clientArea.Width() * sp;
         sx2 = sx1 + shw;
         sx1 -= shw;
-    } else { // vertical
+    }
+    else { // vertical
         sx1 = 0.0f;
         sx2 = this->clientArea.Width();
         sy1 = this->clientArea.Height() * sp;
@@ -297,7 +299,7 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
         car = &this->client2Area;
         fbo = &this->fbo2;
     }
-    
+
     ::glMatrixMode(GL_PROJECTION);
     ::glPopMatrix();
     ::glMatrixMode(GL_MODELVIEW);
@@ -322,7 +324,7 @@ void view::SplitView::ResetView(void) {
  */
 void view::SplitView::Resize(unsigned int width, unsigned int height) {
     if (!vislib::math::IsEqual(this->clientArea.Width(), static_cast<float>(width))
-            || !vislib::math::IsEqual(this->clientArea.Height(), static_cast<float>(height))) {
+        || !vislib::math::IsEqual(this->clientArea.Height(), static_cast<float>(height))) {
         this->clientArea.SetWidth(static_cast<float>(width));
         this->clientArea.SetHeight(static_cast<float>(height));
 
@@ -346,9 +348,9 @@ void view::SplitView::Resize(unsigned int width, unsigned int height) {
         CallRenderView *crv = this->render1();
         if (crv != NULL) {
             // der ganz ganz dicke "because-i-know"-Knüppel
-            AbstractView *crvView = 
+            AbstractView *crvView =
                 const_cast<AbstractView*>(dynamic_cast<const AbstractView *>(
-                static_cast<const Module*>(crv->PeekCalleeSlot()->Owner())));
+                    static_cast<const Module*>(crv->PeekCalleeSlot()->Owner())));
             if (crvView != NULL) {
                 crvView->Resize(
                     static_cast<unsigned int>(this->client1Area.Width()),
@@ -358,9 +360,9 @@ void view::SplitView::Resize(unsigned int width, unsigned int height) {
         crv = this->render2();
         if (crv != NULL) {
             // der ganz ganz dicke "because-i-know"-Knüppel
-            AbstractView *crvView = 
+            AbstractView *crvView =
                 const_cast<AbstractView*>(dynamic_cast<const AbstractView *>(
-                static_cast<const Module*>(crv->PeekCalleeSlot()->Owner())));
+                    static_cast<const Module*>(crv->PeekCalleeSlot()->Owner())));
             if (crvView != NULL) {
                 crvView->Resize(
                     static_cast<unsigned int>(this->client2Area.Width()),
@@ -377,7 +379,7 @@ void view::SplitView::Resize(unsigned int width, unsigned int height) {
 bool view::SplitView::OnRenderView(Call& call) {
     view::CallRenderView *crv = dynamic_cast<view::CallRenderView *>(&call);
     if (crv == NULL) return false;
-    
+
     this->overrideCall = crv;
 
     mmcRenderViewContext context;
@@ -405,32 +407,59 @@ void view::SplitView::UpdateFreeze(bool freeze) {
 
 
 bool view::SplitView::OnKey(Key key, KeyAction action, Modifiers mods) {
-    auto* crv = this->renderFocused();
-    if (crv == NULL) return false;
 
-    InputEvent evt;
-    evt.tag = InputEvent::Tag::Key;
-    evt.keyData.key = key;
-    evt.keyData.action = action;
-    evt.keyData.mods = mods;
-    crv->SetInputEvent(evt);
-    if (!(*crv)(view::CallRenderView::FnOnKey)) return false;
+    bool consumed = false;
 
-    return true;
+    auto* crv = this->render1();
+    if (crv != nullptr) {
+        InputEvent evt;
+        evt.tag = InputEvent::Tag::Key;
+        evt.keyData.key = key;
+        evt.keyData.action = action;
+        evt.keyData.mods = mods;
+        crv->SetInputEvent(evt);
+        if ((*crv)(view::CallRenderView::FnOnKey)) consumed = true;
+    }
+
+    crv = this->render2();
+    if (crv != nullptr) {
+
+        InputEvent evt;
+        evt.tag = InputEvent::Tag::Key;
+        evt.keyData.key = key;
+        evt.keyData.action = action;
+        evt.keyData.mods = mods;
+        crv->SetInputEvent(evt);
+        if ((*crv)(view::CallRenderView::FnOnKey)) consumed = true;
+    }
+
+    return consumed;
 }
 
 
 bool view::SplitView::OnChar(unsigned int codePoint) {
-    auto* crv = this->renderFocused();
-    if (crv == NULL) return false;
 
-    InputEvent evt;
-    evt.tag = InputEvent::Tag::Char;
-    evt.charData.codePoint = codePoint;
-    crv->SetInputEvent(evt);
-    if (!(*crv)(view::CallRenderView::FnOnChar)) return false;
+    bool consumed = false;
 
-    return true;
+    auto* crv = this->render1();
+    if (crv != nullptr) {
+        InputEvent evt;
+        evt.tag = InputEvent::Tag::Char;
+        evt.charData.codePoint = codePoint;
+        crv->SetInputEvent(evt);
+        if ((*crv)(view::CallRenderView::FnOnChar)) consumed = true;
+    }
+
+    crv = this->render2();
+    if (crv != nullptr) {
+        InputEvent evt;
+        evt.tag = InputEvent::Tag::Char;
+        evt.charData.codePoint = codePoint;
+        crv->SetInputEvent(evt);
+        if ((*crv)(view::CallRenderView::FnOnChar)) consumed = true;
+    }
+
+    return consumed;
 }
 
 
@@ -439,16 +468,20 @@ bool view::SplitView::OnMouseButton(MouseButton button, MouseButtonAction action
     auto* crv1 = this->render1();
     auto* crv2 = this->render2();
 
-    auto down = action == MouseButtonAction::PRESS;
-    if (crv == crv1 && this->focus == 0 && down) {
-        this->focus = 1;
-    } else if (crv == crv2 && this->focus == 0 && down) {
-        this->focus = 2;
-    } else {
-        this->focus = 0;
+    auto down = (action == MouseButtonAction::PRESS);
+    if (down) {
+        if (crv == crv1) {
+            this->focus = 1;
+        }
+        else if (crv == crv2) {
+            this->focus = 2;
+        }
+        else {
+            this->focus = 0;
+        }
     }
 
-	if (crv) {
+    if (crv) {
         InputEvent evt;
         evt.tag = InputEvent::Tag::MouseButton;
         evt.mouseButtonData.button = button;
@@ -476,10 +509,12 @@ bool view::SplitView::OnMouseMove(double x, double y) {
     if (crv == crv1) {
         mx = x - this->client1Area.Left();
         my = y - this->client1Area.Bottom();
-    } else if (crv == crv2) {
+    }
+    else if (crv == crv2) {
         mx = x - this->client2Area.Left();
         my = y - this->client2Area.Bottom();
-    } else {
+    }
+    else {
         return false;
     }
 
@@ -547,7 +582,8 @@ bool view::SplitView::splitColourUpdated(param::ParamSlot& sender) {
         vislib::graphics::ColourParser::FromString(
             this->splitColourSlot.Param<param::StringParam>()->Value(),
             this->splitColour);
-    } catch(...) {
+    }
+    catch (...) {
         Log::DefaultLog.WriteError("Unable to parse splitter colour");
     }
     return true;
@@ -576,7 +612,8 @@ void view::SplitView::calcClientAreas(void) {
             this->clientArea.Bottom(),
             this->clientArea.Right(),
             this->clientArea.Top());
-    } else { // vertical
+    }
+    else { // vertical
         this->client1Area.Set(
             this->clientArea.Left(),
             this->clientArea.Bottom(),

--- a/core/src/view/SplitView.cpp
+++ b/core/src/view/SplitView.cpp
@@ -11,7 +11,6 @@
 #include "mmcore/param/EnumParam.h"
 #include "mmcore/param/FloatParam.h"
 #include "mmcore/param/StringParam.h"
-#include "vislib/graphics/ColourParser.h"
 #include "vislib/sys/Log.h"
 #include "vislib/Trace.h"
 
@@ -31,7 +30,7 @@ splitOriSlot("split.orientation", "The split orientation"),
 splitSlot("split.pos", "The split position"),
 splitWidthSlot("split.width", "The split border width"),
 splitColourSlot("split.colour", "The split border colour"),
-splitColour(192, 192, 192, 255), overrideCall(NULL),
+overrideCall(NULL),
 clientArea(), client1Area(), client2Area(), fbo1(), fbo2(),
 focus(0), mouseX(0.0f), mouseY(0.0f) {
 
@@ -53,8 +52,8 @@ focus(0), mouseX(0.0f), mouseY(0.0f) {
     this->splitWidthSlot << new param::FloatParam(4.0f, 0.0f, 100.0f);
     this->MakeSlotAvailable(&this->splitWidthSlot);
 
-    vislib::StringA s;
-    this->splitColourSlot << new param::StringParam(vislib::graphics::ColourParser::ToString(s, this->splitColour));
+    this->splitColour = { 0.75f, 0.75f, 0.75f, 1.0f };
+    this->splitColourSlot << new param::ColorParam(this->splitColour);
     this->splitColourSlot.SetUpdateCallback(&SplitView::splitColourUpdated);
     this->MakeSlotAvailable(&this->splitColourSlot);
 
@@ -211,7 +210,7 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
     ::glDisable(GL_DEPTH_TEST);
     ::glDisable(GL_TEXTURE_2D);
     ::glBegin(GL_QUADS);
-    ::glColor4ubv(this->splitColour.PeekComponents());
+    ::glColor4fv(this->splitColour.data());
     float sx1, sx2, sy1, sy2;
     float sp = this->splitSlot.Param<param::FloatParam>()->Value();
     float shw = this->splitWidthSlot.Param<param::FloatParam>()->Value() * 0.5f;
@@ -579,9 +578,7 @@ void view::SplitView::unpackMouseCoordinates(float &x, float &y) {
  */
 bool view::SplitView::splitColourUpdated(param::ParamSlot& sender) {
     try {
-        vislib::graphics::ColourParser::FromString(
-            this->splitColourSlot.Param<param::StringParam>()->Value(),
-            this->splitColour);
+        this->splitColour = this->splitColourSlot.Param<param::ColorParam>()->Value();
     }
     catch (...) {
         Log::DefaultLog.WriteError("Unable to parse splitter colour");

--- a/core/src/view/View3D.cpp
+++ b/core/src/view/View3D.cpp
@@ -517,6 +517,16 @@ void view::View3D::Render(const mmcRenderViewContext& context) {
     }
     ::glPushMatrix();
 
+    if (this->overrideCall) {
+        (*static_cast<AbstractCallRender*>(cr3d)) = *this->overrideCall;
+        cr3d->SetInstanceTime(instTime);
+#ifndef ROTATOR_HACK
+        cr3d->SetTime(time);
+#else
+        cr3d->SetTime(0);
+#endif
+    }
+
     // call for render
     if (cr3d != NULL) {
         (*cr3d)(AbstractCallRender::FnRender);

--- a/core/src/view/View3D.cpp
+++ b/core/src/view/View3D.cpp
@@ -428,8 +428,6 @@ void view::View3D::Render(const mmcRenderViewContext& context) {
 #endif
         cr3d->SetCameraParameters(this->cam.Parameters()); // < here we use the 'active' parameters!
         cr3d->SetLastFrameTime(AbstractRenderingView::lastFrameTime());
-
-        cr3d->SetInstanceTime(instTime);
     }
     this->camParams->CalcClipping(this->bboxs.ClipBox(), 0.1f);
     // This is painfully wrong in the vislib camera, and is fixed here as sort of hotfix
@@ -517,8 +515,7 @@ void view::View3D::Render(const mmcRenderViewContext& context) {
     }
     ::glPushMatrix();
 
-    if (this->overrideCall) {
-        (*static_cast<AbstractCallRender*>(cr3d)) = *this->overrideCall;
+    if (cr3d != NULL) {
         cr3d->SetInstanceTime(instTime);
 #ifndef ROTATOR_HACK
         cr3d->SetTime(time);

--- a/core/src/view/View3D.cpp
+++ b/core/src/view/View3D.cpp
@@ -428,6 +428,8 @@ void view::View3D::Render(const mmcRenderViewContext& context) {
 #endif
         cr3d->SetCameraParameters(this->cam.Parameters()); // < here we use the 'active' parameters!
         cr3d->SetLastFrameTime(AbstractRenderingView::lastFrameTime());
+
+        cr3d->SetInstanceTime(instTime);
     }
     this->camParams->CalcClipping(this->bboxs.ClipBox(), 0.1f);
     // This is painfully wrong in the vislib camera, and is fixed here as sort of hotfix
@@ -514,16 +516,6 @@ void view::View3D::Render(const mmcRenderViewContext& context) {
         this->renderLookAt();
     }
     ::glPushMatrix();
-
-    if (this->overrideCall) {
-        (*static_cast<AbstractCallRender*>(cr3d)) = *this->overrideCall;
-        cr3d->SetInstanceTime(instTime);
-#ifndef ROTATOR_HACK
-        cr3d->SetTime(time);
-#else
-        cr3d->SetTime(0);
-#endif
-    }
 
     // call for render
     if (cr3d != NULL) {


### PR DESCRIPTION
- Added position and size reset for main window (hotkey: Shift + F12)
- Disabled focus for keyboard in SplitView (parameter hotkeys are otherwise not available in other SplitViews using only one GUIRenderer)
- Only first occurrence of multiply assigned hotkey is processed.
- Added hidden unique imgui ids for parameter widgets (prevent ambiguity).
- Fixed instance time propagation in View3D.
- Fixed conflict between text input and overlapping parameter hotkeys.
- Fixed key map in ButtonParamUILayer for alternative use when no GUi is available    