### PR TITLE
sphere outline in pixels

### DIFF
--- a/core/Shaders/commondefines.glsl
+++ b/core/Shaders/commondefines.glsl
@@ -5,6 +5,12 @@
 #define SMALL_SPRITE_LIGHTING
 //#define CALC_CAM_SYS
 
+//#define HALO
+#ifdef HALO
+    #define HALO_RAD 3.0
+#endif // HALO
+
+//#define DEBUG
 #ifdef DEBUG
     #undef CLIP
     #define RETICLE

--- a/plugins/mmstd_moldyn/Shaders/sphere/fragment_attributes.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/fragment_attributes.glsl
@@ -6,10 +6,6 @@ FLACH in float squarRad;
 FLACH in float rad;
 FLACH in vec4 vertColor;
 
-#ifdef RETICLE
-FLACH in vec2 centerFragment;
-#endif // RETICLE
-
 #ifdef BACKSIDE_ENABLED
 uniform float hitsideFlag;
 #endif // BACKSIDE_ENABLED
@@ -26,15 +22,17 @@ uniform vec4 viewAttr;
 uniform mat4 MVPinv;
 uniform mat4 MVPtransp;
 
-// Only used by SPLAT render mode:
+// SPLAT
 uniform float alphaScaling;
 FLACH in float effectiveDiameter;
 
-// Only used by AMBIENT OCLUSION render mode:
+// AMBIENT OCLUSION
 uniform bool inUseHighPrecision;
 out vec4 outNormal;
 
-// Only used by OUTLINE render mode:
-uniform float outlineSize;
+// OUTLINE / ifdef RETICLE
+uniform float outlineWidth;
+FLACH in float fragmentRadius;
+FLACH in vec2 centerFragment;
 
 layout(location = 0) out vec4 outColor;

--- a/plugins/mmstd_moldyn/Shaders/sphere/fragment_mainend.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/fragment_mainend.glsl
@@ -1,9 +1,6 @@
 
 #ifdef RETICLE
