### PR TITLE
Update eigen git repo

### DIFF
--- a/CMakeExternals.cmake
+++ b/CMakeExternals.cmake
@@ -40,8 +40,8 @@ function(require_external NAME)
     endif()
 
     add_external_headeronly_project(Eigen
-      GIT_REPOSITORY https://github.com/eigenteam/eigen-git-mirror.git
-      GIT_TAG "3.3.4")
+      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+      GIT_TAG "3.3.7")
 
   # glm
   elseif(NAME STREQUAL "glm")


### PR DESCRIPTION
The eigen repo switched now completely from mercurial to git, with the new repository located at: https://gitlab.com/libeigen/eigen
The GitHub git mirror is officially deprecated, because of hash differences to the migrated repository.

See:
- https://github.com/eigenteam/eigen-git-mirror
- http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th

Also I changed the version to latest release.