### PR TITLE
Fix SimpleMoleculeRenderer for AMD GPUs

### DIFF
--- a/plugins/protein/Shaders/protein.btf
+++ b/plugins/protein/Shaders/protein.btf
@@ -2725,7 +2725,8 @@ void main(void) {
       <!--<snippet type="version">130</snippet>-->
       <snippet type="string">
         <!--
-        #version 120
+        #version 140
+        #extension GL_ARB_compatibility : enable
         -->
       </snippet>
       <snippet name="commondefines"/>


### PR DESCRIPTION
## Summary of Changes
Set GLSL version of cylinderFragmentOR shader to 140 and enable GL_ARB_compatibility extension. 

## Test Instructions
Should be tested with Nvidia (and Intel?) GPUs. Expected behaviour: You can successfully create an instance of a SimpleMoleculeRenderer without shader compiler errors.