### PR TITLE
Ugly hack for glfw so files

### DIFF
--- a/CMakeExternals.cmake
+++ b/CMakeExternals.cmake
@@ -210,12 +210,16 @@ function(require_external NAME)
       set(GLFW_LIB "bin/glfw3.dll")
     else()
       set(GLFW_LIB "${CMAKE_INSTALL_LIBDIR}/libglfw.so")
+      # This is a try to fix #544 at least for GLFW. I found no nicer solution, probably this needs some major refactoring of the externals system.
+      # It is probably a very ugly hack, but hopefully this whole dynamic linking stuff dies anytime soon.
+      set(GLFW_LIB2 "${CMAKE_INSTALL_LIBDIR}/libglfw.so.3")
+      set(GLFW_LIB3 "${CMAKE_INSTALL_LIBDIR}/libglfw.so.3.3")
     endif()
 
     add_external_project(glfw SHARED
       GIT_REPOSITORY https://github.com/glfw/glfw.git
       GIT_TAG "3.3.2"
-      BUILD_BYPRODUCTS "<INSTALL_DIR>/${GLFW_LIB}" "<INSTALL_DIR>/${GLFW_IMPORT_LIB}"
+      BUILD_BYPRODUCTS "<INSTALL_DIR>/${GLFW_LIB}" "<INSTALL_DIR>/${GLFW_LIB2}" "<INSTALL_DIR>/${GLFW_LIB3}" "<INSTALL_DIR>/${GLFW_IMPORT_LIB}"
       CMAKE_ARGS
         -DBUILD_SHARED_LIBS=ON
         -DGLFW_BUILD_EXAMPLES=OFF


### PR DESCRIPTION
Workaround for #544 for GLFW.

#544 currently only is not big problem, because there is the system wide GLFW library as fallback. But this breaks, when using GLFW 3.3 functionality and the system wide version is only GLFW 3.2.x.
(This will happen in #559.)