### PR TITLE
Frontend: Graph module search & Module resources access

### DIFF
--- a/core/include/mmcore/Module.h
+++ b/core/include/mmcore/Module.h
@@ -213,6 +213,8 @@ private:
 
     /* Allow the container to access the internal create flag */
     friend class ::megamol::core::AbstractNamedObjectContainer;
+
+    std::vector<megamol::frontend::FrontendResource> frontend_resources;
 };
 
 

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -464,26 +464,21 @@ megamol::core::Call::ptr_type megamol::core::MegaMolGraph::FindCall(
     return call_it->callPtr;
 }
 
-megamol::core::ModuleList_t::iterator megamol::core::MegaMolGraph::find_module_by_prefix(std::string const& name) {
-    auto module_it = std::find_if(module_list_.begin(), module_list_.end(),
-        [&](auto const& module) 
-    {
-        const auto found = name.find(module.request.id);
-        return (found != std::string::npos) && found == 0; // substing found && substring starts at beginning
-    });
+static const auto check_module_is_prefix = [&](auto const& module) {
+        const auto& module_name = module.request.id;
+        const auto substring = request.substr(0, module_name.size());
+        return (module_name == substring) && // module name is prefix of request
+            (request.size() == module_name.size() // module name matches whole request
+            || (request.size() >= module_name.size()+2 && request.substr(module_name.size(), 2) == "::")); // OR request has :: after module name
+    };
 
-    return module_it;
+// find module where module name is prefix of request
+megamol::core::ModuleList_t::iterator megamol::core::MegaMolGraph::find_module_by_prefix(std::string const& request) {
+    return std::find_if(module_list_.begin(), module_list_.end(), check_module_is_prefix);
 }
 
 megamol::core::ModuleList_t::const_iterator megamol::core::MegaMolGraph::find_module_by_prefix(std::string const& name) const {
-    auto module_it = std::find_if(module_list_.begin(), module_list_.end(),
-        [&](auto const& module) 
-    {
-        const auto found = name.find(module.request.id);
-        return (found != std::string::npos) && found == 0; // substing found && substring starts at beginning
-    });
-
-    return module_it;
+    return std::find_if(module_list_.begin(), module_list_.end(), check_module_is_prefix);
 }
 
 megamol::core::param::ParamSlot* megamol::core::MegaMolGraph::FindParameterSlot(std::string const& paramName) const {

--- a/core/src/Module.cpp
+++ b/core/src/Module.cpp
@@ -55,16 +55,7 @@ Module::~Module(void) {
 bool Module::Create(std::vector<megamol::frontend::FrontendResource> resources) {
     using megamol::core::utility::log::Log;
 
-	const megamol::frontend_resources::IOpenGL_Context* opengl_context = nullptr;
-    auto opengl_context_it = std::find_if(resources.begin(), resources.end(),
-        [&](megamol::frontend::FrontendResource& dep) { return dep.getIdentifier() == "IOpenGL_Context"; });
-
-    if (opengl_context_it != resources.end()) {
-        opengl_context = &opengl_context_it->getResource<megamol::frontend_resources::IOpenGL_Context>();
-    }
-
-	if (opengl_context)
-		opengl_context->activate();
+    this->frontend_resources = resources;
 
     ASSERT(this->instance() != NULL);
     if (!this->created) {
@@ -90,9 +81,6 @@ bool Module::Create(std::vector<megamol::frontend::FrontendResource> resources) 
         // Now reregister parents at children
         this->fixParentBackreferences();
     }
-
-	if (opengl_context)
-		opengl_context->close();
 
     return this->created;
 }
@@ -137,24 +125,12 @@ void Module::Release(std::vector<megamol::frontend::FrontendResource> resources)
     auto opengl_context_it = std::find_if(resources.begin(), resources.end(),
         [&](megamol::frontend::FrontendResource& dep) { return dep.getIdentifier() == "IOpenGL_Context"; });
 
-	const megamol::frontend_resources::IOpenGL_Context* opengl_context = nullptr;
-
-    if (opengl_context_it != resources.end()) {
-        opengl_context = &opengl_context_it->getResource<megamol::frontend_resources::IOpenGL_Context>();
-    }
-
-	if (opengl_context)
-		opengl_context->activate();
-
     if (this->created) {
         this->release();
         this->created = false;
         Log::DefaultLog.WriteMsg(Log::LEVEL_INFO + 350,
             "Released module \"%s\"\n", typeid(*this).name());
     }
-
-	if (opengl_context)
-		opengl_context->close();
 }
 
 


### PR DESCRIPTION
* fixes bug where modules in the graph may make other modules unfindable when a module name is prefix of another
* adds `frontend_resources` member variable to **Module** base class so modules can access requested frontend resources
* removes GL context activation/deactivation in module create() and release() because: contrary to initial assumptions the GL context has to be **active all the time** (e.g. parameter changes input from the GUI may trigger GL commands). So the GL service now sets the GL context active from the beginning and the GL context resource shall be used to reflect GL dependency by modules. 