### PR TITLE
imgui and cinematic update

### DIFF
--- a/core/src/view/RenderUtils.cpp
+++ b/core/src/view/RenderUtils.cpp
@@ -192,12 +192,6 @@ bool RenderUtils::InitPrimitiveRendering(megamol::core::utility::ShaderSourceFac
     glDisableVertexAttribArray(Buffers::TEXTURE_COORD);
     glDisableVertexAttribArray(Buffers::ATTRIBUTES);
 
-    auto err = glGetError();
-    if (err != GL_NO_ERROR) {
-        megamol::core::utility::log::Log::DefaultLog.WriteError("OpenGL Error: %i [%s, %s, line %d]\n ", err, __FILE__, __FUNCTION__, __LINE__);
-        return false;
-    }
-
     this->init_once = true;
 
     return true;
@@ -383,12 +377,6 @@ void RenderUtils::drawPrimitives(RenderUtils::Primitives primitive, const glm::m
         return;
 
     this->sortPrimitiveQueue(primitive);
-
-    auto err = glGetError();
-    if (err != GL_NO_ERROR) {
-        megamol::core::utility::log::Log::DefaultLog.WriteError("OpenGL Error: %i [%s, %s, line %d]\n ",  err, __FILE__, __FUNCTION__, __LINE__);
-        return;
-    }
 
     auto texture_id = this->queues[primitive].texture_id;
     this->buffers[Buffers::POSITION]->rebuffer(this->queues[primitive].position);

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -335,7 +335,7 @@ function(require_external NAME)
 
       add_external_project(imgui STATIC
         GIT_REPOSITORY https://github.com/ocornut/imgui.git
-        GIT_TAG 455c21df7100a4727dd6e4c8e69249b7de21d24c # docking branch > version "1.79"
+        GIT_TAG 085cff2fe58077a4a0bf1f9e9284814769141801 # docking branch > version "1.82"
         BUILD_BYPRODUCTS "<INSTALL_DIR>/${IMGUI_LIB}"
         PATCH_COMMAND ${CMAKE_COMMAND} -E copy
           "${CMAKE_SOURCE_DIR}/externals/imgui/CMakeLists.txt"
@@ -350,6 +350,7 @@ function(require_external NAME)
     target_include_directories(imgui INTERFACE "${SOURCE_DIR}/backends" "${SOURCE_DIR}/misc/cpp")
 
     set(imgui_files
+      "${SOURCE_DIR}/imgui_tables.cpp"
       "${SOURCE_DIR}/backends/imgui_impl_opengl3.cpp"
       "${SOURCE_DIR}/backends/imgui_impl_opengl3.h"
       "${SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp"

--- a/plugins/cinematic/CMakeLists.txt
+++ b/plugins/cinematic/CMakeLists.txt
@@ -13,8 +13,10 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
   # afterwards list the dependencies.
   set(DEP_LIST "${DEP_LIST};BUILD_${EXPORT_NAME}_PLUGIN BUILD_CORE" CACHE INTERNAL "")
 
-  # Add externals.
+
+   # png
   require_external(libpng)
+   # imgui
   require_external(imgui)
 
   # Collect source files
@@ -26,7 +28,7 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
 
   # Target definition
   add_library(${PROJECT_NAME} STATIC ${public_header_files} ${header_files} ${resource_files} ${source_files} ${shader_files})
-  target_compile_definitions(${PROJECT_NAME} PRIVATE ${EXPORT_NAME}_EXPORTS)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE ${EXPORT_NAME}_EXPORTS IMGUI_IMPL_OPENGL_LOADER_GLAD)
   target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> "include" "src")
   target_link_libraries(${PROJECT_NAME} PRIVATE core libpng imgui)
 

--- a/plugins/cinematic/CMakeLists.txt
+++ b/plugins/cinematic/CMakeLists.txt
@@ -15,7 +15,8 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
 
   # Add externals.
   require_external(libpng)
-  
+  require_external(imgui)
+
   # Collect source files
   file(GLOB_RECURSE public_header_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "include/*.h")
   file(GLOB_RECURSE source_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.cpp")
@@ -27,7 +28,7 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
   add_library(${PROJECT_NAME} STATIC ${public_header_files} ${header_files} ${resource_files} ${source_files} ${shader_files})
   target_compile_definitions(${PROJECT_NAME} PRIVATE ${EXPORT_NAME}_EXPORTS)
   target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> "include" "src")
-  target_link_libraries(${PROJECT_NAME} PRIVATE core libpng)
+  target_link_libraries(${PROJECT_NAME} PRIVATE core libpng imgui)
 
   # Installation rules for generated files
   #install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "include")

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -14,8 +14,9 @@ using namespace megamol::cinematic;
 
 CinematicUtils::CinematicUtils(void) : core::view::RenderUtils()
     , font(megamol::core::utility::SDFFont::PRESET_ROBOTO_SANS)
-    , font_size(20.0f)
     , init_once(false)
+    , menu_font_size(20.0f)
+    , menu_height(20.0f)
     , background_color(0.0f, 0.0f, 0.0f, 0.0f)
     , hotkey_window_setup_once (true) {
 
@@ -139,25 +140,25 @@ const glm::vec4 CinematicUtils::Color(CinematicUtils::Colors c) const {
 
 void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_label, const std::string& middle_label, const std::string& right_label, glm::vec2 dim_vp) {
 
-    const float menu_height = this->font_size;
-
+    this->gui_update();
+   
     // Push menu background quad
-    this->PushQuadPrimitive(glm::vec3(0.0f, dim_vp.y, 0.0f), glm::vec3(0.0f, dim_vp.y - menu_height, 0.0f), 
-        glm::vec3(dim_vp.x, dim_vp.y - menu_height, 0.0f), glm::vec3(dim_vp.x, dim_vp.y, 0.0f), this->Color(CinematicUtils::Colors::MENU));
+    this->PushQuadPrimitive(glm::vec3(0.0f, dim_vp.y, 0.0f), glm::vec3(0.0f, dim_vp.y - this->menu_height, 0.0f), 
+        glm::vec3(dim_vp.x, dim_vp.y - this->menu_height, 0.0f), glm::vec3(dim_vp.x, dim_vp.y, 0.0f), this->Color(CinematicUtils::Colors::MENU));
 
     // Push menu labels
     float vpWhalf = dim_vp.x / 2.0f;
-    float new_font_size = this->font_size;
-    float leftLabelWidth = this->font.LineWidth(this->font_size, left_label.c_str());
-    float midleftLabelWidth = this->font.LineWidth(this->font_size, middle_label.c_str());
-    float rightLabelWidth = this->font.LineWidth(this->font_size, right_label.c_str());
+    float new_font_size = this->menu_font_size;
+    float leftLabelWidth = this->font.LineWidth(this->menu_font_size, left_label.c_str());
+    float midleftLabelWidth = this->font.LineWidth(this->menu_font_size, middle_label.c_str());
+    float rightLabelWidth = this->font.LineWidth(this->menu_font_size, right_label.c_str());
     while (((leftLabelWidth + midleftLabelWidth / 2.0f) > vpWhalf) || ((rightLabelWidth + midleftLabelWidth / 2.0f) > vpWhalf)) {
         new_font_size -= 0.5f;
         leftLabelWidth = this->font.LineWidth(new_font_size, left_label.c_str());
         midleftLabelWidth = this->font.LineWidth(new_font_size, middle_label.c_str());
         rightLabelWidth = this->font.LineWidth(new_font_size, right_label.c_str());
     }
-    float textPosY = dim_vp.y - (menu_height / 2.0f) + (new_font_size / 2.0f);
+    float textPosY = dim_vp.y - menu_height + this->menu_font_size;
     auto current_back_color = this->Color(CinematicUtils::Colors::BACKGROUND);
     this->SetBackgroundColor(this->Color(CinematicUtils::Colors::MENU));
     auto color = this->Color(CinematicUtils::Colors::FONT);
@@ -171,49 +172,64 @@ void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_la
 
 void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp) {
 
+    this->gui_update();
+
     if (inout_show) {
         if (this->hotkey_window_setup_once) {
-            ImGui::SetNextWindowPos(ImVec2(0.0f, this->font_size));
+            ImGui::SetNextWindowPos(ImVec2(0.0f, this->menu_height));
             this->hotkey_window_setup_once = false;
         }
- 
-        auto flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse;
-        if (ImGui::Begin("[Cinematic] HOTKEYS", &inout_show, flags)) {
-            auto header_flags = ImGuiTreeNodeFlags_DefaultOpen;
+        auto window_flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse;
+        auto header_flags = ImGuiTreeNodeFlags_DefaultOpen;
+        auto table_flags = ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableColumnFlags_NoResize;
+        auto column_flags = ImGuiTableColumnFlags_WidthStretch;
 
-            if (ImGui::CollapsingHeader("  GLOBAL", header_flags)) {
-                ImGui::TextUnformatted("[Shift+a] Apply current settings to selected/new keyframe.");
-                ImGui::TextUnformatted("[Shift+d] Delete selected keyframe.");
-                ImGui::TextUnformatted("[Shift+s] Save keyframes to file.");
-                ImGui::TextUnformatted("[Shift+l] Load keyframes from file.");
-                ImGui::TextUnformatted("[Shift+z] Undo keyframe changes.");
-                ImGui::TextUnformatted("[Shift+y] Redo keyframe changes.");
+        if (ImGui::Begin("[Cinematic] HOTKEYS", &inout_show, window_flags)) {
+            if (ImGui::CollapsingHeader("  GLOBAL###cinematic_global_header", header_flags)) {
+                if (ImGui::BeginTable("cinematic_global_hotkeys", 2, table_flags)) {
+                    ImGui::TableSetupColumn("", column_flags);
+                    this->gui_table_row("SHIFT + A", "Apply current settings to selected/new keyframe.");
+                    this->gui_table_row("HIFT + D", "Delete selected keyframe.");
+                    this->gui_table_row("SHIFT + S", "Save keyframes to file.");
+                    this->gui_table_row("SHIFT + L", "Load keyframes from file.");
+                    this->gui_table_row("SHIFT + Z", "Undo keyframe changes (US Keyboard).");
+                    this->gui_table_row("SHIFT + Y", "Redo keyframe changes (US Keyboard).");
+                    ImGui::EndTable();
+                }
             }
-
-            if (ImGui::CollapsingHeader("  TRACKING SHOT", header_flags)) {
-                ImGui::TextUnformatted("[Shift+q] Toggle different manipulators for the selected keyframe.");
-                ImGui::TextUnformatted("[Shift+w] Show manipulators inside/outside of model bounding box.");
-                ImGui::TextUnformatted("[Shift+u] Reset look-at vector of selected keyframe.");
+            if (ImGui::CollapsingHeader("  TRACKING SHOT###cinematic_tracking_header", header_flags)) {
+                if (ImGui::BeginTable("cinematic_tracking_shot_hotkeys", 2, table_flags)) {
+                    ImGui::TableSetupColumn("", column_flags);
+                    this->gui_table_row("SHIFT + Q", "Toggle different manipulators for the selected keyframe.");
+                    this->gui_table_row("SHIFT + W", "Show manipulators inside/outside of model bounding box.");
+                    this->gui_table_row("SHIFT + U", "Reset look-at vector of selected keyframe.");
+                    ImGui::EndTable();
+                }
             }
-
-            if (ImGui::CollapsingHeader("  CINEMATIC", header_flags)) {
-                ImGui::TextUnformatted("[Shift+r] Start/Stop rendering complete animation.");
-                ImGui::TextUnformatted("[Shift+Space] Start/Stop animation preview.");
+            if (ImGui::CollapsingHeader("  CINEMATIC###cinematic_cineamtic_header", header_flags)) {
+                if (ImGui::BeginTable("cinematic_cinematic_hotkeys", 2, table_flags)) {
+                    ImGui::TableSetupColumn("", column_flags);
+                    this->gui_table_row("SHIFT + R", "Start/Stop rendering complete animation.");
+                    this->gui_table_row("SHIFT + SPACE", "Start/Stop animation preview.");
+                    ImGui::EndTable();
+                }
             }
-
-            if (ImGui::CollapsingHeader("  TIMELINE", header_flags)) {
-                ImGui::TextUnformatted("[Shift+Right/Left Arrow] Move selected keyframe on animation time axis.");
-                ImGui::TextUnformatted("[Shift+f] Snap all keyframes to animation frames.");
-                ImGui::TextUnformatted("[Shift+g] Snap all keyframes to simulation frames.");
-                ImGui::TextUnformatted("[Shift+t] Linearize simulation time between two keyframes.");
-                ImGui::TextUnformatted("[Shift+p] Reset shifted and scaled time axes.");
-                ImGui::TextUnformatted("[Left Mouse Button] Select keyframe.");
-                ImGui::TextUnformatted("[Middle Mouse Button] Axes scaling in mouse direction.");
-                ImGui::TextUnformatted("[Right Mouse Button] Drag & drop keyframe / pan axes.");
-                // ImGui::TextUnformatted("[Shift+v] Set same velocity between all keyframes (Experimental)."); ///XXX
-                // Calcualation is not correct yet ...
+            if (ImGui::CollapsingHeader("  TIMELINE###cinematic_timeline_header", header_flags)) {
+                if (ImGui::BeginTable("cinematic_timeline_hotkeys", 2, table_flags)) {
+                    ImGui::TableSetupColumn("", column_flags);
+                    this->gui_table_row("SHIFT + RIGHT/LEFT Arrow", "Move selected keyframe on animation time axis.");
+                    this->gui_table_row("SHIFT + F", "Snap all keyframes to animation frames.");
+                    this->gui_table_row("SHIFT + G", "Snap all keyframes to simulation frames.");
+                    this->gui_table_row("SHIFT + T", "Linearize simulation time between two keyframes.");
+                    this->gui_table_row("SHIFT + P", "Reset shifted and scaled time axes.");
+                    this->gui_table_row("LEFT Mouse Button", "Select keyframe.");
+                    this->gui_table_row("MIDDLE Mouse Button", "Axes scaling in mouse direction.");
+                    this->gui_table_row("RIGHT Mouse Button", "Drag & drop keyframe / pan axes.");
+                    /// XXX Calcualation is not correct yet ...
+                    //this->gui_table_row("SHIFT + v","Set same velocity between all keyframes (Experimental).");
+                    ImGui::EndTable();
+                }
             }
-       
             ImGui::End();
         }
     }
@@ -222,8 +238,9 @@ void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm:
 
 void CinematicUtils::Push2DText(const glm::mat4& ortho, const std::string& text, float x, float y) {
 
+    this->gui_update();
     auto color = this->Color(CinematicUtils::Colors::FONT);
-    this->font.DrawString(ortho, glm::value_ptr(color), x, y, this->font_size, false, text.c_str(), megamol::core::utility::SDFFont::ALIGN_LEFT_TOP);
+    this->font.DrawString(ortho, glm::value_ptr(color), x, y, this->menu_font_size, false, text.c_str(), megamol::core::utility::SDFFont::ALIGN_LEFT_TOP);
 }
 
 
@@ -245,13 +262,15 @@ void CinematicUtils::DrawAll(const glm::mat4&mvp, glm::vec2 dim_vp) {
 
 float CinematicUtils::GetTextLineHeight(void) {
 
-    return this->font.LineHeight(this->font_size);
+    this->gui_update();
+    return this->font.LineHeight(this->menu_font_size);
 }
 
 
 float CinematicUtils::GetTextLineWidth(const std::string& text_line) {
 
-    return this->font.LineWidth(this->font_size, text_line.c_str());
+    this->gui_update();
+    return this->font.LineWidth(this->menu_font_size, text_line.c_str());
 }
 
 
@@ -264,4 +283,21 @@ void CinematicUtils::SetTextRotation(float a, float x, float y, float z) {
 const float CinematicUtils::lightness(glm::vec4 background) const {
 
     return ((glm::max(background[0], glm::max(background[1], background[2])) + glm::min(background[0], glm::min(background[1], background[2]))) / 2.0f);
+}
+
+
+void megamol::cinematic::CinematicUtils::gui_update(void) {
+
+    this->menu_font_size   = ImGui::GetFontSize() * 1.5f;
+    this->menu_height = this->menu_font_size; // +ImGui::GetFrameHeightWithSpacing();
+}
+
+
+void megamol::cinematic::CinematicUtils::gui_table_row(const char* left, const char* right) {
+
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
+    ImGui::TextUnformatted(left);
+    ImGui::TableNextColumn();
+    ImGui::TextUnformatted(right);
 }

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -192,7 +192,7 @@ void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm:
                 if (ImGui::BeginTable("cinematic_global_hotkeys", 2, table_flags)) {
                     ImGui::TableSetupColumn("", column_flags);
                     this->gui_table_row("SHIFT + A", "Apply current settings to selected/new keyframe.");
-                    this->gui_table_row("HIFT + D", "Delete selected keyframe.");
+                    this->gui_table_row("SHIFT + D", "Delete selected keyframe.");
                     this->gui_table_row("SHIFT + S", "Save keyframes to file.");
                     this->gui_table_row("SHIFT + L", "Load keyframes from file.");
                     this->gui_table_row("SHIFT + Z", "Undo keyframe changes (US Keyboard).");

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -168,7 +168,7 @@ void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_la
 }
 
 
-void CinematicUtils::PushHotkeyList(const glm::mat4& ortho, glm::vec2 dim_vp) {
+void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp) {
 
     std::string hotkey_str = "";
     hotkey_str += "-----[ GLOBAL ]-----\n";
@@ -196,21 +196,15 @@ void CinematicUtils::PushHotkeyList(const glm::mat4& ortho, glm::vec2 dim_vp) {
     hotkey_str += "[Middle Mouse Button] Axes scaling in mouse direction. \n";
     hotkey_str += "[Right Mouse Button] Drag & drop keyframe / pan axes. \n";
 
-    const float border = 10.0f;
-    size_t line_count = std::count(hotkey_str.begin(), hotkey_str.end(), '\n');
-    float hotkey_font_size = (dim_vp.y - 2.0f * this->font_size - 2.0f*border) / static_cast<float>(line_count);
-    hotkey_font_size = (hotkey_font_size > this->font_size) ? (this->font_size) : (hotkey_font_size);
-    float line_height = this->font.LineHeight(hotkey_font_size);
-    float line_width = this->font.LineWidth(hotkey_font_size, hotkey_str.c_str());
-    float quad_width = line_width + 2.0f * border;
-    float quad_height = line_height * line_count + 2.0f * border;
+    if (inout_show) {
+        auto flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse;
+        if (ImGui::Begin("Cinematic", &inout_show, flags)) {
 
-    // Push background quad
-    this->PushQuadPrimitive(glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, quad_height, 0.0f), glm::vec3(quad_width, quad_height, 0.0f), glm::vec3(quad_width, 0.0f, 0.0f), this->Color(CinematicUtils::Colors::MENU));
+            ImGui::TextUnformatted(hotkey_str.c_str());
 
-    // Push hotkey text
-    auto color = this->Color(CinematicUtils::Colors::FONT);
-    this->font.DrawString(ortho, glm::value_ptr(color), border, quad_height - border, hotkey_font_size, false, hotkey_str.c_str(), megamol::core::utility::SDFFont::ALIGN_LEFT_TOP);
+            ImGui::End();
+        }
+    }
 }
 
 

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -52,12 +52,6 @@ bool CinematicUtils::Initialise(megamol::core::CoreInstance* core_instance) {
         return false;
     }
 
-    auto err = glGetError();
-    if (err != GL_NO_ERROR) {
-        megamol::core::utility::log::Log::DefaultLog.WriteError("OpenGL Error: %i [%s, %s, line %d]\n ", err, __FILE__, __FUNCTION__, __LINE__);
-        return false;
-    }
-
     this->init_once = true;
 
     return true;

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -16,7 +16,8 @@ CinematicUtils::CinematicUtils(void) : core::view::RenderUtils()
     , font(megamol::core::utility::SDFFont::PRESET_ROBOTO_SANS)
     , font_size(20.0f)
     , init_once(false)
-    , background_color(0.0f, 0.0f, 0.0f, 0.0f) {
+    , background_color(0.0f, 0.0f, 0.0f, 0.0f)
+    , hotkey_window_setup_once (true) {
 
 }
 
@@ -170,38 +171,49 @@ void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_la
 
 void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp) {
 
-    std::string hotkey_str = "";
-    hotkey_str += "-----[ GLOBAL ]-----\n";
-    hotkey_str += "[Shift+a] Apply current settings to selected/new keyframe. \n";
-    hotkey_str += "[Shift+d] Delete selected keyframe. \n";
-    hotkey_str += "[Shift+s] Save keyframes to file. \n";
-    hotkey_str += "[Shift+l] Load keyframes from file. \n";
-    hotkey_str += "[Shift+z] Undo keyframe changes. \n";
-    hotkey_str += "[Shift+y] Redo keyframe changes. \n";
-    hotkey_str += "-----[ TRACKING SHOT ]----- \n";
-    hotkey_str += "[Shift+q] Toggle different manipulators for the selected keyframe. \n";
-    hotkey_str += "[Shift+w] Show manipulators inside/outside of model bounding box. \n";
-    hotkey_str += "[Shift+u] Reset look-at vector of selected keyframe. \n";
-    hotkey_str += "-----[ CINEMATIC ]----- \n";
-    hotkey_str += "[Shift+r] Start/Stop rendering complete animation. \n";
-    hotkey_str += "[Shift+Space] Start/Stop animation preview. \n";
-    hotkey_str += "-----[ TIMELINE ]----- \n";
-    hotkey_str += "[Shift+Right/Left Arrow] Move selected keyframe on animation time axis. \n";
-    hotkey_str += "[Shift+f] Snap all keyframes to animation frames. \n";
-    hotkey_str += "[Shift+g] Snap all keyframes to simulation frames. \n";
-    hotkey_str += "[Shift+t] Linearize simulation time between two keyframes. \n";
-    //hotkey_str += "[Shift+v] Set same velocity between all keyframes (Experimental).\n"; ///XXX Calcualation is not correct yet ...
-    hotkey_str += "[Shift+p] Reset shifted and scaled time axes. \n";
-    hotkey_str += "[Left Mouse Button] Select keyframe. \n";
-    hotkey_str += "[Middle Mouse Button] Axes scaling in mouse direction. \n";
-    hotkey_str += "[Right Mouse Button] Drag & drop keyframe / pan axes. \n";
-
     if (inout_show) {
+        if (this->hotkey_window_setup_once) {
+            ImGui::SetNextWindowPos(ImVec2(0.0f, this->font_size));
+            this->hotkey_window_setup_once = false;
+        }
+ 
         auto flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse;
-        if (ImGui::Begin("Cinematic", &inout_show, flags)) {
+        if (ImGui::Begin("[Cinematic] HOTKEYS", &inout_show, flags)) {
+            auto header_flags = ImGuiTreeNodeFlags_DefaultOpen;
 
-            ImGui::TextUnformatted(hotkey_str.c_str());
+            if (ImGui::CollapsingHeader("  GLOBAL", header_flags)) {
+                ImGui::TextUnformatted("[Shift+a] Apply current settings to selected/new keyframe.");
+                ImGui::TextUnformatted("[Shift+d] Delete selected keyframe.");
+                ImGui::TextUnformatted("[Shift+s] Save keyframes to file.");
+                ImGui::TextUnformatted("[Shift+l] Load keyframes from file.");
+                ImGui::TextUnformatted("[Shift+z] Undo keyframe changes.");
+                ImGui::TextUnformatted("[Shift+y] Redo keyframe changes.");
+            }
 
+            if (ImGui::CollapsingHeader("  TRACKING SHOT", header_flags)) {
+                ImGui::TextUnformatted("[Shift+q] Toggle different manipulators for the selected keyframe.");
+                ImGui::TextUnformatted("[Shift+w] Show manipulators inside/outside of model bounding box.");
+                ImGui::TextUnformatted("[Shift+u] Reset look-at vector of selected keyframe.");
+            }
+
+            if (ImGui::CollapsingHeader("  CINEMATIC", header_flags)) {
+                ImGui::TextUnformatted("[Shift+r] Start/Stop rendering complete animation.");
+                ImGui::TextUnformatted("[Shift+Space] Start/Stop animation preview.");
+            }
+
+            if (ImGui::CollapsingHeader("  TIMELINE", header_flags)) {
+                ImGui::TextUnformatted("[Shift+Right/Left Arrow] Move selected keyframe on animation time axis.");
+                ImGui::TextUnformatted("[Shift+f] Snap all keyframes to animation frames.");
+                ImGui::TextUnformatted("[Shift+g] Snap all keyframes to simulation frames.");
+                ImGui::TextUnformatted("[Shift+t] Linearize simulation time between two keyframes.");
+                ImGui::TextUnformatted("[Shift+p] Reset shifted and scaled time axes.");
+                ImGui::TextUnformatted("[Left Mouse Button] Select keyframe.");
+                ImGui::TextUnformatted("[Middle Mouse Button] Axes scaling in mouse direction.");
+                ImGui::TextUnformatted("[Right Mouse Button] Drag & drop keyframe / pan axes.");
+                // ImGui::TextUnformatted("[Shift+v] Set same velocity between all keyframes (Experimental)."); ///XXX
+                // Calcualation is not correct yet ...
+            }
+       
             ImGui::End();
         }
     }

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -172,6 +172,8 @@ void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_la
 
 void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp) {
 
+    this->gui_update();
+
     bool valid_imgui_scope =
         ((ImGui::GetCurrentContext() != nullptr) ? (ImGui::GetCurrentContext()->WithinFrameScope) : (false));
 

--- a/plugins/cinematic/src/CinematicUtils.cpp
+++ b/plugins/cinematic/src/CinematicUtils.cpp
@@ -172,9 +172,10 @@ void CinematicUtils::PushMenu(const glm::mat4& ortho, const std::string& left_la
 
 void CinematicUtils::HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp) {
 
-    this->gui_update();
+    bool valid_imgui_scope =
+        ((ImGui::GetCurrentContext() != nullptr) ? (ImGui::GetCurrentContext()->WithinFrameScope) : (false));
 
-    if (inout_show) {
+    if (inout_show && valid_imgui_scope) {
         if (this->hotkey_window_setup_once) {
             ImGui::SetNextWindowPos(ImVec2(0.0f, this->menu_height));
             this->hotkey_window_setup_once = false;

--- a/plugins/cinematic/src/CinematicUtils.h
+++ b/plugins/cinematic/src/CinematicUtils.h
@@ -93,15 +93,21 @@ private:
     // VARIABLES ------------------------------------------------------- //
 
     megamol::core::utility::SDFFont font;
-    const float font_size;
-    bool init_once;
-    glm::vec4 background_color;
 
+    bool init_once;
+
+    float menu_font_size;
+    float menu_height;
+    glm::vec4 background_color;
     bool hotkey_window_setup_once;
 
     // FUNCTIONS ------------------------------------------------------- //
 
     const float lightness(glm::vec4 background) const;
+
+    void gui_update(void);
+
+    void gui_table_row(const char* left, const char* right);
 };
 
 } /* end namespace cinematic */

--- a/plugins/cinematic/src/CinematicUtils.h
+++ b/plugins/cinematic/src/CinematicUtils.h
@@ -11,6 +11,8 @@
 
 #include "mmcore/view/RenderUtils.h"
 
+#include "imgui.h"
+
 
 // #### Utility minimal camera state ################################### //
 
@@ -73,7 +75,7 @@ public:
 
     void PushMenu(const glm::mat4& ortho, const std::string& left_label, const std::string& middle_label, const std::string& right_label, glm::vec2 dim_vp);
 
-    void PushHotkeyList(const glm::mat4& ortho, glm::vec2 dim_vp);
+    void HotkeyWindow(bool& inout_show, const glm::mat4& ortho, glm::vec2 dim_vp);
 
     void Push2DText(const glm::mat4& ortho, const std::string& text, float x, float y);
 

--- a/plugins/cinematic/src/CinematicUtils.h
+++ b/plugins/cinematic/src/CinematicUtils.h
@@ -97,6 +97,8 @@ private:
     bool init_once;
     glm::vec4 background_color;
 
+    bool hotkey_window_setup_once;
+
     // FUNCTIONS ------------------------------------------------------- //
 
     const float lightness(glm::vec4 background) const;

--- a/plugins/cinematic/src/CinematicUtils.h
+++ b/plugins/cinematic/src/CinematicUtils.h
@@ -12,6 +12,7 @@
 #include "mmcore/view/RenderUtils.h"
 
 #include "imgui.h"
+#include "imgui_internal.h"
 
 
 // #### Utility minimal camera state ################################### //

--- a/plugins/cinematic/src/CinematicView.cpp
+++ b/plugins/cinematic/src/CinematicView.cpp
@@ -436,13 +436,6 @@ void CinematicView::Render(const mmcRenderViewContext& context, core::Call* call
 
     Base::Render(context, call);
 
-    auto err = glGetError();
-    if (err != GL_NO_ERROR) {
-        megamol::core::utility::log::Log::DefaultLog.WriteError(
-            "OpenGL Error: %i [%s, %s, line %d]\n ", err, __FILE__, __FUNCTION__, __LINE__);
-        return;
-    }
-
     // Write frame to file
     if (this->rendering) {
         // Check if fbo in cr3d was reset by renderer to indicate that no new frame is available (e.g. see
@@ -498,11 +491,6 @@ void CinematicView::Render(const mmcRenderViewContext& context, core::Call* call
     // Draw 2D ----------------------------------------------------------------
     this->utils.DrawAll(ortho, glm::vec2(vp_fw, vp_fh));
 
-    err = glGetError();
-    if (err != GL_NO_ERROR) {
-        megamol::core::utility::log::Log::DefaultLog.WriteError(
-            "OpenGL Error: %i [%s, %s, line %d]\n ", err, __FILE__, __FUNCTION__, __LINE__);
-    }
 }
 
 

--- a/plugins/cinematic/src/TrackingShotRenderer.cpp
+++ b/plugins/cinematic/src/TrackingShotRenderer.cpp
@@ -210,17 +210,14 @@ bool TrackingShotRenderer::Render(megamol::core::view::CallRender3DGL& call) {
     this->utils.DrawAll(mvp, viewport);
 
     // Push hotkey list ------------------------------------------------------
-    // Draw help text 
-    if (this->showHelpText) {
-        this->utils.PushHotkeyList(ortho, viewport);
-    }
+    this->utils.HotkeyWindow(this->showHelpText, ortho, viewport);
 
     // Push menu --------------------------------------------------------------
     std::string leftLabel = " TRACKING SHOT ";
     std::string midLabel = "";
-    std::string rightLabel = " [Shift+h] Show Help Text ";
+    std::string rightLabel = " [Shift+h] Show Hotkeys ";
     if (this->showHelpText) {
-        rightLabel = " [Shift+h] Hide Help Text ";
+        rightLabel = " [Shift+h] Hide Hotkeys ";
     }
     this->utils.PushMenu(ortho, leftLabel, midLabel, rightLabel, viewport);
 

--- a/plugins/gui/CMakeLists.txt
+++ b/plugins/gui/CMakeLists.txt
@@ -40,7 +40,7 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
   target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     "include" "src"
-    "${SOURCE_DIR}/examples/" "${SOURCE_DIR}/misc/cpp/")
+    "${SOURCE_DIR}/examples/" "${SOURCE_DIR}/misc/cpp/") # imgui
   target_link_libraries(${PROJECT_NAME} PRIVATE vislib core glad abstract_frontend_service PUBLIC imgui imguizmoquat)
 
   # Installation rules for generated files
@@ -73,7 +73,6 @@ if(BUILD_${EXPORT_NAME}_PLUGIN)
     string(REGEX REPLACE "^include\\\\mmcore" "Public Header Files" GROUP_NAME ${GROUP_NAME})
     source_group(${GROUP_NAME} FILES ${FILE_NAME})
   endforeach()
-  source_group("Version" FILES ${version_files})
   source_group("ImGui Files" FILES ${imgui_files})
   source_group("Resources" FILES ${resource_files})
 

--- a/plugins/gui/src/GUIWindows.cpp
+++ b/plugins/gui/src/GUIWindows.cpp
@@ -330,6 +330,10 @@ bool GUIWindows::PreDraw(glm::vec2 framebuffer_size, glm::vec2 window_size, doub
         default:
             break;
         }
+
+        // Set tesselation error: Smaller value => better tesselation of circles and round corners.
+        style.CircleTessellationMaxError = 0.3f;
+
         this->state.style_changed = false;
     }
 

--- a/plugins/gui/src/graph/Call.cpp
+++ b/plugins/gui/src/graph/Call.cpp
@@ -202,7 +202,7 @@ void megamol::gui::Call::Draw(megamol::gui::PresentPhase phase, megamol::gui::Gr
                         draw_list->AddLine(
                             caller_pos, callee_pos, color_curve, GUI_LINE_THICKNESS * state.canvas.zooming);
                     } else {
-                        draw_list->AddBezierCurve(caller_pos,
+                        draw_list->AddBezierCubic(caller_pos,
                             caller_pos + ImVec2((50.0f * megamol::gui::gui_scaling.Get()), 0.0f),
                             callee_pos + ImVec2((-50.0f * megamol::gui::gui_scaling.Get()), 0.0f), callee_pos,
                             color_curve, GUI_LINE_THICKNESS * state.canvas.zooming);

--- a/plugins/gui/src/graph/CallSlot.cpp
+++ b/plugins/gui/src/graph/CallSlot.cpp
@@ -476,9 +476,8 @@ void megamol::gui::CallSlot::Draw(PresentPhase phase, megamol::gui::GraphItemsSt
                     tmpcol = ImVec4(tmpcol.x * brightness, tmpcol.y * brightness, tmpcol.z * brightness, tmpcol.w);
                     slot_background_color = ImGui::ColorConvertFloat4ToU32(tmpcol);
                 }
-                const float segment_numer = (20.0f * megamol::gui::gui_scaling.Get());
-                draw_list->AddCircleFilled(slot_position, radius, slot_background_color, segment_numer);
-                draw_list->AddCircle(slot_position, radius, slot_border_color, segment_numer);
+                draw_list->AddCircleFilled(slot_position, radius, slot_background_color);
+                draw_list->AddCircle(slot_position, radius, slot_border_color);
 
                 // Text
                 if (state.interact.callslot_show_label) {

--- a/plugins/gui/src/graph/Graph.cpp
+++ b/plugins/gui/src/graph/Graph.cpp
@@ -2483,7 +2483,7 @@ void megamol::gui::Graph::draw_canvas_dragged_call(void) {
                         p2 = tmp;
                     }
                     if (glm::length(glm::vec2(p1.x, p1.y) - glm::vec2(p2.x, p2.y)) > GUI_SLOT_RADIUS) {
-                        draw_list->AddBezierCurve(p1, p1 + ImVec2(+50, 0), p2 + ImVec2(-50, 0), p2, COLOR_CALL_CURVE,
+                        draw_list->AddBezierCubic(p1, p1 + ImVec2(+50, 0), p2 + ImVec2(-50, 0), p2, COLOR_CALL_CURVE,
                             GUI_LINE_THICKNESS * this->gui_graph_state.canvas.zooming);
                     }
                 }
@@ -2518,11 +2518,11 @@ void megamol::gui::Graph::draw_canvas_multiselection(void) {
         const ImU32 COLOR_MULTISELECT_BORDER = ImGui::ColorConvertFloat4ToU32(style.Colors[ImGuiCol_Border]);
 
         draw_list->AddRectFilled(this->gui_multiselect_start_pos, this->gui_multiselect_end_pos,
-            COLOR_MULTISELECT_BACKGROUND, GUI_RECT_CORNER_RADIUS, ImDrawCornerFlags_All);
+            COLOR_MULTISELECT_BACKGROUND, GUI_RECT_CORNER_RADIUS, ImDrawFlags_RoundCornersAll);
 
         float border = (1.0f * megamol::gui::gui_scaling.Get());
         draw_list->AddRect(this->gui_multiselect_start_pos, this->gui_multiselect_end_pos, COLOR_MULTISELECT_BORDER,
-            GUI_RECT_CORNER_RADIUS, ImDrawCornerFlags_All, border);
+            GUI_RECT_CORNER_RADIUS, ImDrawFlags_RoundCornersAll, border);
     } else if (this->gui_multiselect_done && ImGui::IsWindowHovered() && ImGui::IsMouseReleased(0)) {
         ImVec2 outer_rect_min = ImVec2(std::min(this->gui_multiselect_start_pos.x, this->gui_multiselect_end_pos.x),
             std::min(this->gui_multiselect_start_pos.y, this->gui_multiselect_end_pos.y));

--- a/plugins/gui/src/graph/Group.cpp
+++ b/plugins/gui/src/graph/Group.cpp
@@ -582,7 +582,7 @@ void megamol::gui::Group::Draw(megamol::gui::PresentPhase phase, GraphItemsState
             }
             auto header_color = (this->gui_selected) ? (GUI_COLOR_GROUP_HEADER_HIGHLIGHT) : (GUI_COLOR_GROUP_HEADER);
             draw_list->AddRectFilled(group_rect_min, header_rect_max, ImGui::ColorConvertFloat4ToU32(header_color),
-                GUI_RECT_CORNER_RADIUS, (ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_TopRight));
+                GUI_RECT_CORNER_RADIUS, (ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight));
             draw_list->AddText(text_pos_left_upper, COLOR_TEXT, this->name.c_str());
         }
 

--- a/plugins/gui/src/graph/InterfaceSlot.cpp
+++ b/plugins/gui/src/graph/InterfaceSlot.cpp
@@ -426,9 +426,8 @@ void megamol::gui::InterfaceSlot::Draw(PresentPhase phase, megamol::gui::GraphIt
             }
 
             // Draw Slot
-            const float segment_numer = (20.0f * megamol::gui::gui_scaling.Get());
-            draw_list->AddCircleFilled(actual_position, radius, slot_color, segment_numer);
-            draw_list->AddCircle(actual_position, radius, COLOR_INTERFACE_BORDER, segment_numer);
+            draw_list->AddCircleFilled(actual_position, radius, slot_color);
+            draw_list->AddCircle(actual_position, radius, COLOR_INTERFACE_BORDER);
 
             // Draw Curves
             if (!this->gui_group_collapsed_view) {

--- a/plugins/gui/src/graph/Module.cpp
+++ b/plugins/gui/src/graph/Module.cpp
@@ -413,7 +413,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                     ImU32 module_bg_color =
                         (this->gui_selected) ? (COLOR_MODULE_HIGHTLIGHT) : (COLOR_MODULE_BACKGROUND);
                     draw_list->AddRectFilled(module_rect_min, module_rect_max, module_bg_color, GUI_RECT_CORNER_RADIUS,
-                        ImDrawCornerFlags_All);
+                        ImDrawFlags_RoundCornersAll);
 
                     // Draw Text and Option Buttons
                     float text_width;
@@ -430,7 +430,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                         ImVec2 header_rect_max =
                             module_rect_min + ImVec2(module_size.x, ImGui::GetTextLineHeightWithSpacing());
                         draw_list->AddRectFilled(module_rect_min, header_rect_max, header_color, GUI_RECT_CORNER_RADIUS,
-                            (ImDrawCornerFlags_TopLeft | ImDrawCornerFlags_TopRight));
+                            (ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight));
 
                         text_width = ImGui::CalcTextSize(this->class_name.c_str()).x;
                         text_pos_left_upper = ImVec2(
@@ -516,7 +516,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                     float border = ((!this->graph_entry_name.empty()) ? (4.0f) : (1.0f)) *
                                    megamol::gui::gui_scaling.Get() * state.canvas.zooming;
                     draw_list->AddRect(module_rect_min, module_rect_max, COLOR_MODULE_BORDER, GUI_RECT_CORNER_RADIUS,
-                        ImDrawCornerFlags_All, border);
+                        ImDrawFlags_RoundCornersAll, border);
                 }
             }
 

--- a/plugins/gui/src/graph/Parameter.cpp
+++ b/plugins/gui/src/graph/Parameter.cpp
@@ -1349,7 +1349,8 @@ bool megamol::gui::Parameter::widget_bool(
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        retval = ImGui::Checkbox(label.c_str(), &value);
+        retval = megamol::gui::ButtonWidgets::ToggleButton(label, value);
+        /// retval = ImGui::Checkbox(label.c_str(), &value);
     }
     return retval;
 }

--- a/plugins/gui/src/widgets/ButtonWidgets.cpp
+++ b/plugins/gui/src/widgets/ButtonWidgets.cpp
@@ -250,3 +250,49 @@ bool megamol::gui::ButtonWidgets::LuaButton(const std::string& id, const megamol
 
     return retval;
 }
+
+
+bool megamol::gui::ButtonWidgets::ToggleButton(const std::string& id, bool& inout_bool) {
+
+    bool retval = false;
+
+    ImVec4* colors = ImGui::GetStyle().Colors;
+    ImVec2 p = ImGui::GetCursorScreenPos();
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+
+    float height = ImGui::GetFrameHeight();
+    float width = height * 1.55f;
+    float radius = height * 0.50f;
+
+    std::string button_id = "inv_button_" + id;
+    ImGui::InvisibleButton(button_id.c_str(), ImVec2(width, height));
+    if (ImGui::IsItemClicked()) {
+        inout_bool = !inout_bool;
+        retval = true;
+    }
+    ImGuiContext& gg = *GImGui;
+    float ANIM_SPEED = 0.085f;
+    if (gg.LastActiveId == gg.CurrentWindow->GetID(id.c_str())) { // && g.LastActiveIdTimer < ANIM_SPEED)
+        float t_anim = ImSaturate(gg.LastActiveIdTimer / ANIM_SPEED);
+    }
+
+    ImGuiStyle& style = ImGui::GetStyle();
+
+    if (ImGui::IsItemHovered()) {
+        draw_list->AddRectFilled(p, ImVec2(p.x + width, p.y + height),
+            ImGui::GetColorU32(inout_bool ? colors[ImGuiCol_ButtonActive] : ImVec4(0.78f, 0.78f, 0.78f, 1.0f)),
+            height * 0.5f, ImDrawFlags_RoundCornersAll);
+    } else {
+        draw_list->AddRectFilled(p, ImVec2(p.x + width, p.y + height),
+            ImGui::GetColorU32(inout_bool ? colors[ImGuiCol_Button] : ImVec4(0.85f, 0.85f, 0.85f, 1.0f)), height * 0.5f,
+            ImDrawFlags_RoundCornersAll);
+    }
+    draw_list->AddCircleFilled(ImVec2(p.x + radius + (inout_bool ? 1 : 0) * (width - radius * 2.0f), p.y + radius),
+        radius - 1.5f, IM_COL32(255, 255, 255, 255), 0);
+
+    ImGui::SameLine();
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(id.c_str());
+
+    return retval;
+}

--- a/plugins/gui/src/widgets/ButtonWidgets.cpp
+++ b/plugins/gui/src/widgets/ButtonWidgets.cpp
@@ -50,7 +50,7 @@ bool megamol::gui::ButtonWidgets::OptionButton(const std::string& id, const std:
     if (dirty) {
         color_front = ImGui::ColorConvertFloat4ToU32(GUI_COLOR_BUTTON_MODIFIED);
     }
-    draw_list->AddCircleFilled(center, thickness, color_front, 12);
+    draw_list->AddCircleFilled(center, thickness, color_front);
     draw_list->AddCircle(center, 2.0f * thickness, color_front, 12, (thickness / 2.0f));
 
     ImVec2 rect = ImVec2(button_size, button_size);
@@ -149,7 +149,7 @@ bool megamol::gui::ButtonWidgets::KnobButton(
         retval = true;
     }
     draw_list->AddLine(widget_center, widget_center + knob_pos, knob_line_color, thickness);
-    draw_list->AddCircleFilled(widget_center + knob_pos, knob_radius, knob_color, 12);
+    draw_list->AddCircleFilled(widget_center + knob_pos, knob_radius, knob_color);
 
     ImGui::EndChild();
     ImGui::PopStyleColor();
@@ -288,7 +288,7 @@ bool megamol::gui::ButtonWidgets::ToggleButton(const std::string& id, bool& inou
             ImDrawFlags_RoundCornersAll);
     }
     draw_list->AddCircleFilled(ImVec2(p.x + radius + (inout_bool ? 1 : 0) * (width - radius * 2.0f), p.y + radius),
-        radius - 1.5f, IM_COL32(255, 255, 255, 255), 0);
+        radius - 1.5f, IM_COL32(255, 255, 255, 255));
 
     ImGui::SameLine();
     ImGui::AlignTextToFramePadding();

--- a/plugins/gui/src/widgets/ButtonWidgets.h
+++ b/plugins/gui/src/widgets/ButtonWidgets.h
@@ -29,11 +29,16 @@ namespace gui {
         static bool KnobButton(const std::string& id, float size, float& inout_value, float minval, float maxval);
 
         /** Extended mode button. */
+        // OptionButton with menu for 'Basic' and 'Expert' option
         static bool ExtendedModeButton(const std::string& id, bool& inout_extended_mode);
 
         /** Lua parameter command copy button. */
         static bool LuaButton(const std::string& id, const megamol::gui::Parameter& param,
             const std::string& param_fullname, const std::string& module_fullname);
+
+        /** Toggle Button */
+        // https://github.com/ocornut/imgui/issues/1537#issuecomment-780262461
+        static bool ToggleButton(const std::string& id, bool& inout_bool);
 
     private:
         ButtonWidgets(void) = default;

--- a/plugins/gui/src/widgets/DefaultStyle.h
+++ b/plugins/gui/src/widgets/DefaultStyle.h
@@ -57,7 +57,7 @@ inline void DefaultStyle(void) {
     style.AntiAliasedLinesUseTex = true;
     style.AntiAliasedFill = true;
     style.CurveTessellationTol = 1.25f;
-    style.CircleSegmentMaxError = 1.60f;
+    style.CircleTessellationMaxError = 1.10f;
 
     // Colors
     ImGui::StyleColorsDark();

--- a/plugins/gui/src/widgets/DefaultStyle.h
+++ b/plugins/gui/src/widgets/DefaultStyle.h
@@ -57,7 +57,6 @@ inline void DefaultStyle(void) {
     style.AntiAliasedLinesUseTex = true;
     style.AntiAliasedFill = true;
     style.CurveTessellationTol = 1.25f;
-    style.CircleTessellationMaxError = 1.10f;
 
     // Colors
     ImGui::StyleColorsDark();

--- a/plugins/gui/src/widgets/TransferFunctionEditor.cpp
+++ b/plugins/gui/src/widgets/TransferFunctionEditor.cpp
@@ -835,7 +835,7 @@ void TransferFunctionEditor::drawFunctionPlot(const ImVec2& size) {
 
             // Draw node point
             drawList->AddCircle(point, pointAndBorderRadius, pointBorderColor, circle_subdiv, point_border_width);
-            drawList->AddCircleFilled(point, point_radius, pointColor, 12);
+            drawList->AddCircleFilled(point, point_radius, pointColor);
         }
     }
     drawList->PopClipRect();


### PR DESCRIPTION
- Updated to ImGui version 1.82 (docking branch).
- Replaced manually drawn cinematic hotkey list with imgui window.

## Summary of Changes
- Updated CMakeExternal für new ImGui version (required to replaced some renamed functions and flags...)
- Added ImGui dependency to cinematic plugin.
- Replaced manually drawn cinematic hotkey list with imgui window using tables.
-  Removed explicit number of segments for circles and round corners, using global tesselation error instead (style.CircleTessellationMaxError).
- Added toggle button for bool parameters.

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
Rebuild EXTERNAL for ImGui and ImGuiZMO.quat ...
