### PR TITLE
minor fix to delete stale data in boxrenderer

### DIFF
--- a/plugins/thermodyn/src/rendering/BoxRenderer.h
+++ b/plugins/thermodyn/src/rendering/BoxRenderer.h
@@ -79,10 +79,13 @@ private:
     std::pair<std::vector<float>, std::vector<float>> drawData;
     static void prepareData(std::vector<BoxDataCall::box_entry_t> const& indata,
         std::pair<std::vector<float>, std::vector<float>>& outdata) {
+
         auto& pos = outdata.first;
         pos.reserve(indata.size() * 72);
         auto& col = outdata.second;
         col.reserve(indata.size() * 96);
+        pos.clear();
+        col.clear();
 
         for (auto const& e : indata) {
             auto const& box = e.box_;

--- a/plugins/thermodyn/src/rendering/BoxRenderer.h
+++ b/plugins/thermodyn/src/rendering/BoxRenderer.h
@@ -80,11 +80,11 @@ private:
     static void prepareData(std::vector<BoxDataCall::box_entry_t> const& indata,
         std::pair<std::vector<float>, std::vector<float>>& outdata) {
 
-        pos.clear();
-        col.clear();
         auto& pos = outdata.first;
+        pos.clear();
         pos.reserve(indata.size() * 72);
         auto& col = outdata.second;
+        col.clear();
         col.reserve(indata.size() * 96);
 
         for (auto const& e : indata) {

--- a/plugins/thermodyn/src/rendering/BoxRenderer.h
+++ b/plugins/thermodyn/src/rendering/BoxRenderer.h
@@ -80,12 +80,12 @@ private:
     static void prepareData(std::vector<BoxDataCall::box_entry_t> const& indata,
         std::pair<std::vector<float>, std::vector<float>>& outdata) {
 
+        pos.clear();
+        col.clear();
         auto& pos = outdata.first;
         pos.reserve(indata.size() * 72);
         auto& col = outdata.second;
         col.reserve(indata.size() * 96);
-        pos.clear();
-        col.clear();
 
         for (auto const& e : indata) {
             auto const& box = e.box_;


### PR DESCRIPTION
Clearing the drawdata vector guarantees that unneeded data will no longer be rendered