### PR TITLE
Reworking Freelancer-style controls

### DIFF
--- a/core/include/mmcore/thecam/rotate_manipulator.h
+++ b/core/include/mmcore/thecam/rotate_manipulator.h
@@ -64,12 +64,12 @@ public:
      *
      * @param angle The angle to rotate in degrees.
      */
-    void yaw(const world_type angle);
+    void yaw(const world_type angle, bool fixToWorldUp);
 
     /**
      * Rotates the camera around the up vector using the internally stored rotation angle.
      */
-    inline void yaw(void) { this->yaw(this->rotationAngle); }
+    inline void yaw(bool fixToWorldUp) { this->yaw(this->rotationAngle, fixToWorldUp); }
 
     /**
      * Rotates the camera around the view vector.

--- a/core/include/mmcore/thecam/rotate_manipulator.inl
+++ b/core/include/mmcore/thecam/rotate_manipulator.inl
@@ -26,11 +26,11 @@ template <class T> void megamol::core::thecam::rotate_manipulator<T>::pitch(cons
 /*
  * megamol::core::thecam::rotate_manipulator<T>::yaw
  */
-template <class T> void megamol::core::thecam::rotate_manipulator<T>::yaw(const world_type angle) {
+template <class T> void megamol::core::thecam::rotate_manipulator<T>::yaw(const world_type angle, bool fixToWorldUp) {
     if (this->enabled()) {
         auto cam = this->camera();
         quaternion_type rotquat;
-        auto up = cam->up_vector();
+        auto up = fixToWorldUp ? vector_type(0.0f, 1.0f, 0.0f, 0.0f) : cam->up_vector();
         set_from_angle_axis(rotquat, math::angle_deg2rad(angle), up);
         cam->orientation(rotquat * cam->orientation());
     }

--- a/core/include/mmcore/view/View3D_2.h
+++ b/core/include/mmcore/view/View3D_2.h
@@ -339,6 +339,8 @@ protected:
     /** The angle rotate step in degrees */
     param::ParamSlot viewKeyAngleStepSlot;
 
+    param::ParamSlot viewKeyFixToWorldUpSlot;
+
     /** sensitivity for mouse rotation in WASD mode */
     param::ParamSlot mouseSensitivitySlot;
 

--- a/core/src/view/View3D_2.cpp
+++ b/core/src/view/View3D_2.cpp
@@ -81,6 +81,7 @@ View3D_2::View3D_2(void)
     , viewKeyMoveStepSlot("viewKey::MoveStep", "The move step size in world coordinates")
     , viewKeyRunFactorSlot("viewKey::RunFactor", "The factor for step size multiplication when running (shift)")
     , viewKeyAngleStepSlot("viewKey::AngleStep", "The angle rotate step in degrees")
+    , viewKeyFixToWorldUpSlot("viewKey::FixToWorldUp","Fix rotation manipulator to world up vector")
     , mouseSensitivitySlot("viewKey::MouseSensitivity", "used for WASD mode")
     , viewKeyRotPointSlot("viewKey::RotPoint", "The point around which the view will be rotated")
     , enableMouseSelectionSlot("enableMouseSelection", "Enable selecting and picking with the mouse")
@@ -175,6 +176,9 @@ View3D_2::View3D_2(void)
 
     this->viewKeyAngleStepSlot.SetParameter(new param::FloatParam(90.0f, 0.1f, 360.0f));
     this->MakeSlotAvailable(&this->viewKeyAngleStepSlot);
+
+    this->viewKeyFixToWorldUpSlot.SetParameter(new param::BoolParam(true));
+    this->MakeSlotAvailable(&this->viewKeyFixToWorldUpSlot);
 
     this->mouseSensitivitySlot.SetParameter(new param::FloatParam(3.0f, 0.001f, 10.0f));
     this->mouseSensitivitySlot.SetUpdateCallback(&View3D_2::mouseSensitivityChanged);
@@ -778,10 +782,6 @@ bool view::View3D_2::OnMouseButton(view::MouseButton button, view::MouseButtonAc
                 {
                     this->turntableManipulator.setActive(
                         wndSize.width() - static_cast<int>(this->mouseX), static_cast<int>(this->mouseY));
-                } else {
-                    this->rotateManipulator.setActive();
-                    this->translateManipulator.setActive(
-                        wndSize.width() - static_cast<int>(this->mouseX), static_cast<int>(this->mouseY));
                 }
             }
 
@@ -792,6 +792,10 @@ bool view::View3D_2::OnMouseButton(view::MouseButton button, view::MouseButtonAc
             if (!anyManipulatorActive) {
                 if ((altPressed ^ this->arcballDefault) || ctrlPressed) {
                     this->orbitAltitudeManipulator.setActive(
+                        wndSize.width() - static_cast<int>(this->mouseX), static_cast<int>(this->mouseY));
+                } else {
+                    this->rotateManipulator.setActive();
+                    this->translateManipulator.setActive(
                         wndSize.width() - static_cast<int>(this->mouseX), static_cast<int>(this->mouseY));
                 }
             }
@@ -906,19 +910,26 @@ bool view::View3D_2::OnMouseScroll(double dx, double dy) {
         if ((*cr)(view::CallRender3D_2::FnOnMouseScroll)) return true;
     }
 
-    // ToDo scrollwheel zooming..
-    if (abs(dy) > 0.0) {
 
-        auto cam_pos = this->cam.eye_position();
-        auto rot_cntr = thecam::math::point<glm::vec4>(glm::vec4(this->rotCenter, 0.0f));
+    // This mouse handling/mapping is so utterly weird and should die!
+    if (!this->toggleMouseSelection && (abs(dy) > 0.0)) {
+        if (this->rotateManipulator.manipulating()) {
+            this->viewKeyMoveStepSlot.Param<param::FloatParam>()->SetValue(
+                this->viewKeyMoveStepSlot.Param<param::FloatParam>()->Value() + 
+                (dy * 0.1f * this->viewKeyMoveStepSlot.Param<param::FloatParam>()->Value())
+            ); 
+        } else {
+            auto cam_pos = this->cam.eye_position();
+            auto rot_cntr = thecam::math::point<glm::vec4>(glm::vec4(this->rotCenter, 0.0f));
 
-        cam_pos.w() = 0.0f;
+            cam_pos.w() = 0.0f;
 
-        auto v = thecam::math::normalise(rot_cntr - cam_pos);
+            auto v = thecam::math::normalise(rot_cntr - cam_pos);
 
-        auto altitude = thecam::math::length(rot_cntr - cam_pos);
+            auto altitude = thecam::math::length(rot_cntr - cam_pos);
 
-        this->cam.position(cam_pos + (v * dy * (altitude / 50.0f)));
+            this->cam.position(cam_pos + (v * dy * (altitude / 50.0f)));
+        }
     }
 
     return true;
@@ -1183,7 +1194,10 @@ void View3D_2::handleCameraMovement(void) {
         mouseDirection /= midpoint;
 
         this->rotateManipulator.pitch(-mouseDirection.y * rotationStep);
-        this->rotateManipulator.yaw(mouseDirection.x * rotationStep);
+        this->rotateManipulator.yaw(
+            mouseDirection.x * rotationStep,
+            this->viewKeyFixToWorldUpSlot.Param<param::BoolParam>()->Value()
+        );
     }
 
     glm::vec3 newCamPos(static_cast<glm::vec4>(this->cam.eye_position()));


### PR DESCRIPTION
- Mapped activation of rotation+translation manipulator (i.e. our Freelancer-style camera controls) to right mouse button
- While rotation manipulator is active, scrolling will increase/decrease movement speed (very convenient for large scenes)
- Yaw axis of rotation manipulator is now fixed to world up vector ([0,1,0]) by default with the option to change via parameter
