### PR TITLE
Bugfixes and features

### DIFF
--- a/core/Shaders/viewcube.btf
+++ b/core/Shaders/viewcube.btf
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<btf type="MegaMolGLSLShader" version="1.0" namespace="viewcube">
+  <include file="common"/>
+  <shader name="vertex">
+    <snippet type="version">330</snippet>
+    <snippet type="string">
+<!--
+uniform mat4 rot_mx;
+uniform mat4 model_mx;
+uniform mat4 proj_mx;
+
+out vec4 vertex_color;
+
+void main() {
+    const vec4 vertices[36] = vec4[36](
+        // front
+        vec4(-1.0, -1.0,  1.0, 1.0),
+        vec4( 1.0, -1.0,  1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        vec4(-1.0, -1.0,  1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        vec4(-1.0,  1.0,  1.0, 1.0),
+        // back
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0, -1.0, 1.0),
+        vec4( 1.0, -1.0, -1.0, 1.0),
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4(-1.0,  1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0, -1.0, 1.0),
+        // top
+        vec4(-1.0,  1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        vec4( 1.0,  1.0, -1.0, 1.0),
+        vec4(-1.0,  1.0, -1.0, 1.0),
+        vec4(-1.0,  1.0,  1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        // bottom
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0, -1.0,  1.0, 1.0),
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0, -1.0,  1.0, 1.0),
+        vec4(-1.0, -1.0,  1.0, 1.0),
+        // right
+        vec4( 1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        vec4( 1.0, -1.0, -1.0, 1.0),
+        vec4( 1.0,  1.0,  1.0, 1.0),
+        vec4( 1.0, -1.0,  1.0, 1.0),
+        // left
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4(-1.0,  1.0,  1.0, 1.0),
+        vec4(-1.0,  1.0, -1.0, 1.0),
+        vec4(-1.0, -1.0, -1.0, 1.0),
+        vec4(-1.0, -1.0,  1.0, 1.0),
+        vec4(-1.0,  1.0,  1.0, 1.0) 
+    );
+
+    const vec4 colors[6] = vec4[6](
+        vec4(0.0, 0.0, 1.0, 1.0),
+        vec4(0.0, 0.0, 0.5, 1.0),
+        vec4(0.0, 1.0, 0.0, 1.0),
+        vec4(0.0, 0.5, 0.0, 1.0),
+        vec4(1.0, 0.0, 0.0, 1.0),
+        vec4(0.5, 0.0, 0.0, 1.0) 
+    );
+
+    vertex_color = colors[gl_VertexID / 6];
+    gl_Position = proj_mx * model_mx * rot_mx * vertices[gl_VertexID];
+}
+-->
+    </snippet>
+  </shader>
+  <shader name="fragment">
+    <snippet type="version">330</snippet>
+    <snippet type="string">
+<!--
+in vec4 vertex_color;
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vertex_color;
+}
+-->
+    </snippet>
+  </shader>
+</btf>

--- a/core/include/mmcore/utility/DataHash.h
+++ b/core/include/mmcore/utility/DataHash.h
@@ -5,8 +5,8 @@
  * Alle Rechte vorbehalten.
  */
 
-#ifndef MEGAMOLCORE_CONFIGURATION_H_INCLUDED
-#define MEGAMOLCORE_CONFIGURATION_H_INCLUDED
+#ifndef MEGAMOLCORE_DATAHASH_H_INCLUDED
+#define MEGAMOLCORE_DATAHASH_H_INCLUDED
 #if (defined(_MSC_VER) && (_MSC_VER > 1000))
 #pragma once
 #endif /* (defined(_MSC_VER) && (_MSC_VER > 1000)) */

--- a/core/include/mmcore/view/BoundingBoxRenderer.h
+++ b/core/include/mmcore/view/BoundingBoxRenderer.h
@@ -97,7 +97,7 @@ private:
     /**
      * Render function for the bounding box back
      *
-     * @param call The incoming render call
+     * @param mvp Model, view and projection matrices combined
      * @param bb The bounding box to render
      * @param smoothLines Determines whether the lines of the box should get smoothed. default = true
      * @return True on success, false otherwise.
@@ -107,7 +107,7 @@ private:
     /**
      * Render function for the view cube
      *
-     * @param call The incoming render call
+     * @param call The call containing the camera and other parameters
      * @return True on success, false otherwise.
      */
     bool RenderViewCube(core::view::CallRender3D_2& call);
@@ -124,6 +124,12 @@ private:
     /** Parameter that enables or disables the view cube rendering */
     param::ParamSlot enableViewCubeSlot;
 
+    /** Parameter for setting the position of the view cube */
+    param::ParamSlot viewCubePosSlot;
+
+    /** Parameter for setting the view cube size */
+    param::ParamSlot viewCubeSizeSlot;
+
     /** Handle of the vertex buffer object */
     GLuint vbo;
 
@@ -135,6 +141,9 @@ private:
 
     /** Shader program for lines */
     vislib::graphics::gl::GLSLShader lineShader;
+
+    /** Shader program for a cube */
+    vislib::graphics::gl::GLSLShader cubeShader;
 };
 } // namespace view
 } // namespace core

