### PR TITLE
Ignore cmake warnings about unused cli variables in externals.

### DIFF
--- a/cmake/External.cmake
+++ b/cmake/External.cmake
@@ -134,7 +134,7 @@ function(add_external_project TARGET)
 
     # Configure project
     execute_process(
-      COMMAND ${CMAKE_COMMAND} "-G${CMAKE_GENERATOR}" ${GEN_ARGS} ${CONF_ARGS}
+      COMMAND ${CMAKE_COMMAND} "--no-warn-unused-cli" "-G${CMAKE_GENERATOR}" ${GEN_ARGS} ${CONF_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
Currently for the cmake configuration of externals, there are passed some common default parameters like `-DCMAKE_C_COMPILER=...` or `-DCMAKE_CXX_COMPILER=...`.
This generates a lot of warnings about unused cmake variables, like:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_COMPILER
```
This is especially bad when using `ccmake` to build, because the warnings from the external cmake execution destroys the curses GUI.
This PR adds the `--no-warn-unused-cli` parameter when configuring the externals to surpress this warnings.
