### PR TITLE
Use relative paths in startup scripts

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -46,12 +46,10 @@ if(BUILD_CONSOLE)
   endif ()
 
   # Configuration of the megamol.cfg megamol.sh remoteconsole.sh files
-  set(cfg_LIB_PATH "${CMAKE_INSTALL_PREFIX}/lib")
-  set(cfg_MEGAMOLCON "${CMAKE_INSTALL_PREFIX}/bin/${PROJECT_NAME}")
 
   if(UNIX)
     include(GNUInstallDirs)
-    set(cfg_EXTERNAL_LIB_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+    set(cfg_LIB_PATH "../lib") # relative path from bin to lib dir
     set(MEGAMOL_SHELL_START_SCRIPT "megamol.sh")
     configure_file(extra/megamol.sh.in ${CMAKE_BINARY_DIR}/${MEGAMOL_SHELL_START_SCRIPT} @ONLY)
     install(PROGRAMS ${CMAKE_BINARY_DIR}/${MEGAMOL_SHELL_START_SCRIPT} DESTINATION "bin")

--- a/console/extra/megamol.sh.in
+++ b/console/extra/megamol.sh.in
@@ -1,8 +1,10 @@
 #!/bin/bash
 #
 # MegaMol startup script
-# Copyright 2018, https://megamol.org/
+# Copyright 2020, https://megamol.org/
 #
 
-LD_LIBRARY_PATH=$LD_LIBRARY_PATH:@cfg_LIB_PATH@:@cfg_EXTERNAL_LIB_PATH@ @cfg_MEGAMOLCON@ "$@"
+BIN_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+cd "$BIN_DIR"
 
+LD_LIBRARY_PATH=@cfg_LIB_PATH@:$LD_LIBRARY_PATH ./@PROJECT_NAME@ "$@"

--- a/core/remoteconsole/CMakeLists.txt
+++ b/core/remoteconsole/CMakeLists.txt
@@ -31,9 +31,7 @@ if(BUILD_REMOTECONSOLE)
   # Installation rules for generated files
   if(UNIX)
     include(GNUInstallDirs)
-    set(cfg_LIB_PATH "${CMAKE_INSTALL_PREFIX}/lib")
-    set(cfg_EXTERNAL_LIB_PATH "${CMAKE_INSTALL_LIBDIR}")
-    set(cfg_REMOTE "${CMAKE_INSTALL_PREFIX}/bin/${PROJECT_NAME}")
+    set(cfg_LIB_PATH "../lib") # relative path from bin to lib dir
     set(MEGAMOL_REMOTECONSOLE_SCRIPT "remoteconsole.sh")
     configure_file(extra/remoteconsole.sh.in ${CMAKE_BINARY_DIR}/${MEGAMOL_REMOTECONSOLE_SCRIPT} @ONLY)
     install(PROGRAMS ${CMAKE_BINARY_DIR}/${MEGAMOL_REMOTECONSOLE_SCRIPT} DESTINATION "bin")

--- a/core/remoteconsole/extra/remoteconsole.sh.in
+++ b/core/remoteconsole/extra/remoteconsole.sh.in
@@ -1,8 +1,11 @@
 #!/bin/bash
 #
 # MegaMol remoteconsole startup script
-# Copyright 2018, https://megamol.org/
+# Copyright 2020, https://megamol.org/
 #
 
-LD_LIBRARY_PATH=$LD_LIBRARY_PATH:@cfg_LIB_PATH@:@cfg_EXTERNAL_LIB_PATH@ @cfg_REMOTE@ "$@"
+BIN_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+cd "$BIN_DIR"
+
+LD_LIBRARY_PATH=@cfg_LIB_PATH@:$LD_LIBRARY_PATH ./@PROJECT_NAME@ "$@"
 


### PR DESCRIPTION
This PR changes the startup scripts used on linux to use relative paths instead of hard coding absolute paths on installation. This allows moving the install directory and still be able to run megamol.

Side effect is, that the working directory is changed to the binary dir.
This is just the simplest solution, if this will be an problem I can try a more fancy solution.

Also I removed the `cfg_EXTERNAL_LIB_PATH`, as it is used nowhere else.
Furthermore LD_LIBRARY_PATH is now prefixed instead of extended as we want MegaMol libraries to be found first in case there is a name conflict with any other system wide installed library (i.e. an older/other MegaMol installation which somehow managed to be included in LD_LIBRARY_PATH.).