-    coord = gl_FragCoord 
-        * vec4(viewAttr.z, viewAttr.w, 2.0, 0.0) 
-        + vec4(-1.0, -1.0, -1.0, 1.0);
-    if (min(abs(coord.x - centerFragment.x), abs(coord.y - centerFragment.y)) < 0.002) {
+    if (min(abs(gl_FragCoord.x - centerFragment.x), abs(gl_FragCoord.y - centerFragment.y)) < 2.0f) {
         //outColor.rgb = vec3(1.0, 1.0, 0.5);
         outColor.rgb += vec3(0.3, 0.3, 0.5);
     }

--- a/plugins/mmstd_moldyn/Shaders/sphere/fragment_mainstart.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/fragment_mainstart.glsl
@@ -78,11 +78,25 @@ void main(void) {
 #ifdef AXISHINTS
     // debug-axis-hints
     float mc = min(abs(normal.x), min(abs(normal.y), abs(normal.z)));
-    if (mc < 0.05)            { color = vec3(0.5); }
-    if (abs(normal.x) > 0.98) { color = vec3(1.0, 0.0, 0.0); }
-    if (abs(normal.y) > 0.98) { color = vec3(0.0, 1.0, 0.0); }
-    if (abs(normal.z) > 0.98) { color = vec3(0.0, 0.0, 1.0); }
-    if (normal.x < -0.99)     { color = vec3(0.5); }
-    if (normal.y < -0.99)     { color = vec3(0.5); }
-    if (normal.z < -0.99)     { color = vec3(0.5); }
+    if (mc < 0.05) {
+        color = vec4(0.5, 0.5, 0.5, 1.0);
+    }
+    if (abs(normal.x) > 0.98) {
+        color = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+    if (abs(normal.y) > 0.98) {
+        color = vec4(0.0, 1.0, 0.0, 1.0);
+    }
+    if (abs(normal.z) > 0.98) {
+        color = vec4(0.0, 0.0, 1.0, 1.0);
+    }
+    if (normal.x < -0.99) {
+        color = vec4(0.5, 0.5, 0.5, 1.0);
+    }
+    if (normal.y < -0.99) {
+        color = vec4(0.5, 0.5, 0.5, 1.0);
+    }
+    if (normal.z < -0.99) {
+        color = vec4(0.5, 0.5, 0.5, 1.0);
+    }
 #endif // AXISHINTS

--- a/plugins/mmstd_moldyn/Shaders/sphere/outline_fragment_cutout.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/outline_fragment_cutout.glsl
@@ -21,5 +21,11 @@
     //
     //if (throwaway) discard;
 
-    if (delta > outlineSize) discard;
-    // TODO make this independent of the sphere radius
+    // dependent on the sphere radius
+    //if (delta > outlineWidth) discard;
+
+    if (length(gl_FragCoord.xy - centerFragment) < (fragmentRadius - outlineWidth)) {
+        discard;
+    }
+
+    outColor = color;

--- a/plugins/mmstd_moldyn/Shaders/sphere/outline_fragment_nolighting.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/outline_fragment_nolighting.glsl
@@ -1,2 +1,0 @@
-
-    outColor = color;

--- a/plugins/mmstd_moldyn/Shaders/sphere/vertex_attributes.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/vertex_attributes.glsl
@@ -10,9 +10,9 @@ out vec4 vertColor;
 out float pointSize;
 #endif // DEFERRED_SHADING
 
-#ifdef RETICLE
+// OUTLINE / ifdef RETICLE
+out float fragmentRadius;
 out vec2 centerFragment;
-#endif // RETICLE
 
 uniform vec4 viewAttr;
 uniform vec4 lightDir;

--- a/plugins/mmstd_moldyn/Shaders/sphere/vertex_mainend.glsl
+++ b/plugins/mmstd_moldyn/Shaders/sphere/vertex_mainend.glsl
@@ -1,18 +1,19 @@
 
+    // Debug
+    // gl_PointSize = 32.0;
+
 #ifdef SMALL_SPRITE_LIGHTING
     // for normal crowbaring on very small sprites
     outlightDir.w = (clamp(gl_PointSize, 1.0, 5.0) - 1.0) / 4.0;
 #else
     outlightDir.w = 1.0;
 #endif // SMALL_SPRITE_LIGHTING
-    
-#ifdef RETICLE
-    centerFragment = gl_Position.xy / gl_Position.w;
-#endif // RETICLE
+
+    fragmentRadius = gl_PointSize / 2.0;
+    centerFragment = ((gl_Position.xy / gl_Position.w) - vec2(-1.0, -1.0)) / vec2(viewAttr.z, viewAttr.w);
 
 #ifdef DEFERRED_SHADING
     pointSize = gl_PointSize;
 #endif // DEFERRED_SHADING
 
-    // gl_PointSize = 32.0;
 }

--- a/plugins/mmstd_moldyn/Shaders/sphere_outline.btf
+++ b/plugins/mmstd_moldyn/Shaders/sphere_outline.btf
@@ -33,7 +33,6 @@
         <snippet name="LightDirectional" type="file">lightdirectional.glsl</snippet>        
         <snippet name="MainStart"        type="file">sphere/fragment_mainstart.glsl</snippet>         
         <snippet name="CutOut"           type="file">sphere/outline_fragment_cutout.glsl</snippet>
-        <snippet name="NoLighting"       type="file">sphere/outline_fragment_nolighting.glsl</snippet>
         <snippet name="OutDepth"         type="file">sphere/fragment_out-depth.glsl</snippet>
         <snippet name="MainEnd"          type="file">sphere/fragment_mainend.glsl</snippet>
     </shader>

--- a/plugins/mmstd_moldyn/src/rendering/SphereRenderer.cpp
+++ b/plugins/mmstd_moldyn/src/rendering/SphereRenderer.cpp
@@ -110,7 +110,7 @@ SphereRenderer::SphereRenderer(void) : view::Renderer3DModuleGL()
     , aoStrengthSlot("ambient occlusion::strength", "Ambient Occlusion: Strength")
     , aoConeLengthSlot("ambient occlusion::coneLength", "Ambient Occlusion: Cone length")
     , useHPTexturesSlot("ambient occlusion::highPrecisionTexture", "Ambient Occlusion: Use high precision textures")
-    , outlineSizeSlot("outline::width", "Width of the outline") {
+    , outlineWidthSlot("outline::width", "Width of the outline in pixels") {
 
     this->getDataSlot.SetCompatibleCall<MultiParticleDataCallDescription>();
     this->MakeSlotAvailable(&this->getDataSlot);
@@ -190,8 +190,8 @@ SphereRenderer::SphereRenderer(void) : view::Renderer3DModuleGL()
     this->useHPTexturesSlot << (new param::BoolParam(false));
     this->MakeSlotAvailable(&this->useHPTexturesSlot);
 
-    this->outlineSizeSlot << (new core::param::FloatParam(2.0f, 0.0f));
-    this->MakeSlotAvailable(&this->outlineSizeSlot);
+    this->outlineWidthSlot << (new core::param::FloatParam(2.0f, 0.0f));
+    this->MakeSlotAvailable(&this->outlineWidthSlot);
 }
 
 
@@ -323,7 +323,7 @@ bool SphereRenderer::resetResources(void) {
     this->aoConeLengthSlot.Param<param::FloatParam>()->SetGUIVisible(false);
     this->useHPTexturesSlot.Param<param::BoolParam>()->SetGUIVisible(false);
     // Outlining
-    this->outlineSizeSlot.Param<param::FloatParam>()->SetGUIVisible(false);
+    this->outlineWidthSlot.Param<param::FloatParam>()->SetGUIVisible(false);
 
     this->flags_enabled = false;
     this->flags_available = false;
@@ -713,7 +713,7 @@ bool SphereRenderer::createResources() {
         } break;
 
         case RenderMode::OUTLINE: {
-            this->outlineSizeSlot.Param<param::FloatParam>()->SetGUIVisible(true);
+            this->outlineWidthSlot.Param<param::FloatParam>()->SetGUIVisible(true);
             vertShaderName = "sphere_outline::vertex";
             fragShaderName = "sphere_outline::fragment";
             if (!instance()->ShaderSourceFactory().MakeShaderSource(vertShaderName.PeekBuffer(), *this->vertShader)) {
@@ -1857,7 +1857,7 @@ bool SphereRenderer::renderOutline(view::CallRender3DGL& call, MultiParticleData
     glUniformMatrix4fv(this->sphereShader.ParameterLocation("MVPinv"), 1, GL_FALSE, glm::value_ptr(this->curMVPinv));
     glUniformMatrix4fv(this->sphereShader.ParameterLocation("MVPtransp"), 1, GL_FALSE, glm::value_ptr(this->curMVPtransp));
 
-    glUniform1f(this->sphereShader.ParameterLocation("outlineSize"), this->outlineSizeSlot.Param<param::FloatParam>()->Value());
+    glUniform1f(this->sphereShader.ParameterLocation("outlineWidth"), this->outlineWidthSlot.Param<param::FloatParam>()->Value());
 
     GLuint flagPartsCount = 0;
     for (unsigned int i = 0; i < mpdc->GetParticleListCount(); i++) {

--- a/plugins/mmstd_moldyn/src/rendering/SphereRenderer.h
+++ b/plugins/mmstd_moldyn/src/rendering/SphereRenderer.h
@@ -380,7 +380,7 @@ namespace rendering {
 
 		// Affects only Outline rendering: --------------------------
 
-		megamol::core::param::ParamSlot outlineSizeSlot;
+		megamol::core::param::ParamSlot outlineWidthSlot;
 
         /*********************************************************************/
         /* FUNCTIONS                                                         */

--- a/utils/MMPLD/GenTestFiles.pl
+++ b/utils/MMPLD/GenTestFiles.pl
@@ -327,8 +327,6 @@ foreach my $r (@renderer_modes) {
         open my $fh, ">", $proj or die "cannot open $proj";
         
         print $fh qq{mmCreateView("test", "View3DGL", "::view")\n};
-
-        print $fh qq{mmCreateModule("ScreenShooter", "::imgmaker")\n};
         print $fh qq{mmCreateModule("MMPLDDataSource", "::dat")\n};
 
         if ($r =~ /^OSPRay/) {
@@ -392,13 +390,11 @@ foreach my $r (@renderer_modes) {
         print $fh qq{mmSetParamValue("::view::camstore::settings", [=[{"centre_offset":[0.0,0.0],"convergence_plane":0.0,"eye":0,"far_clipping_plane":12.97671890258789,"film_gate":[0.0,0.0],"gate_scaling":0,"half_aperture_angle":0.2617993950843811,"half_disparity":0.02500000037252903,"image_tile":[0,720,1280,0],"near_clipping_plane":0.012976719066500664,"orientation":[0.17020022869110107,-0.24738462269306183,-0.0711577907204628,-0.9511932134628296],"position":[4.224766731262207,3.3975491523742676,7.757389545440674],"projection_type":0,"resolution_gate":[1280,720]}]=])\n};
         print $fh qq{mmSetParamValue("::view::camstore::autoLoadSettings", "true")\n};
         print $fh qq{mmSetParamValue("::dat::filename", "}.getcwd().qq{/$f")\n};
-        # Image resolution MUST fit current viewport, using default from megamolconfig.lua
-        print $fh qq{mmSetParamValue("::imgmaker::imgWidth", "1280")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::imgHeight", "720")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::filename", "}.getcwd().qq{/$f-$r.png")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::view", "::view")\n};
-        # print $fh qq{mmSetParamValue("::imgmaker::closeAfter", "true")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::trigger", " ")\n};        
+
+        print $fh qq{mmShowGUI(false)\n};                          # print $fh qq{mmSetGUIVisible(false)\n};
+        print $fh qq{mmRenderNextFrame()\n};
+        print $fh qq{mmScreenShot("}.getcwd().qq{/$f-$r.png")\n};  # print $fh qq{mmScreenshot("}.getcwd().qq{/$f-$r.png")\n};
+        print $fh qq{mmQuit()\n};
 
         close $fh;
 

--- a/utils/MMPLD/GenTestFiles.pl
+++ b/utils/MMPLD/GenTestFiles.pl
@@ -325,10 +325,16 @@ foreach my $r (@renderer_modes) {
     foreach my $f (@outfiles) {
         my $proj = "$f-$r.lua";
         open my $fh, ">", $proj or die "cannot open $proj";
-        print $fh qq{mmCreateJob("imagemaker", "ScreenShooter", "::imgmaker")\n};
+        
+        print $fh qq{mmCreateView("test", "View3DGL", "::view")\n};
+
+        print $fh qq{mmCreateModule("ScreenShooter", "::imgmaker")\n};
         print $fh qq{mmCreateModule("MMPLDDataSource", "::dat")\n};
+
         if ($r =~ /^OSPRay/) {
-            print $fh qq{mmCreateView("test", "View3D", "::view")\n};
+
+            print $fh qq{mmCreateModule("BoundingBoxRenderer","::bbox")\n};
+            print $fh qq{mmCreateModule("ContextToGL","::c2gl")\n};
             print $fh qq{mmCreateModule("OSPRayRenderer", "::osp")\n};
             if ($r =~ /^OSPRayGeometrySphere/) {
                 print $fh qq{mmCreateModule("OSPRaySphereGeometry", "::renderer")\n};
@@ -336,25 +342,29 @@ foreach my $r (@renderer_modes) {
             elsif ($r =~ /^OSPRayNHGeometrySphere/) {
                 print $fh qq{mmCreateModule("OSPRayNHSphereGeometry", "::renderer")\n};
             }
-            print $fh qq{mmCreateModule("OSPRayAmbientLight", "::amb")\n};
+
+            print $fh qq{mmCreateModule("AmbientLight", "::amb")\n};
             print $fh qq{mmCreateModule("OSPRayOBJMaterial", "::mat")\n};
-            print $fh qq{mmCreateCall("CallRender3D", "::view::rendering", "::osp::rendering")\n};
+
+            print $fh qq{mmCreateCall("CallRender3DGL","::view::rendering","::bbox::rendering")\n};
+            print $fh qq{mmCreateCall("CallRender3DGL","::bbox::chainRendering","::c2gl::rendering")\n};
+            print $fh qq{mmCreateCall("CallRender3D","::c2gl::getContext","::osp::rendering")\n};
             print $fh qq{mmCreateCall("CallOSPRayStructure", "::osp::getStructure", "::renderer::deployStructureSlot")\n};
-            print $fh qq{mmCreateCall("CallOSPRayLight", "::osp::getLight", "::amb::deployLightSlot")\n};
+            print $fh qq{mmCreateCall("CallLight", "::osp::lights", "::amb::deployLightSlot")\n};
             print $fh qq{mmCreateCall("CallOSPRayMaterial", "::renderer::getMaterialSlot", "::mat::deployMaterialSlot")\n};
+
             print $fh qq{mmSetParamValue("::osp::useDBcomponent", "false")\n};
-            print $fh qq|mmSetParamValue("::view::camsettings", "{ApertureAngle=30\\nCoordSystemType=2\\nNearClip=14.746623992919921875\\nFarClip=32.5738677978515625\\nProjection=0\\nStereoDisparity=0.300000011920928955078125\\nStereoEye=0\\nFocalDistance=23.6602458953857421875\\nPositionX=14.33369541168212890625\\nPositionY=8.6866302490234375\\nPositionZ=16.7001476287841796875\\nLookAtX=0\\nLookAtY=0\\nLookAtZ=0\\nUpX=-0.1268725097179412841796875\\nUpY=0.920388698577880859375\\nUpZ=-0.3698485195636749267578125\\nTileLeft=0\\nTileBottom=0\\nTileRight=1280\\nTileTop=720\\nVirtualViewWidth=1280\\nVirtualViewHeight=720\\nAutoFocusOffset=0\\n}")\n|;
+
         } else {
-            print $fh qq{mmCreateView("test", "View3D_2", "::view")\n};
+
             print $fh qq{mmCreateModule("BoundingBoxRenderer","::bbox")\n};
             print $fh qq{mmCreateModule("DistantLight","::distlight")\n};
             print $fh qq{mmCreateModule("SphereRenderer", "::renderer")\n};
 
-            print $fh qq{mmCreateCall("CallRender3D_2", "::view::rendering", "::bbox::rendering")\n};
-            print $fh qq{mmCreateCall("CallRender3D_2","::bbox::chainRendering","::renderer::rendering")\n};
-            #print $fh qq{mmCreateCall("CallRender3D_2","::view::rendering","::renderer::rendering")\n};
+            print $fh qq{mmCreateCall("CallRender3DGL", "::view::rendering", "::bbox::rendering")\n};
+            print $fh qq{mmCreateCall("CallRender3DGL","::bbox::chainRendering","::renderer::rendering")\n};
+            print $fh qq{mmCreateCall("CallLight","::renderer::lights","::distlight::deployLightSlot")\n};   
 
-            print $fh qq{mmCreateCall("CallLight","::renderer::lights","::distlight::deployLightSlot")\n};            
             if ($r =~ /^SimpleSphere/) {
                 print $fh qq{mmSetParamValue("::renderer::renderMode", "Simple")\n};
             }
@@ -374,24 +384,24 @@ foreach my $r (@renderer_modes) {
                 print $fh qq{mmSetParamValue("::renderer::renderMode", "Ambient_Occlusion")\n};
                 print $fh qq{mmSetParamValue("::renderer::ambient occlusion::enableLighting", "true")\n};
             }      
-            print $fh qq{mmSetParamValue("::view::camstore::settings", [=[{"centre_offset":[0.0,0.0],"convergence_plane":0.0,"eye":0,"far_clipping_plane":12.97671890258789,"film_gate":[0.0,0.0],"gate_scaling":0,"half_aperture_angle":0.2617993950843811,"half_disparity":0.02500000037252903,"image_tile":[0,720,1280,0],"near_clipping_plane":0.012976719066500664,"orientation":[0.17020022869110107,-0.24738462269306183,-0.0711577907204628,-0.9511932134628296],"position":[4.224766731262207,3.3975491523742676,7.757389545440674],"projection_type":0,"resolution_gate":[1280,720]}]=])\n};
-            print $fh qq{mmSetParamValue("::view::camstore::autoLoadSettings", "true")\n};
-            print $fh qq{mmSetParamValue("::distlight::Direction", "-0.500000;0.500000;0.000000")\n};                     
+               
+            print $fh qq{mmSetParamValue("::distlight::Direction", "-0.500000;0.500000;0.000000")\n};                   
         }
-        print $fh qq{mmCreateCall("MultiParticleDataCall", "::renderer::getdata", "::dat::getData")\n};             
+        print $fh qq{mmCreateCall("MultiParticleDataCall", "::renderer::getdata", "::dat::getData")\n};   
+
+        print $fh qq{mmSetParamValue("::view::camstore::settings", [=[{"centre_offset":[0.0,0.0],"convergence_plane":0.0,"eye":0,"far_clipping_plane":12.97671890258789,"film_gate":[0.0,0.0],"gate_scaling":0,"half_aperture_angle":0.2617993950843811,"half_disparity":0.02500000037252903,"image_tile":[0,720,1280,0],"near_clipping_plane":0.012976719066500664,"orientation":[0.17020022869110107,-0.24738462269306183,-0.0711577907204628,-0.9511932134628296],"position":[4.224766731262207,3.3975491523742676,7.757389545440674],"projection_type":0,"resolution_gate":[1280,720]}]=])\n};
+        print $fh qq{mmSetParamValue("::view::camstore::autoLoadSettings", "true")\n};
         print $fh qq{mmSetParamValue("::dat::filename", "}.getcwd().qq{/$f")\n};
         # Image resolution MUST fit current viewport, using default from megamolconfig.lua
         print $fh qq{mmSetParamValue("::imgmaker::imgWidth", "1280")\n};
         print $fh qq{mmSetParamValue("::imgmaker::imgHeight", "720")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::tileWidth", "1280")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::tileHeight", "720")\n};  
         print $fh qq{mmSetParamValue("::imgmaker::filename", "}.getcwd().qq{/$f-$r.png")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::view", "test")\n};
-        print $fh qq{mmSetParamValue("::imgmaker::closeAfter", "true")\n};
+        print $fh qq{mmSetParamValue("::imgmaker::view", "::view")\n};
+        # print $fh qq{mmSetParamValue("::imgmaker::closeAfter", "true")\n};
         print $fh qq{mmSetParamValue("::imgmaker::trigger", " ")\n};        
 
         close $fh;
 
-        print $batch qq{mmconsole.exe -p ..\\utils\\MMPLD\\$proj\n};
+        print $batch qq{megamol.exe ..\\..\\..\\utils\\MMPLD\\$proj\n};
     }
 }


### PR DESCRIPTION
Outline width in outline render mode of SphereRenderer is now defined as number of pixels.

## Summary of Changes
- Modified some SphereRenderer shader snippets.
- Updated GenTestFiles.pl 
  - new module and call names
  - run new frontend
  - use lua screenshoot option

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
Run example using SphereRenderer and switch to render mode "Outline". Adjust outline width.