--- a/core/src/AbstractNamedObjectContainer.cpp
+++ b/core/src/AbstractNamedObjectContainer.cpp
@@ -71,7 +71,7 @@ void AbstractNamedObjectContainer::addChild(AbstractNamedObject::ptr_type child)
  */
 void AbstractNamedObjectContainer::removeChild(AbstractNamedObject::ptr_type child) {
     if (!child) return;
-    ASSERT(child->Parent().get() == this);
+    //ASSERT(child->Parent().get() == this);
     this->children.remove(child);
     child->setParent(AbstractNamedObject::ptr_type(nullptr));
 }

--- a/core/src/view/BoundingBoxRenderer.cpp
+++ b/core/src/view/BoundingBoxRenderer.cpp
@@ -197,6 +197,9 @@ bool BoundingBoxRenderer::Render(CallRender3D_2& call) {
             "The BoundingBoxRenderer does not work without a renderer attached to its right");
         return false;
     }
+    *chainedCall = call;
+    bool retVal = (*chainedCall)(view::AbstractCallRender::FnGetExtents);
+    call = *chainedCall;
 
     Camera_2 cam;
     call.GetCamera(cam);

--- a/core/src/view/BoundingBoxRenderer.cpp
+++ b/core/src/view/BoundingBoxRenderer.cpp
@@ -336,26 +336,7 @@ bool BoundingBoxRenderer::RenderViewCube(CallRender3D_2& call) {
     call.GetCamera(cam);
 
     const auto orientation = cam.orientation();
-
-    // Calculate rotation matrix from quaternion,
-    // see https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
-    const auto qr = orientation.w();
-    const auto qi = orientation.x();
-    const auto qj = orientation.y();
-    const auto qk = orientation.z();
-
-    glm::mat4 rotation(1.0f);
-    rotation[0][0] = 1.0f - 2.0f * (qj * qj + qk * qk);
-    rotation[0][1] = 2.0f * (qi * qj + qk * qr);
-    rotation[0][2] = 2.0f * (qi * qk - qj * qr);
-    rotation[1][0] = 2.0f * (qi * qj - qk * qr);
-    rotation[1][1] = 1.0f - 2.0f * (qi * qi + qk * qk);
-    rotation[1][2] = 2.0f * (qj * qk + qi * qr);
-    rotation[2][0] = 2.0f * (qi * qk + qj * qr);
-    rotation[2][1] = 2.0f * (qj * qk - qi * qr);
-    rotation[2][2] = 1.0f - 2.0f * (qi * qi + qj * qj);
-
-    rotation = glm::inverse(rotation);
+    const auto rotation = glm::mat4_cast(static_cast<glm::quat>(orientation));
 
     // Create view/model and projection matrices
     const float dist = 2.0f / std::tan(thecam::math::angle_deg2rad(30.0f) / 2.0f);

--- a/core/src/view/SplitView.cpp
+++ b/core/src/view/SplitView.cpp
@@ -148,10 +148,17 @@ void view::SplitView::Render(const mmcRenderViewContext& context) {
         }
 
         // Bind and blit framebuffer.
+        GLint binding, readBuffer;
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &binding);
+        glGetIntegerv(GL_READ_BUFFER, &readBuffer);
+
         glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo.GetID());
         glReadBuffer(GL_COLOR_ATTACHMENT0);
         glBlitFramebuffer(0, 0, fbo.GetWidth(), fbo.GetHeight(), ca.Left(), this->clientArea.Height() - ca.Top(),
             ca.Right(), this->clientArea.Height() - ca.Bottom(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, binding);
+        glReadBuffer(readBuffer);
     };
 
     // Draw the splitter through clearing without overplotting.

