### PR TITLE
Fix cmake slashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     CACHE PATH "default install path" FORCE)
 endif()
 
+# This will replace "\" by "/"
+set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "default install path" FORCE)
+
 # Enable CUDA
 option(ENABLE_CUDA "Enable CUDA, which is needed for certain plugins" OFF)
 


### PR DESCRIPTION
CMAKE_PREFIX_PATH should only use `/` in all paths, otherwise this leads to errors in lua path stuff when `\` and `/` are combined.

When setting CMAKE_PREFIX_PATH from within cmake code this replacement is applied automatically. But when you set CMAKE_PREFIX_PATH from the GUI the backslashes are kept.

Therefore this hack does overwrite CMAKE_PREFIX_PATH with itself in cmake code to trigger slash replacement.