### PR TITLE
SPLOM: draw cell labels on mouse hover

### DIFF
--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
@@ -1026,7 +1026,8 @@ void ScatterplotMatrixRenderer2D::drawMouseLabels() {
         return;
     }
 
-    this->axisFont.ClearBatchDrawCache();
+    auto oldMode = this->axisFont.GetBatchDrawMode();
+    this->axisFont.SetBatchDrawMode(false);
 
     // Labels
     std::string labelX = columnInfos[cellIdX].Name();
@@ -1045,7 +1046,7 @@ void ScatterplotMatrixRenderer2D::drawMouseLabels() {
 
     this->axisFont.ResetRotation();
 
-    this->axisFont.BatchDrawString();
+    this->axisFont.SetBatchDrawMode(oldMode);
 }
 
 void ScatterplotMatrixRenderer2D::bindAndClearScreen() {

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
@@ -93,6 +93,7 @@ ScatterplotMatrixRenderer2D::ScatterplotMatrixRenderer2D()
     , pickRadiusParam("pickRadius", "Picking radius")
     , resetSelectionParam("resetSelection", "Reset selection")
     , drawPickIndicatorParam("drawPickIndicator", "Draw picking indicator")
+    , drawMouseLabelsParam("drawMouseLabels", "Draw labels on cells on mouse hover")
     , triangulationSmoothnessParam("triangulationSmoothness", "Number of iterations to smooth the triangulation")
     , axisModeParam("axisMode", "Axis drawing mode")
     , axisColorParam("axisColor", "Color of axis")
@@ -178,6 +179,9 @@ ScatterplotMatrixRenderer2D::ScatterplotMatrixRenderer2D()
 
     this->drawPickIndicatorParam << new core::param::BoolParam(true);
     this->MakeSlotAvailable(&this->drawPickIndicatorParam);
+
+    this->drawMouseLabelsParam << new core::param::BoolParam(false);
+    this->MakeSlotAvailable(&this->drawMouseLabelsParam);
 
     auto* axisModes = new core::param::EnumParam(1);
     axisModes->SetTypePair(AXIS_MODE_NONE, "None");
@@ -352,6 +356,10 @@ bool ScatterplotMatrixRenderer2D::Render(core::view::CallRender2D& call) {
 
         if (this->drawPickIndicatorParam.Param<core::param::BoolParam>()->Value()) {
             this->drawPickIndicator();
+        }
+
+        if (this->drawMouseLabelsParam.Param<core::param::BoolParam>()->Value()) {
+            this->drawMouseLabels();
         }
 
         this->drawScreen();
@@ -995,6 +1003,49 @@ void ScatterplotMatrixRenderer2D::drawPickIndicator() {
     this->pickIndicatorShader.Disable();
 
     debugPop();
+}
+
+void ScatterplotMatrixRenderer2D::drawMouseLabels() {
+    const float cellSize = this->cellSizeParam.Param<core::param::FloatParam>()->Value();
+    const float cellMargin = this->cellMarginParam.Param<core::param::FloatParam>()->Value();
+    const auto axisColor = this->axisColorParam.Param<core::param::ColorParam>()->Value();
+    const auto columnCount = this->floatTable->GetColumnsCount();
+    const auto columnInfos = this->floatTable->GetColumnsInfos();
+    const float nameSize = this->cellNameSizeParam.Param<core::param::FloatParam>()->Value();
+
+    if (this->mouse.x < 0 || this->mouse.y < 0) {
+        return;
+    }
+
+    int cellIdX = static_cast<int>(this->mouse.x / (cellSize + cellMargin));
+    int cellIdY = static_cast<int>(this->mouse.y / (cellSize + cellMargin));
+
+    if (cellIdX >= columnCount || cellIdY >= columnCount || cellIdX + 1 >= cellIdY ||
+        this->mouse.x - static_cast<float>(cellIdX) * (cellSize + cellMargin) > cellSize ||
+        this->mouse.y - static_cast<float>(cellIdY) * (cellSize + cellMargin) > cellSize) {
+        return;
+    }
+
+    this->axisFont.ClearBatchDrawCache();
+
+    // Labels
+    std::string labelX = columnInfos[cellIdX].Name();
+    const float xLabelLeft = static_cast<float>(cellIdX) * (cellSize + cellMargin);
+    const float xLabelTop = static_cast<float>(cellIdY) * (cellSize + cellMargin);
+    this->axisFont.DrawString(axisColor.data(), xLabelLeft, xLabelTop, cellSize, cellSize, nameSize, false,
+        labelX.c_str(), core::utility::AbstractFont::ALIGN_CENTER_TOP);
+
+    this->axisFont.SetRotation(90.0, 0.0, 0.0, 1.0);
+
+    std::string labelY = columnInfos[cellIdY].Name();
+    const float yLabelLeft = static_cast<float>(cellIdX + 1) * (cellSize + cellMargin) - cellMargin;
+    const float yLabelTop = static_cast<float>(cellIdY) * (cellSize + cellMargin);
+    this->axisFont.DrawString(axisColor.data(), yLabelTop, -yLabelLeft, cellSize, cellSize, nameSize, false,
+        labelY.c_str(), core::utility::AbstractFont::ALIGN_CENTER_TOP);
+
+    this->axisFont.ResetRotation();
+
+    this->axisFont.BatchDrawString();
 }
 
 void ScatterplotMatrixRenderer2D::bindAndClearScreen() {

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.h
@@ -169,6 +169,8 @@ private:
 
     void drawPickIndicator();
 
+    void drawMouseLabels();
+
     void unbindScreen();
 
     void bindAndClearScreen();
@@ -206,6 +208,8 @@ private:
     core::param::ParamSlot resetSelectionParam;
 
     core::param::ParamSlot drawPickIndicatorParam;
+
+    core::param::ParamSlot drawMouseLabelsParam;
 
     core::param::ParamSlot triangulationSmoothnessParam;
 


### PR DESCRIPTION
Draw labels directly on currently hovered cell. This is very useful when zooming into SPLOM on data with many columns. There is a param for switching this on/off. Default is off.
Example:
![splom-mouse-labels](https://user-images.githubusercontent.com/7849248/78395679-37f9b780-75ee-11ea-87e0-7c01d69e3cf1.png)