--- a/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
+++ b/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
@@ -99,7 +99,7 @@ bool RaycastVolumeRenderer::create() {
     m_render_target = std::make_unique<glowl::Texture2D>("raycast_volume_render_target", render_tgt_layout, nullptr);
 
     // create empty volume texture
-	glowl::TextureLayout volume_layout(GL_R32F, 1, 1, 1, GL_RED, GL_FLOAT, 1,
+    glowl::TextureLayout volume_layout(GL_R32F, 1, 1, 1, GL_RED, GL_FLOAT, 1,
         {{GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER}, {GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER},
             {GL_TEXTURE_MIN_FILTER, GL_LINEAR}, {GL_TEXTURE_MAG_FILTER, GL_LINEAR}},
         {});
@@ -136,22 +136,23 @@ bool RaycastVolumeRenderer::GetExtents(megamol::core::view::CallRender3D_2& cr) 
 bool RaycastVolumeRenderer::Render(megamol::core::view::CallRender3D_2& cr) {
     if (!updateVolumeData()) return false;
 
-	auto ct = this->m_transferFunction_callerSlot.CallAs<core::view::CallGetTransferFunction>();
-	if (ct == nullptr || !(*ct)()) return false;
+    auto ct = this->m_transferFunction_callerSlot.CallAs<core::view::CallGetTransferFunction>();
+    if (ct == nullptr || !(*ct)()) return false;
 
-	// get camera
-	core::view::Camera_2 cam;
-	cr.GetCamera(cam);
+    // get camera
+    core::view::Camera_2 cam;
+    cr.GetCamera(cam);
 
-	cam_type::matrix_type view, proj;
-	cam.calc_matrices(view, proj);
-	
+    cam_type::matrix_type view, proj;
+    cam.calc_matrices(view, proj);
+
     // enable raycast volume rendering program
     m_raycast_volume_compute_shdr->Enable();
 
-    glUniformMatrix4fv(
-        m_raycast_volume_compute_shdr->ParameterLocation("view_mx"), 1, GL_FALSE, glm::value_ptr(static_cast<glm::mat4>(view)));
-    glUniformMatrix4fv(m_raycast_volume_compute_shdr->ParameterLocation("proj_mx"), 1, GL_FALSE, glm::value_ptr(static_cast<glm::mat4>(proj)));
+    glUniformMatrix4fv(m_raycast_volume_compute_shdr->ParameterLocation("view_mx"), 1, GL_FALSE,
+        glm::value_ptr(static_cast<glm::mat4>(view)));
+    glUniformMatrix4fv(m_raycast_volume_compute_shdr->ParameterLocation("proj_mx"), 1, GL_FALSE,
+        glm::value_ptr(static_cast<glm::mat4>(proj)));
 
     std::array<float, 2> rt_resolution;
     rt_resolution[0] = static_cast<float>(m_render_target->getWidth());
@@ -159,11 +160,11 @@ bool RaycastVolumeRenderer::Render(megamol::core::view::CallRender3D_2& cr) {
     glUniform2fv(m_raycast_volume_compute_shdr->ParameterLocation("rt_resolution"), 1, rt_resolution.data());
 
     // bbox sizes
-	glm::vec3 box_min;
+    glm::vec3 box_min;
     box_min[0] = m_volume_origin[0];
     box_min[1] = m_volume_origin[1];
     box_min[2] = m_volume_origin[2];
-	glm::vec3 box_max;
+    glm::vec3 box_max;
     box_max[0] = m_volume_origin[0] + m_volume_extents[0];
     box_max[1] = m_volume_origin[1] + m_volume_extents[1];
     box_max[2] = m_volume_origin[2] + m_volume_extents[2];
@@ -187,7 +188,7 @@ bool RaycastVolumeRenderer::Render(megamol::core::view::CallRender3D_2& cr) {
     m_volume_texture->bindTexture();
     glUniform1i(m_raycast_volume_compute_shdr->ParameterLocation("volume_tx3D"), 0);
     // bind the transfer function
-	ct->BindConvenience(*m_raycast_volume_compute_shdr, GL_TEXTURE1, 1);
+    ct->BindConvenience(*m_raycast_volume_compute_shdr, GL_TEXTURE1, 1);
 
     // bind image texture
     m_render_target->bindImage(0, GL_WRITE_ONLY);
@@ -196,53 +197,56 @@ bool RaycastVolumeRenderer::Render(megamol::core::view::CallRender3D_2& cr) {
     m_raycast_volume_compute_shdr->Dispatch(
         static_cast<int>(std::ceil(rt_resolution[0] / 8.0f)), static_cast<int>(std::ceil(rt_resolution[1] / 8.0f)), 1);
 
-	// unbind image texture
-	glBindImageTexture(0, 0, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_R);
+    // unbind image texture
+    glBindImageTexture(0, 0, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_R);
 
-	// unbind the transfer function
-	ct->UnbindConvenience();
-	// unbind volume texture
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_3D, 0);
+    // unbind the transfer function
+    ct->UnbindConvenience();
+    // unbind volume texture
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_3D, 0);
 
     m_raycast_volume_compute_shdr->Disable();
 
     glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT);
 
-	// store state
-	bool state_depth_test = glIsEnabled(GL_DEPTH_TEST);
-	bool state_blend = glIsEnabled(GL_BLEND);
+    // store state
+    bool state_depth_test = glIsEnabled(GL_DEPTH_TEST);
+    bool state_blend = glIsEnabled(GL_BLEND);
 
-	GLint state_blend_src_rgb, state_blend_src_alpha, state_blend_dst_rgb, state_blend_dst_alpha;
-	glGetIntegerv(GL_BLEND_SRC_RGB, &state_blend_src_rgb);
-	glGetIntegerv(GL_BLEND_SRC_ALPHA, &state_blend_src_alpha);
-	glGetIntegerv(GL_BLEND_DST_RGB, &state_blend_dst_rgb);
-	glGetIntegerv(GL_BLEND_DST_ALPHA, &state_blend_dst_alpha);
+    GLint state_blend_src_rgb, state_blend_src_alpha, state_blend_dst_rgb, state_blend_dst_alpha;
+    glGetIntegerv(GL_BLEND_SRC_RGB, &state_blend_src_rgb);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &state_blend_src_alpha);
+    glGetIntegerv(GL_BLEND_DST_RGB, &state_blend_dst_rgb);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &state_blend_dst_alpha);
 
-	if (state_depth_test) glDisable(GL_DEPTH_TEST);
-	if (!state_blend) glEnable(GL_BLEND);
+    if (state_depth_test) glDisable(GL_DEPTH_TEST);
+    if (!state_blend) glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     m_render_to_framebuffer_shdr->Enable();
 
-	// bind texture
+    // bind texture
     glActiveTexture(GL_TEXTURE0);
     m_render_target->bindTexture();
     glUniform1i(m_render_to_framebuffer_shdr->ParameterLocation("src_tx2D"), 0);
 
-	// render
-	glDrawArrays(GL_TRIANGLES, 0, 6);
+    // render
+    glDrawArrays(GL_TRIANGLES, 0, 6);
 
-	// unbind texture
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, 0);
+    // unbind texture
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, 0);
 
     m_render_to_framebuffer_shdr->Disable();
 
