### PR TITLE
Glsl compiler error

### DIFF
--- a/plugins/mmstd_moldyn/Shaders/sphere_flags.btf
+++ b/plugins/mmstd_moldyn/Shaders/sphere_flags.btf
@@ -30,7 +30,7 @@ uint flag = uint(0);
 
 #ifdef FLAGS_AVAILABLE
     if (bool(flags_enabled)) {    
-        flag = inFlags[(flags_offset + gl_VertexID)];
+        flag = inFlags[(flags_offset + uint(gl_VertexID))];
     }
 #endif // FLAGS_AVAILABLE
 


### PR DESCRIPTION
Basic fix by casting gl_VertexID to uint.
Might cause range issues with flags_offset ... please check this.