### PR TITLE
Improve SPLOM picking

### DIFF
--- a/plugins/infovis/Shaders/splom.btf
+++ b/plugins/infovis/Shaders/splom.btf
@@ -86,6 +86,16 @@
       <snippet type="file">splom_triangle.frag</snippet>
     </shader>
   </namespace>
+  <namespace name="pickIndicator">
+    <shader name="vert">
+      <snippet type="version">430</snippet>
+      <snippet type="file">splom_pick_indicator.vert</snippet>
+    </shader>
+    <shader name="frag">
+      <snippet type="version">430</snippet>
+      <snippet type="file">splom_pick_indicator.frag</snippet>
+    </shader>
+  </namespace>
   <namespace name="screen">
     <shader name="vert">
       <snippet type="version">430</snippet>

--- a/plugins/infovis/Shaders/splom_pick.comp
+++ b/plugins/infovis/Shaders/splom_pick.comp
@@ -17,7 +17,7 @@ void main() {
         vec2 vsPosition = valuesToPosition(plot, 
             vec2(values[rowOffset + plot.indexX],
             values[rowOffset + plot.indexY])).xy;
-        if (distance(mouse, vsPosition) < kernelWidth / 2.0) {
+        if (distance(mouse, vsPosition) < kernelWidth) {
             selected = true;
             break;
         }

--- a/plugins/infovis/Shaders/splom_pick.comp
+++ b/plugins/infovis/Shaders/splom_pick.comp
@@ -3,25 +3,36 @@ uniform int numPlots;
 uniform int rowStride;
 uniform uint itemCount;
 uniform float kernelWidth;
+uniform float pickRadius;
+uniform int selector;
+uniform bool reset;
 
 layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 
-void main() {
-  uint itemID = gl_GlobalInvocationID.y * (gl_NumWorkGroups.x * gl_WorkGroupSize.x) + gl_GlobalInvocationID.x;
+void main()
+{
+    uint itemID = gl_GlobalInvocationID.y * (gl_NumWorkGroups.x * gl_WorkGroupSize.x) + gl_GlobalInvocationID.x;
 
-  if (itemID < itemCount && bitflag_isVisible(flags[itemID])) {
-    bool selected = false;
+    if (itemID >= itemCount || !bitflag_isVisible(flags[itemID])) {
+        return;
+    }
+
+    if (reset) {
+        bitflag_set(flags[itemID], FLAG_SELECTED, false);
+        return;
+    }
+
+    bool picked = false;
     for (int x = 0; x < numPlots; x++) {
         const Plot plot = plots[x];
         const uint rowOffset = itemID * rowStride;
-        vec2 vsPosition = valuesToPosition(plot, 
-            vec2(values[rowOffset + plot.indexX],
-            values[rowOffset + plot.indexY])).xy;
-        if (distance(mouse, vsPosition) < kernelWidth) {
-            selected = true;
+        vec2 vsPosition = valuesToPosition(plot, vec2(values[rowOffset + plot.indexX], values[rowOffset + plot.indexY])).xy;
+        if (distance(mouse, vsPosition) < kernelWidth + pickRadius) {
+            picked = true;
             break;
         }
     }
-    bitflag_set(flags[itemID], FLAG_SELECTED, selected);
-  }
+    if (picked) {
+        bitflag_set(flags[itemID], FLAG_SELECTED, (selector == 1));
+    }
 }

--- a/plugins/infovis/Shaders/splom_pick_indicator.frag
+++ b/plugins/infovis/Shaders/splom_pick_indicator.frag
@@ -1,0 +1,16 @@
+uniform vec4 indicatorColor = vec4(0.0, 0.0, 1.0, 1.0);
+
+in vec2 circleCoord;
+
+out vec4 fragColor;
+
+void main()
+{
+    float dist = length(circleCoord);
+
+    if (dist < 1.0) {
+        fragColor = indicatorColor;
+    } else {
+        discard;
+    }
+}

--- a/plugins/infovis/Shaders/splom_pick_indicator.vert
+++ b/plugins/infovis/Shaders/splom_pick_indicator.vert
@@ -1,0 +1,21 @@
+uniform mat4 modelViewProjection;
+uniform vec2 mouse = vec2(0, 0);
+uniform float pickRadius = 0.1;
+
+smooth out vec2 circleCoord;
+
+void main()
+{
+    vec2 vertices[6] = {
+        // b_l, b_r, t_r
+        vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(1.0, 1.0),
+        // t_r, t_l, b_l
+        vec2(1.0, 1.0), vec2(-1.0, 1.0), vec2(-1.0, -1.0)
+    };
+
+    circleCoord = vertices[gl_VertexID];
+
+    vec4 vertex = vec4(mouse + pickRadius * circleCoord, 0.0f, 1.0f);
+
+    gl_Position = modelViewProjection * vertex;
+}

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
@@ -238,6 +238,7 @@ bool ScatterplotMatrixRenderer2D::create() {
     if (!makeProgram("::splom::point", this->pointShader)) return false;
     if (!makeProgram("::splom::line", this->lineShader)) return false;
     if (!makeProgram("::splom::triangle", this->triangleShader)) return false;
+    if (!makeProgram("::splom::pickIndicator", this->pickIndicatorShader)) return false;
     if (!makeProgram("::splom::screen", this->screenShader)) return false;
 
     if (!makeProgram("::splom::pick", this->pickProgram)) return false;
@@ -331,6 +332,9 @@ bool ScatterplotMatrixRenderer2D::Render(core::view::CallRender2D& call) {
             this->drawText();
             break;
         }
+
+        this->drawPickIndicator();
+
         this->drawScreen();
 
     } catch (...) {
@@ -950,6 +954,26 @@ void ScatterplotMatrixRenderer2D::drawText() {
     validateText();
 
     this->textFont.BatchDrawString();
+
+    debugPop();
+}
+
+void ScatterplotMatrixRenderer2D::drawPickIndicator() {
+    debugPush(15, "drawPickIndicator");
+
+    this->pickIndicatorShader.Enable();
+
+    float color[] = {0.0, 1.0, 1.0, 1.0};
+    glUniformMatrix4fv(this->pickIndicatorShader.ParameterLocation("modelViewProjection"), 1, GL_FALSE,
+        getModelViewProjection().PeekComponents());
+    glUniform2f(this->pickIndicatorShader.ParameterLocation("mouse"), this->mouse.x, this->mouse.y);
+    glUniform1f(this->pickIndicatorShader.ParameterLocation("pickRadius"),
+        this->kernelWidthParam.Param<core::param::FloatParam>()->Value());
+    glUniform4fv(this->pickIndicatorShader.ParameterLocation("indicatorColor"), 1, color);
+    glDisable(GL_DEPTH_TEST);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glEnable(GL_DEPTH_TEST);
+    this->pickIndicatorShader.Disable();
 
     debugPop();
 }

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
@@ -92,6 +92,7 @@ ScatterplotMatrixRenderer2D::ScatterplotMatrixRenderer2D()
     , kernelTypeParam("kernelType", "Kernel function, i.e., box or gaussian kernel")
     , pickRadiusParam("pickRadius", "Picking radius")
     , resetSelectionParam("resetSelection", "Reset selection")
+    , drawPickIndicatorParam("drawPickIndicator", "Draw picking indicator")
     , triangulationSmoothnessParam("triangulationSmoothness", "Number of iterations to smooth the triangulation")
     , axisModeParam("axisMode", "Axis drawing mode")
     , axisColorParam("axisColor", "Color of axis")
@@ -174,6 +175,9 @@ ScatterplotMatrixRenderer2D::ScatterplotMatrixRenderer2D()
     this->resetSelectionParam << new core::param::ButtonParam();
     this->resetSelectionParam.SetUpdateCallback(this, &ScatterplotMatrixRenderer2D::resetSelectionCallback);
     this->MakeSlotAvailable(&this->resetSelectionParam);
+
+    this->drawPickIndicatorParam << new core::param::BoolParam(true);
+    this->MakeSlotAvailable(&this->drawPickIndicatorParam);
 
     auto* axisModes = new core::param::EnumParam(1);
     axisModes->SetTypePair(AXIS_MODE_NONE, "None");
@@ -346,7 +350,9 @@ bool ScatterplotMatrixRenderer2D::Render(core::view::CallRender2D& call) {
             break;
         }
 
-        this->drawPickIndicator();
+        if (this->drawPickIndicatorParam.Param<core::param::BoolParam>()->Value()) {
+            this->drawPickIndicator();
+        }
 
         this->drawScreen();
 

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
@@ -205,6 +205,8 @@ private:
 
     core::param::ParamSlot resetSelectionParam;
 
+    core::param::ParamSlot drawPickIndicatorParam;
+
     core::param::ParamSlot triangulationSmoothnessParam;
 
     core::param::ParamSlot axisModeParam;

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
@@ -177,6 +177,8 @@ private:
 
     void updateSelection();
 
+    bool resetSelectionCallback(core::param::ParamSlot& caller);
+
     core::CallerSlot floatTableInSlot;
 
     core::CallerSlot transferFunctionInSlot;
@@ -198,6 +200,10 @@ private:
     core::param::ParamSlot kernelWidthParam;
 
     core::param::ParamSlot kernelTypeParam;
+
+    core::param::ParamSlot pickRadiusParam;
+
+    core::param::ParamSlot resetSelectionParam;
 
     core::param::ParamSlot triangulationSmoothnessParam;
 
@@ -270,6 +276,7 @@ private:
     core::FlagStorage::FlagVersionType flagsBufferVersion;
 
     bool selectionNeedsUpdate = false;
+    bool selectionNeedsReset = false;
 
     GLuint triangleVBO;
     GLuint triangleIBO;

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
@@ -167,6 +167,8 @@ private:
 
     void drawText();
 
+    void drawPickIndicator();
+
     void unbindScreen();
 
     void bindAndClearScreen();
@@ -249,6 +251,8 @@ private:
     vislib::graphics::gl::GLSLGeometryShader lineShader;
 
     vislib::graphics::gl::GLSLShader triangleShader;
+
+    vislib::graphics::gl::GLSLShader pickIndicatorShader;
 
     vislib::graphics::gl::GLSLShader screenShader;
 


### PR DESCRIPTION
- Add pick radius parameter
- Draw selection marker
- Selection reacts now on first click, not only on move
- Remember selection, drawing with left clicks adds now to selection instead of replacing selection. Therefore it is possible to draw a larger selected area instead of just selecting pick radius around the mouse. Drawing with right clicks, removes selection
- Reset button to clear selection