### PR TITLE
GenericTimedVersionedCall

### DIFF
--- a/core/include/mmcore/Call.h
+++ b/core/include/mmcore/Call.h
@@ -64,7 +64,7 @@ namespace core {
          *
          * @return The return value of the function.
          */
-        bool operator()(unsigned int func = 0);
+        virtual bool operator()(unsigned int func = 0);
 
         /**
          * Answers the callee slot this call is connected to.

--- a/core/include/mmcore/CallGeneric.h
+++ b/core/include/mmcore/CallGeneric.h
@@ -79,6 +79,119 @@ private:
     uint32_t m_set_version = 0;
 };
 
+
+template<typename DataType, typename MetaDataType>
+class GenericTimedVersionedCall : public Call {
+public:
+    using data_type = DataType;
+    using meta_data_type = MetaDataType;
+
+    GenericTimedVersionedCall() = default;
+    ~GenericTimedVersionedCall() = default;
+
+    static unsigned int FunctionCount() {
+        return 2;
+    }
+
+    static const unsigned int CallGetData = 0;
+
+    static const unsigned int CallGetMetaData = 1;
+
+    static const char* FunctionName(unsigned int idx) {
+        switch (idx) {
+        case 0:
+            return "GetData";
+        case 1:
+            return "GetMetaData";
+        }
+        return NULL;
+    }
+
+    // For compiler reasons I couldn't set a default 0 for frame_id, forcing calls for CallGetMetaData
+    // to supply some value, even if the function isn't supposed to be know about a specific frame id yet.
+    // In a better world, data and meta data maybe shouldn't be called via the same function, if the parameters
+    // aren't even the same....
+    bool operator()(unsigned int func, uint32_t frame_id) {
+        if (func == CallGetData) {
+            m_req_frame_id = frame_id;
+        }
+        return Call::operator()(func);
+    }
+
+    void setData(DataType const& data, uint32_t version, uint32_t frame_id) {
+        m_data = data;
+        m_set_version = version;
+        m_set_frame_id = frame_id;
+    }
+
+    void setMetaData(MetaDataType const& meta_data) {
+        m_meta_data = meta_data;
+    }
+
+    DataType const& getData() {
+        m_get_version = m_set_version;
+        m_get_frame_id = m_set_frame_id;
+        return m_data;
+    }
+
+    MetaDataType const& getMetaData() {
+        return m_meta_data;
+    }
+
+    // TODO move setters?
+
+    uint32_t version() {
+        return m_set_version;
+    }
+
+    /**
+     * Returns frame id of currently set data
+     */
+    uint32_t frameID() {
+        return m_set_frame_id;
+    }
+
+    /**
+     * Returns frame id from last issued request for data, i.e., from last call to CallData callback
+     */
+    uint32_t requestedFrameID() {
+        return m_req_frame_id;
+    }
+
+    bool hasUpdate() {
+        bool version_check = (m_set_version > m_get_version);
+        // the best I could come up with for a somewhat sane float comparison...see http://realtimecollisiondetection.net/blog/?p=89
+        bool frame_id_check = std::abs(m_set_frame_id - m_get_frame_id) >=
+                              (std::numeric_limits<float>::epsilon() *
+                                  std::max(1.0f, std::max(std::abs(m_set_frame_id), std::abs(m_get_frame_id))));
+        return (version_check || frame_id_check);
+    }
+
+private:
+
+    /**
+    * "Block" original callback operator to users of GenericTimedVersionedCall
+    */
+    virtual bool operator()(unsigned int func = 0) override final {
+        return false;
+    }
+
+    DataType m_data;
+    MetaDataType m_meta_data;
+
+    uint32_t m_get_version = 0;
+    uint32_t m_set_version = 0;
+
+    // comment: still not too thrilled about the name "frame id" because of the ambiguity of
+    // simulation frame and render frame (and I usually refer to the latter whenever I use just "frame")
+    float m_get_frame_id = 0;
+    float m_set_frame_id = 0;
+    // comment: technically we could abuse m_set_frame_id to handle requested frame ids but
+    // if a module dares not to call setData with the proper frame id during a callback
+    // things would probably break, therefore: using a dedicated variable for requested frame id
+    float m_req_frame_id = 0;
+};
+
 } // namespace mesh
 } // namespace megamol
 

--- a/plugins/mesh/include/mesh/MeshCalls.h
+++ b/plugins/mesh/include/mesh/MeshCalls.h
@@ -57,10 +57,10 @@ public:
 };
 
 class CallGPUMeshData
