### PR TITLE
ignores/RaycastVolumeRenderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/**/*
 build-*/**/*
 build_*/**/*
+out/**/*
 cmake-build-*/**/*
 bin/**/*
 include/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ utils/MMPLD/SphereTest.bat
 examples/
 solution/**/*
 deploy/**/*
+
+CMakeSettings.json
+
+.vs/

--- a/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
+++ b/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
@@ -653,8 +653,8 @@ bool RaycastVolumeRenderer::updateVolumeData(const unsigned int frameID) {
     m_volume_resolution[1] = metadata->Resolution[1];
     m_volume_resolution[2] = metadata->Resolution[2];
 
-    valRange[0] = metadata->MinValues[0];
-    valRange[1] = metadata->MaxValues[0];
+    valRange[0] = 0.0f;
+    valRange[1] = 1.0f;
 
     GLenum internal_format;
     GLenum format;
@@ -666,6 +666,9 @@ bool RaycastVolumeRenderer::updateVolumeData(const unsigned int frameID) {
             internal_format = GL_R32F;
             format = GL_RED;
             type = GL_FLOAT;
+            // this only makes sense here, all other data types are normalized anyway
+            valRange[0] = metadata->MinValues[0];
+            valRange[1] = metadata->MaxValues[0];
         } else {
             megamol::core::utility::log::Log::DefaultLog.WriteError("Floating point values with a length != 4 byte are invalid.");
             return false;

--- a/plugins/mmstd_volume/src/RaycastVolumeRenderer.h
+++ b/plugins/mmstd_volume/src/RaycastVolumeRenderer.h
@@ -141,10 +141,6 @@ private:
     core::param::ParamSlot m_specular_color;
     core::param::ParamSlot m_material_color;
 
-    core::param::ParamSlot paramOverride;
-    core::param::ParamSlot paramMinOverride;
-    core::param::ParamSlot paramMaxOverride;
-
     /** caller slot */
     megamol::core::CallerSlot m_renderer_callerSlot;
     megamol::core::CallerSlot m_volumetricData_callerSlot;
@@ -152,6 +148,7 @@ private:
     megamol::core::CallerSlot m_transferFunction_callerSlot;
 
     std::array<float, 2> valRange;
+    bool valRangeNeedsUpdate = false;
 
     /** FBO for chaining renderers */
     vislib::graphics::gl::FramebufferObject fbo;


### PR DESCRIPTION
## Summary of Changes
- updates to ignore list for VS/Cmake in VS
- should fix a thinko in RaycastVolumeRenderer
- Range override in RaycastVolumeRenderer is taken from TF instead

## Test Instructions
you need a raycast_volume_renderer.lua that works with your frontend of choice :/