### PR TITLE
If we have no GL, the user needs to know that this is a problem!

### DIFF
--- a/console/src/gl/Window.cpp
+++ b/console/src/gl/Window.cpp
@@ -156,6 +156,12 @@ gl::Window::Window(const char* title, const utility::WindowPlacement & placement
             glGetIntegerv(GL_VIEWPORT, vp);
             vislib::sys::Log::DefaultLog.WriteInfo("Console::Window: viewport size w: %d, h: %d\n", vp[2], vp[3]);
 
+        } else {
+            vislib::sys::Log::DefaultLog.WriteError(
+                "Could not create GLFW Window. You probably do not have OpenGL support. Your graphics hardware might "
+                "be very old, your drivers could be outdated or you are running in a remote desktop session.");
+            // we should do a proper shutdown now, but that is too expensive given the expected lifetime of this front end.
+            exit(-1);
         }
 
         glGenQueries(1, &fragmentQuery);


### PR DESCRIPTION
Someone tried to use MegaMol via Rdesktop and did not see the problem: the frontend does not behave sensibly when there is no GL. That is acceptable as long as we *tell the user*.