### PR TITLE
Default install path set to binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 project(megamol)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}
+  set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}
     CACHE PATH "default install path" FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 project(megamol)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install"
     CACHE PATH "default install path" FORCE)
 endif()
 


### PR DESCRIPTION
Set default install path to `${CMAKE_BINARY_DIR}/install` instead of `${CMAKE_SOURCE_DIR}`.
This resolves #600.