-    : public core::GenericVersionedCall<std::vector<std::shared_ptr<GPUMeshCollection>>, core::Spatial3DMetaData> {
+    : public core::GenericTimedVersionedCall<std::vector<std::shared_ptr<GPUMeshCollection>>, core::Spatial3DMetaData> {
 public:
     CallGPUMeshData()
-            : GenericVersionedCall<std::vector<std::shared_ptr<GPUMeshCollection>>, core::Spatial3DMetaData>() {}
+            : GenericTimedVersionedCall<std::vector<std::shared_ptr<GPUMeshCollection>>, core::Spatial3DMetaData>() {}
     ~CallGPUMeshData() = default;
 
     static const char* ClassName(void) { return "CallGPUMeshData"; }
@@ -70,20 +70,23 @@ public:
 };
 
 class CallGPURenderTaskData
-    : public core::GenericVersionedCall<std::vector<std::shared_ptr<GPURenderTaskCollection>>, core::Spatial3DMetaData> {
+        : public core::GenericTimedVersionedCall<std::vector<std::shared_ptr<GPURenderTaskCollection>>,
+              core::Spatial3DMetaData> {
 public:
     CallGPURenderTaskData()
-            : GenericVersionedCall<std::vector<std::shared_ptr<GPURenderTaskCollection>>, core::Spatial3DMetaData>(){}
+            : GenericTimedVersionedCall<std::vector<std::shared_ptr<GPURenderTaskCollection>>,
+                  core::Spatial3DMetaData>() {}
     ~CallGPURenderTaskData(){};
 
     static const char* ClassName(void) { return "CallGPURenderTaskData"; }
     static const char* Description(void) { return "Call that gives access to render tasks."; }
 };
 
-class CallMesh : public core::GenericVersionedCall<std::shared_ptr<MeshDataAccessCollection>, core::Spatial3DMetaData> {
+class CallMesh
+        : public core::GenericTimedVersionedCall<std::shared_ptr<MeshDataAccessCollection>, core::Spatial3DMetaData> {
 public:
-    CallMesh() : GenericVersionedCall<std::shared_ptr<MeshDataAccessCollection>, core::Spatial3DMetaData>() {}
-    ~CallMesh(){};
+    CallMesh() : GenericTimedVersionedCall<std::shared_ptr<MeshDataAccessCollection>, core::Spatial3DMetaData>() {}
+    ~CallMesh() = default;
 
     static const char* ClassName(void) { return "CallMesh"; }
     static const char* Description(void) { return "Call that gives access to CPU-side mesh data."; }

--- a/plugins/mesh/src/3DUIRenderTaskDataSource.cpp
+++ b/plugins/mesh/src/3DUIRenderTaskDataSource.cpp
@@ -47,11 +47,14 @@ bool megamol::mesh::ThreeDimensionalUIRenderTaskDataSource::getDataCallback(core
         return false;
     }
 
+    uint32_t requested_frame_id = lhs_rtc->requestedFrameID();
+    uint32_t current_frame_id = lhs_rtc->frameID();
+
     CallGPURenderTaskData* rhs_rtc = this->m_renderTask_rhs_slot.CallAs<CallGPURenderTaskData>();
 
     std::vector<std::shared_ptr<GPURenderTaskCollection>> gpu_render_tasks;
     if (rhs_rtc != nullptr) {
-        if (!(*rhs_rtc)(0)) {
+        if (!(*rhs_rtc)(CallGPURenderTaskData::CallGetData, requested_frame_id)) {
             return false;
         }
         if (rhs_rtc->hasUpdate()) {
@@ -64,7 +67,7 @@ bool megamol::mesh::ThreeDimensionalUIRenderTaskDataSource::getDataCallback(core
     CallGPUMeshData* mc = this->m_mesh_slot.CallAs<CallGPUMeshData>();
     if (mc == NULL)
         return false;
-    if (!(*mc)(0))
+    if (!(*mc)(CallGPUMeshData::CallGetData, requested_frame_id))
         return false;
 
     CallGlTFData* gltf_call = this->m_glTF_callerSlot.CallAs<CallGlTFData>();
@@ -82,6 +85,7 @@ bool megamol::mesh::ThreeDimensionalUIRenderTaskDataSource::getDataCallback(core
 
         auto model = gltf_call->getData().second;
         auto gpu_mesh_storage = mc->getData();
+        current_frame_id = mc->frameID();
 
         for (size_t node_idx = 0; node_idx < model->nodes.size(); node_idx++) {
             if (node_idx < model->nodes.size() && model->nodes[node_idx].mesh != -1) {
@@ -237,7 +241,7 @@ bool megamol::mesh::ThreeDimensionalUIRenderTaskDataSource::getDataCallback(core
         m_rendertask_collection.first->addPerFrameDataBuffer("lights", lights, 1);
     }
 
-    lhs_rtc->setData(gpu_render_tasks, m_version);
+    lhs_rtc->setData(gpu_render_tasks, m_version, current_frame_id);
 
     return true;
 }

--- a/plugins/mesh/src/AbstractGPURenderTaskDataSource.cpp
+++ b/plugins/mesh/src/AbstractGPURenderTaskDataSource.cpp
@@ -58,7 +58,7 @@ bool megamol::mesh::AbstractGPURenderTaskDataSource::getMetaDataCallback(core::C
         auto rhs_meta_data = rhs_rt_call->getMetaData();
         rhs_meta_data.m_frame_ID = lhs_meta_data.m_frame_ID;
         rhs_rt_call->setMetaData(rhs_meta_data);
-        if (!(*rhs_rt_call)(1))
+        if (!(*rhs_rt_call)(1,0))
             return false;
         rhs_meta_data = rhs_rt_call->getMetaData();
 
@@ -76,7 +76,7 @@ bool megamol::mesh::AbstractGPURenderTaskDataSource::getMetaDataCallback(core::C
         auto mesh_meta_data = mesh_call->getMetaData();
         mesh_meta_data.m_frame_ID = lhs_meta_data.m_frame_ID;
         mesh_call->setMetaData(mesh_meta_data);
-        if (!(*mesh_call)(1))
+        if (!(*mesh_call)(1,0))
             return false;
         mesh_meta_data = mesh_call->getMetaData();
 

--- a/plugins/mesh/src/AbstractMeshDataSource.cpp
+++ b/plugins/mesh/src/AbstractMeshDataSource.cpp
@@ -43,7 +43,7 @@ bool megamol::mesh::AbstractMeshDataSource::getMeshMetaDataCallback(core::Call& 
         auto rhs_meta_data = rhs_mesh_call->getMetaData();
         rhs_meta_data.m_frame_ID = lhs_meta_data.m_frame_ID;
         rhs_mesh_call->setMetaData(rhs_meta_data);
-        if (!(*rhs_mesh_call)(1))
+        if (!(*rhs_mesh_call)(CallMesh::CallGetMetaData, 0))
             return false;
         rhs_meta_data = rhs_mesh_call->getMetaData();
 
@@ -67,7 +67,7 @@ void megamol::mesh::AbstractMeshDataSource::release() {}
 void megamol::mesh::AbstractMeshDataSource::syncMeshAccessCollection(CallMesh* lhs_call, CallMesh* rhs_call) {
     if (lhs_call->getData() == nullptr) {
         // no incoming mesh -> use your own mesh access collection, i.e. share to left
-        lhs_call->setData(m_mesh_access_collection.first, lhs_call->version());
+        lhs_call->setData(m_mesh_access_collection.first, lhs_call->version(), lhs_call->frameID());
     } else {
         // incoming material -> use it, copy material from last used collection if needed
         if (lhs_call->getData() != m_mesh_access_collection.first) {
@@ -86,7 +86,7 @@ void megamol::mesh::AbstractMeshDataSource::syncMeshAccessCollection(CallMesh* l
     }
 
     if (rhs_call != nullptr) {
-        rhs_call->setData(m_mesh_access_collection.first, rhs_call->version());
+        rhs_call->setData(m_mesh_access_collection.first, rhs_call->version(), rhs_call->frameID());
     }
 }
 

--- a/plugins/mesh/src/MeshBakery.cpp
+++ b/plugins/mesh/src/MeshBakery.cpp
@@ -30,11 +30,14 @@ bool megamol::mesh::MeshBakery::getMeshDataCallback(core::Call& caller) {
         return false;
     }
 
+    uint32_t requested_frame_id = lhs_mesh_call->requestedFrameID();
+    uint32_t current_frame_id = 0; // not supporting time at the moment
+
     syncMeshAccessCollection(lhs_mesh_call, rhs_mesh_call);
 
     // if there is a mesh connection to the right, pass on the mesh collection
     if (rhs_mesh_call != NULL) {
-        if (!(*rhs_mesh_call)(0)) {
+        if (!(*rhs_mesh_call)(CallMesh::CallGetData, requested_frame_id)) {
             return false;
         }
         if (rhs_mesh_call->hasUpdate()) {
@@ -110,7 +113,7 @@ bool megamol::mesh::MeshBakery::getMeshDataCallback(core::Call& caller) {
         lhs_mesh_call->setMetaData(meta_data);
     }
 
-    lhs_mesh_call->setData(m_mesh_access_collection.first, m_version);
+    lhs_mesh_call->setData(m_mesh_access_collection.first, m_version, current_frame_id);
 
     return true; 
 }

--- a/plugins/mesh/src/RenderMDIMesh.cpp
+++ b/plugins/mesh/src/RenderMDIMesh.cpp
@@ -144,7 +144,7 @@ bool RenderMDIMesh::GetExtents(core::view::CallRender3DGL& call) {
     meta_data.m_frame_ID = static_cast<int>(cr->Time());
     rtc->setMetaData(meta_data);
 
-	if (!(*rtc)(1))
+	if (!(*rtc)(CallGPURenderTaskData::CallGetMetaData,0))
 		return false;
 
     meta_data = rtc->getMetaData();
@@ -173,7 +173,7 @@ bool RenderMDIMesh::Render(core::view::CallRender3DGL& call) {
 	if (task_call == NULL)
 		return false;
 	
-	if ((!(*task_call)(0)) )
+	if ((!(*task_call)(CallGPURenderTaskData::CallGetData,cr->Time())) )
 		return false;
 	
 	//megamol::core::utility::log::Log::DefaultLog.WriteError("Hey listen!");

--- a/plugins/mesh/src/WavefrontObjLoader.cpp
+++ b/plugins/mesh/src/WavefrontObjLoader.cpp
@@ -29,11 +29,14 @@ bool megamol::mesh::WavefrontObjLoader::getMeshDataCallback(core::Call& caller) 
         return false;
     }
 
+    uint32_t requested_frame_id = lhs_mesh_call->requestedFrameID();
+    uint32_t current_frame_id = 0; // not supporting time at the moment
+
     syncMeshAccessCollection(lhs_mesh_call, rhs_mesh_call);
 
     // if there is a mesh connection to the right, pass on the mesh collection
     if (rhs_mesh_call != NULL) {
-        if (!(*rhs_mesh_call)(0)) {
+        if (!(*rhs_mesh_call)(CallMesh::CallGetData, requested_frame_id)) {
             return false;
         }
         if (rhs_mesh_call->hasUpdate()) {
@@ -193,7 +196,7 @@ bool megamol::mesh::WavefrontObjLoader::getMeshDataCallback(core::Call& caller) 
 
     if (lhs_mesh_call->version() < m_version) {
         lhs_mesh_call->setMetaData(m_meta_data);
-        lhs_mesh_call->setData(m_mesh_access_collection.first, m_version);
+        lhs_mesh_call->setData(m_mesh_access_collection.first, m_version, current_frame_id);
     }
 
     return true;

--- a/plugins/mesh/src/gltf/glTFFileLoader.cpp
+++ b/plugins/mesh/src/gltf/glTFFileLoader.cpp
@@ -65,17 +65,21 @@ bool megamol::mesh::GlTFFileLoader::getMeshDataCallback(core::Call& caller) {
         return false;
     }
 
+    uint32_t requested_frame_id = lhs_mesh_call->requestedFrameID();
+    uint32_t current_frame_id = 0; // not supporting time at the moment
+
     syncMeshAccessCollection(lhs_mesh_call, rhs_mesh_call);
 
     // if there is a mesh connection to the right, pass on the mesh collection
     if (rhs_mesh_call != NULL) {
-        if (!(*rhs_mesh_call)(0)) {
+        if (!(*rhs_mesh_call)(CallMesh::CallGetData, requested_frame_id)) {
             return false;
         }
         if (rhs_mesh_call->hasUpdate()) {
             ++m_version;
             rhs_mesh_call->getData();
         }
+        // TODO: frame id and chaining?
     }
 
     auto has_update = checkAndLoadGltfModel();
@@ -90,7 +94,7 @@ bool megamol::mesh::GlTFFileLoader::getMeshDataCallback(core::Call& caller) {
         m_mesh_access_collection.second.clear();
 
         // set data and version to signal update
-        lhs_mesh_call->setData(m_mesh_access_collection.first, m_version);
+        lhs_mesh_call->setData(m_mesh_access_collection.first, m_version, current_frame_id);
 
         // compute mesh call specific update
         std::array<float, 6> bbox;


### PR DESCRIPTION
Adds a new generic call that explicitly contains a frame ID (a point in time of a simulation/dataset) alongside the version of the data and uses it to communicate availabilty of updates.

## Summary of Changes
- [x] Adds GenericTimedVersionedCall
- [x] MeshCalls that are aware of time now use the timed version of a generic call
- [ ] Update all plugins that use MeshCalls
- [ ] Remove m_frame_ID from Spatial3DMetaData

## Test Instructions
More of a design discussion so far. Take a look, leave a comment.