-	// restore state
-	glBlendFuncSeparate(state_blend_src_rgb, state_blend_dst_rgb, state_blend_src_alpha, state_blend_dst_alpha);
-	if (!state_blend) glDisable(GL_BLEND);
-	if (state_depth_test) glEnable(GL_DEPTH_TEST); else glDisable(GL_DEPTH_TEST);
+    // restore state
+    glBlendFuncSeparate(state_blend_src_rgb, state_blend_dst_rgb, state_blend_src_alpha, state_blend_dst_alpha);
+    if (!state_blend) glDisable(GL_BLEND);
+    if (state_depth_test)
+        glEnable(GL_DEPTH_TEST);
+    else
+        glDisable(GL_DEPTH_TEST);
 
     return true;
 }
@@ -335,13 +339,13 @@ bool RaycastVolumeRenderer::updateVolumeData() {
 
     // debug using dummy-data
     std::array<uint8_t, 8> debug_volume_data = {255, 0, 255, 0, 255, 255, 0, 0};
-	glowl::TextureLayout debug_volume_layout(GL_R8, 2, 2, 2, GL_RED, GL_UNSIGNED_BYTE, 1,
+    glowl::TextureLayout debug_volume_layout(GL_R8, 2, 2, 2, GL_RED, GL_UNSIGNED_BYTE, 1,
         {{GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER}, {GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER},
             {GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER}, {GL_TEXTURE_MIN_FILTER, GL_NEAREST},
             {GL_TEXTURE_MAG_FILTER, GL_NEAREST}},
         {});
 
-	glowl::TextureLayout volume_layout(internal_format, metadata->Resolution[0], metadata->Resolution[1],
+    glowl::TextureLayout volume_layout(internal_format, metadata->Resolution[0], metadata->Resolution[1],
         metadata->Resolution[2], format, type, 1,
         {{GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER}, {GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER},
             {GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER}, {GL_TEXTURE_MIN_FILTER, GL_LINEAR},
@@ -350,5 +354,5 @@ bool RaycastVolumeRenderer::updateVolumeData() {
 
     m_volume_texture->reload(volume_layout, volumedata);
 
-	return true;
+    return true;
 }

--- a/plugins/mmstd_volume/src/RaycastVolumeRenderer.h
+++ b/plugins/mmstd_volume/src/RaycastVolumeRenderer.h
@@ -104,9 +104,9 @@ protected:
      */
     virtual bool Render(core::view::CallRender3D_2& call) override;
 
-	/**
-	 * Get and update data by calling input modules
-	 */
+    /**
+     * Get and update data by calling input modules
+     */
     bool updateVolumeData();
 
 private:
@@ -120,7 +120,7 @@ private:
     std::size_t m_volume_datahash = std::numeric_limits<std::size_t>::max();
     int m_frame_id = -1;
 
-	glm::vec3 m_volume_origin;
+    glm::vec3 m_volume_origin;
     glm::vec3 m_volume_extents;
     glm::vec3 m_volume_resolution;
 


### PR DESCRIPTION
Fixed the following bugs:
- Wrong include guard in DataHash
- OpenGL state was left in bad shape in SplitView (how did this ever work correctly?)
- Camera propagation of the BoundingBoxRenderer is also done in the Render method, which fixes #477 
- VolumetricDataSource was reloading the input file every frame, this is now prevented by better hash usage, which should fix #484 

Added feature:
- BoundingBoxRenderer can now render a (basic) view cube, with user-defined position (bottom left, bottom right, top left, top right) and size

Additionally, I removed the assert for SetSlotUnavailable, as it does not seem to have any positive effect, disallowing removal of slots in the constructor (closes #474).