### PR TITLE
Frontend 1: ImagePresentation Service manages Graph Entry Points

### DIFF
--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -144,7 +144,7 @@ public:
 
     void RenderNextFrame();
 
-    void AddModuleDependencies(std::vector<megamol::frontend::FrontendResource> const& resources);
+    bool AddFrontendResources(std::vector<megamol::frontend::FrontendResource> const& resources);
 
     // shut down all calls, modules, graph entry points
     void Clear();

--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -20,6 +20,7 @@
 #include "mmcore/RootModuleNamespace.h"
 
 #include "FrontendResource.h"
+#include "ImagePresentationEntryPoints.h"
 
 namespace megamol {
 namespace core {
@@ -131,18 +132,9 @@ public:
 
     std::vector<megamol::core::param::ParamSlot*> ListParameterSlots() const;
 
-    using EntryPointExecutionCallback =
-        std::function<void(Module::ptr_type, std::vector<megamol::frontend::FrontendResource> const&)>;
-
-    bool SetGraphEntryPoint(
-        std::string moduleName,
-        std::vector<std::string> execution_resources,
-        EntryPointExecutionCallback render_callback,
-        EntryPointExecutionCallback init_callback);
+    bool SetGraphEntryPoint(std::string moduleName);
 
     bool RemoveGraphEntryPoint(std::string moduleName);
-
-    void RenderNextFrame();
 
     bool AddFrontendResources(std::vector<megamol::frontend::FrontendResource> const& resources);
 
@@ -194,19 +186,11 @@ private:
 
     std::vector<megamol::frontend::FrontendResource> provided_resources;
 
-    // for each View in the MegaMol graph we create a GraphEntryPoint with corresponding callback for resource/input
-    // consumption the graph makes sure that the (lifetime and rendering) resources/dependencies requested by the module
-    // are satisfied, which means that the execute() callback for the entry point is provided the requested
-    // dependencies/resources for rendering and the Create() and Release() mehods of all modules receive the
-    // dependencies/resources they request for their lifetime
-    struct GraphEntryPoint {
-        std::string moduleName;
-        Module::ptr_type modulePtr = nullptr;
-        std::vector<megamol::frontend::FrontendResource> entry_point_resources;
-
-        EntryPointExecutionCallback execute;
-    };
-    std::list<GraphEntryPoint> graph_entry_points;
+    // for each View in the MegaMol graph we create a GraphEntryPoint
+    // that entry point is used by the Image Presentation Service to
+    // poke the rendering, collect the resulting View renderings and present them to the user appropriately
+    std::list<Module::ptr_type> graph_entry_points;
+    megamol::frontend_resources::ImagePresentationEntryPoints* m_image_presentation = nullptr;
 
     MegaMolGraph_Convenience convenience_functions;
 

--- a/core/include/mmcore/view/AbstractView.h
+++ b/core/include/mmcore/view/AbstractView.h
@@ -29,6 +29,8 @@
 #include "mmcore/view/TimeControl.h"
 #include "ScriptPaths.h"
 
+#include "ImageWrapper.h"
+
 namespace megamol {
 namespace core {
 namespace view {
@@ -269,6 +271,10 @@ public:
      */
     bool OnResetView(param::ParamSlot& p);
 
+    using ImageWrapper = megamol::frontend_resources::ImageWrapper;
+    virtual ImageWrapper GetRenderingResult() const {
+        return {};
+    }
 
 protected:
 

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -23,16 +23,24 @@ namespace view {
     MEGAMOLCORE_API void view_consume_mouse_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_window_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_framebuffer_events(AbstractView & view, megamol::frontend::FrontendResource const& resource);
-    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view);//, megamol::frontend::FrontendResource const& resource);
+    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view);
 
     // to do this right we should be able to as a view object which runtime resources it expects (keyboard inputs, gl context)
     // and just pass those resources to the view when rendering a frame
     // until we implement the 'optimal' approach, this is the best we can do
     MEGAMOLCORE_API std::vector<std::string> get_gl_view_runtime_resources_requests();
-    MEGAMOLCORE_API bool view_rendering_execution(megamol::core::Module::ptr_type module_ptr, std::vector<megamol::frontend::FrontendResource> const& resources);
+
+    MEGAMOLCORE_API bool view_rendering_execution(
+          void* module_ptr
+        , std::vector<megamol::frontend::FrontendResource> const& resources
+    );
+
     // before rendering the first frame views need to know the current framebuffer size
     // because they may have beed added to the graph after the initial framebuffer size event, we need this init callback to give them that info
-    MEGAMOLCORE_API bool view_init_rendering_state(megamol::core::Module::ptr_type module_ptr, std::vector<megamol::frontend::FrontendResource> const& resources);
+    MEGAMOLCORE_API bool view_init_rendering_state(
+          void* module_ptr
+        , std::vector<megamol::frontend::FrontendResource> const& resources
+    );
 
 } /* end namespace view */
 } /* end namespace core */

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -24,7 +24,7 @@ namespace view {
     MEGAMOLCORE_API void view_consume_mouse_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_window_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_framebuffer_events(AbstractView & view, megamol::frontend::FrontendResource const& resource);
-    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view);
+    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageWrapper& result_image);
 
     // to do this right we should be able to as a view object which runtime resources it expects (keyboard inputs, gl context)
     // and just pass those resources to the view when rendering a frame

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -9,6 +9,7 @@
 
 #include "AbstractView.h"
 #include "FrontendResource.h"
+#include "ImageWrapper.h"
 
 namespace megamol {
 namespace core {
@@ -33,6 +34,7 @@ namespace view {
     MEGAMOLCORE_API bool view_rendering_execution(
           void* module_ptr
         , std::vector<megamol::frontend::FrontendResource> const& resources
+        , megamol::frontend_resources::ImageWrapper& result_image
     );
 
     // before rendering the first frame views need to know the current framebuffer size
@@ -40,6 +42,7 @@ namespace view {
     MEGAMOLCORE_API bool view_init_rendering_state(
           void* module_ptr
         , std::vector<megamol::frontend::FrontendResource> const& resources
+        , megamol::frontend_resources::ImageWrapper& result_image
     );
 
 } /* end namespace view */

--- a/core/include/mmcore/view/View2DGL.h
+++ b/core/include/mmcore/view/View2DGL.h
@@ -178,6 +178,15 @@ private:
     float _width;
 
     std::shared_ptr<vislib::graphics::gl::FramebufferObject> _fbo;
+
+    ImageWrapper GetRenderingResult() const override {
+        ImageWrapper::DataChannels channels = ImageWrapper::DataChannels::RGBA8; // vislib::graphics::gl::FramebufferObject seems to use RGBA8
+        unsigned int fbo_color_buffer_gl_handle = _fbo->GetColourTextureID(0); // IS THIS SAFE?? IS THIS THE COLOR BUFFER??
+        size_t fbo_width = _fbo->GetWidth();
+        size_t fbo_height = _fbo->GetHeight();
+
+        return frontend_resources::wrap_image({fbo_width, fbo_height}, fbo_color_buffer_gl_handle, channels);
+    }
 };
 } /* end namespace view */
 } /* end namespace core */

--- a/core/include/mmcore/view/View3DGL.h
+++ b/core/include/mmcore/view/View3DGL.h
@@ -78,6 +78,15 @@ protected:
 
     std::shared_ptr<vislib::graphics::gl::FramebufferObject> _fbo;
 
+    ImageWrapper GetRenderingResult() const override {
+        ImageWrapper::DataChannels channels = ImageWrapper::DataChannels::RGBA8; // vislib::graphics::gl::FramebufferObject seems to use RGBA8
+        unsigned int fbo_color_buffer_gl_handle = _fbo->GetColourTextureID(0); // IS THIS SAFE?? IS THIS THE COLOR BUFFER??
+        size_t fbo_width = _fbo->GetWidth();
+        size_t fbo_height = _fbo->GetHeight();
+
+        return frontend_resources::wrap_image({fbo_width, fbo_height}, fbo_color_buffer_gl_handle, channels);
+    }
+
 private:
 
     /** The mouse x coordinate */

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -4,7 +4,6 @@
 #include "mmcore/MegaMolGraph.h"
 
 #include "mmcore/AbstractSlot.h"
-#include "mmcore/view/AbstractView_EventConsumption.h"
 
 #include "mmcore/utility/log/Log.h"
 
@@ -156,6 +155,15 @@ bool megamol::core::MegaMolGraph::RenameModule(std::string const& oldId, std::st
         }
         if (matches_old_prefix(call.request.to)) {
             put_new_prefix(call.request.to);
+        }
+    }
+
+    // dont know what we are supposed to do when entry point renaming fails... how can it fail?
+    if (module_it->isGraphEntryPoint) {
+        bool view_rename_ok = m_image_presentation->rename_entry_point(oldId, newId);
+        if (!view_rename_ok) {
+            log_error("error renaming graph entry point. image presentation service could not rename module: " + oldId + " -> " + newId);
+            return false;
         }
     }
 
@@ -439,13 +447,6 @@ bool megamol::core::MegaMolGraph::delete_call(CallDeletionRequest_t const& reque
     return true;
 }
 
-
-void megamol::core::MegaMolGraph::RenderNextFrame() {
-    for (auto& entry : graph_entry_points) {
-        entry.execute(entry.modulePtr, entry.entry_point_resources);
-    }
-}
-
 megamol::core::Module::ptr_type megamol::core::MegaMolGraph::FindModule(std::string const& moduleName) const {
     auto module_it = find_module(moduleName);
 
@@ -585,12 +586,9 @@ std::vector<megamol::core::param::AbstractParam*> megamol::core::MegaMolGraph::L
     return parameters;
 }
 
-bool megamol::core::MegaMolGraph::SetGraphEntryPoint(
-    std::string moduleName,
-    std::vector<std::string> execution_resource_requests,
-    EntryPointExecutionCallback render_callback,
-    EntryPointExecutionCallback init_callback)
+bool megamol::core::MegaMolGraph::SetGraphEntryPoint(std::string moduleName)
 {
+    // currently, we expect the entry point to be derived from AbstractView
     auto module_it = find_module(moduleName);
 
     if (module_it == module_list_.end()) {
@@ -598,20 +596,20 @@ bool megamol::core::MegaMolGraph::SetGraphEntryPoint(
         return false;
     }
     
-    auto module_ptr = module_it->modulePtr;
+    auto module_shared_ptr = module_it->modulePtr; // we cant cast shared_ptr to void* for image presentation rendering
+    auto& module_ref = *module_shared_ptr;
+    auto* module_raw_ptr = &module_ref;
 
-    auto resources = get_requested_resources(execution_resource_requests);
+    // the image presentation will issue the rendering and provide the view with resources for rendering
+    // probably we dont care or dont check wheter the same view is added as entry point multiple times
+    bool view_presentation_ok = m_image_presentation->add_entry_point(moduleName, static_cast<void*>(module_raw_ptr));
 
-    if (resources.size() != execution_resource_requests.size() ||
-        !std::equal<>(resources.begin(), resources.end(), 
-            execution_resource_requests.begin(), execution_resource_requests.end(), 
-            [](megamol::frontend::FrontendResource& l, std::string& r) { return l.getIdentifier() == r; })) 
-    {
+    if (!view_presentation_ok) {
+        log_error("error adding graph entry point. image presentation service rejected module: " + moduleName);
         return false;
     }
 
-    this->graph_entry_points.push_back({moduleName, module_ptr, resources, render_callback});
-    init_callback(module_ptr, resources);
+    this->graph_entry_points.push_back(module_shared_ptr);
 
     module_it->isGraphEntryPoint = true;
     log("set graph entry point: " + moduleName);
@@ -627,7 +625,18 @@ bool megamol::core::MegaMolGraph::RemoveGraphEntryPoint(std::string moduleName) 
         return false;
     }
 
-    this->graph_entry_points.remove_if([&](GraphEntryPoint& entry) { return entry.moduleName == moduleName; });
+    bool view_removal_ok = m_image_presentation->remove_entry_point(moduleName);
+
+    // note that for us it is not an error to try to remove a module as graph entry point
+    // if that module is not registered as an entry point
+    // but maybe image presentation may tell us that for some other reason removal failed?
+    if (!view_removal_ok) {
+        log_error("error adding graph entry point. image presentation service could not remove module: " + moduleName);
+        return false;
+    }
+
+    this->graph_entry_points.remove_if(
+        [&](Module::ptr_type& module) { return std::string{module->Name().PeekBuffer()} == moduleName; });
 
     module_it->isGraphEntryPoint = false;
     log("remove graph entry point: " + moduleName);
@@ -638,6 +647,18 @@ bool megamol::core::MegaMolGraph::RemoveGraphEntryPoint(std::string moduleName) 
 bool megamol::core::MegaMolGraph::AddFrontendResources(std::vector<megamol::frontend::FrontendResource> const& resources) {
     this->provided_resources.insert(provided_resources.end(), resources.begin(), resources.end());
 
+    auto find_it = std::find_if(provided_resources.begin(), provided_resources.end(),
+        [&](megamol::frontend::FrontendResource const& resource) {
+            return resource.getIdentifier() == "ImagePresentationEntryPoints";
+        });
+
+    if (find_it == provided_resources.end()) {
+        return false;
+    }
+
+    m_image_presentation = & const_cast<megamol::frontend_resources::ImagePresentationEntryPoints&>(
+        find_it->getResource<megamol::frontend_resources::ImagePresentationEntryPoints>());
+
     return true;
 }
 
@@ -646,6 +667,9 @@ megamol::core::MegaMolGraph_Convenience& megamol::core::MegaMolGraph::Convenienc
 }
 
 void megamol::core::MegaMolGraph::Clear() {
+    // currently entry points are expected to be graph modules, i.e. views
+    // therefore it is ok for us to clear all entry points if the graph shuts down
+    m_image_presentation->clear_entry_points();
     graph_entry_points.clear();
     call_list_.clear();
     module_list_.clear();

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -635,8 +635,10 @@ bool megamol::core::MegaMolGraph::RemoveGraphEntryPoint(std::string moduleName) 
     return true;
 }
 
-void megamol::core::MegaMolGraph::AddModuleDependencies(std::vector<megamol::frontend::FrontendResource> const& resources) {
+bool megamol::core::MegaMolGraph::AddFrontendResources(std::vector<megamol::frontend::FrontendResource> const& resources) {
     this->provided_resources.insert(provided_resources.end(), resources.begin(), resources.end());
+
+    return true;
 }
 
 megamol::core::MegaMolGraph_Convenience& megamol::core::MegaMolGraph::Convenience() {

--- a/core/src/Module.cpp
+++ b/core/src/Module.cpp
@@ -24,8 +24,6 @@
 #include "vislib/graphics/gl/IncludeAllGL.h"
 #endif
 
-#include "IOpenGL_Context.h"
-
 using namespace megamol::core;
 
 
@@ -121,9 +119,6 @@ vislib::StringA Module::GetDemiRootName() const {
  */
 void Module::Release(std::vector<megamol::frontend::FrontendResource> resources) {
     using megamol::core::utility::log::Log;
-
-    auto opengl_context_it = std::find_if(resources.begin(), resources.end(),
-        [&](megamol::frontend::FrontendResource& dep) { return dep.getIdentifier() == "IOpenGL_Context"; });
 
     if (this->created) {
         this->release();

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -102,6 +102,7 @@ std::vector<std::string> get_gl_view_runtime_resources_requests() {
 bool view_rendering_execution(
       void* module_ptr
     , std::vector<megamol::frontend::FrontendResource> const& resources
+    , megamol::frontend_resources::ImageWrapper& result_image
 ) {
     megamol::core::view::AbstractView* view_ptr =
         dynamic_cast<megamol::core::view::AbstractView*>(static_cast<megamol::core::Module*>(module_ptr));
@@ -126,6 +127,7 @@ bool view_rendering_execution(
 bool view_init_rendering_state(
       void* module_ptr
     , std::vector<megamol::frontend::FrontendResource> const& resources
+    , megamol::frontend_resources::ImageWrapper& result_image
 ) {
     megamol::core::view::AbstractView* view_ptr =
         dynamic_cast<megamol::core::view::AbstractView*>(static_cast<megamol::core::Module*>(module_ptr));

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -69,7 +69,7 @@ void view_consume_framebuffer_events(AbstractView& view, megamol::frontend::Fron
 // this is a weird place to measure passed program time, but we do it here so we satisfy _mmcRenderViewContext and nobody else needs to know
 static std::chrono::high_resolution_clock::time_point render_view_context_timer_start;
 
-void view_poke_rendering(AbstractView& view) { // , megamol::frontend::FrontendResource const& resource) {
+void view_poke_rendering(AbstractView& view) {
     static bool started_timer = false;
     if (!started_timer) {
         render_view_context_timer_start = std::chrono::high_resolution_clock::now();
@@ -99,9 +99,12 @@ std::vector<std::string> get_gl_view_runtime_resources_requests() {
     return {"KeyboardEvents", "MouseEvents", "WindowEvents", "FramebufferEvents"};
 }
 
-bool view_rendering_execution(megamol::core::Module::ptr_type module_ptr, std::vector<megamol::frontend::FrontendResource> const& resources) {
+bool view_rendering_execution(
+      void* module_ptr
+    , std::vector<megamol::frontend::FrontendResource> const& resources
+) {
     megamol::core::view::AbstractView* view_ptr =
-        dynamic_cast<megamol::core::view::AbstractView*>(module_ptr.get());
+        dynamic_cast<megamol::core::view::AbstractView*>(static_cast<megamol::core::Module*>(module_ptr));
 
     if (!view_ptr) {
         std::cout << "error. module is not a view module. could not use as rendering entry point." << std::endl;
@@ -120,9 +123,12 @@ bool view_rendering_execution(megamol::core::Module::ptr_type module_ptr, std::v
     return true;
 }
 
-bool view_init_rendering_state(megamol::core::Module::ptr_type module_ptr, std::vector<megamol::frontend::FrontendResource> const& resources) {
+bool view_init_rendering_state(
+      void* module_ptr
+    , std::vector<megamol::frontend::FrontendResource> const& resources
+) {
     megamol::core::view::AbstractView* view_ptr =
-        dynamic_cast<megamol::core::view::AbstractView*>(module_ptr.get());
+        dynamic_cast<megamol::core::view::AbstractView*>(static_cast<megamol::core::Module*>(module_ptr));
 
     if (!view_ptr) {
         std::cout << "error. module is not a view module. could not use as rendering entry point." << std::endl;

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -96,24 +96,13 @@ void view_poke_rendering(AbstractView& view) { // , megamol::frontend::FrontendR
 }
 
 std::vector<std::string> get_gl_view_runtime_resources_requests() {
-    return {"KeyboardEvents", "MouseEvents", "WindowEvents", "FramebufferEvents", "IOpenGL_Context"};
+    return {"KeyboardEvents", "MouseEvents", "WindowEvents", "FramebufferEvents"};
 }
 
 bool view_rendering_execution(megamol::core::Module::ptr_type module_ptr, std::vector<megamol::frontend::FrontendResource> const& resources) {
     megamol::core::view::AbstractView* view_ptr =
         dynamic_cast<megamol::core::view::AbstractView*>(module_ptr.get());
 
-    megamol::frontend_resources::IOpenGL_Context const * maybe_opengl = nullptr;
-
-    // if available, we make the opengl context current for all following operations performed by the view/entry point
-    // views and modules may use the GL context to issue GL calls not only during rendering, 
-    // but also when consuming other events, like key presses or framebuffer resizes
-    if (resources.size() >= 5 && resources[4].getIdentifier() == "IOpenGL_Context")
-        maybe_opengl = &resources[4].getResource<megamol::frontend_resources::IOpenGL_Context>();
-
-    if (maybe_opengl)
-        maybe_opengl->activate(); // makes GL context current
-    
     if (!view_ptr) {
         std::cout << "error. module is not a view module. could not use as rendering entry point." << std::endl;
         return false;
@@ -127,9 +116,6 @@ bool view_rendering_execution(megamol::core::Module::ptr_type module_ptr, std::v
     megamol::core::view::view_consume_window_events(view, resources[2]);
     megamol::core::view::view_consume_framebuffer_events(view, resources[3]);
     megamol::core::view::view_poke_rendering(view);//, resources[4]);
-
-    if (maybe_opengl)
-        maybe_opengl->close();
     
     return true;
 }
@@ -138,17 +124,6 @@ bool view_init_rendering_state(megamol::core::Module::ptr_type module_ptr, std::
     megamol::core::view::AbstractView* view_ptr =
         dynamic_cast<megamol::core::view::AbstractView*>(module_ptr.get());
 
-    megamol::frontend_resources::IOpenGL_Context const * maybe_opengl = nullptr;
-
-    // if available, we make the opengl context current for all following operations performed by the view/entry point
-    // views and modules may use the GL context to issue GL calls not only during rendering, 
-    // but also when consuming other events, like key presses or framebuffer resizes
-    if (resources.size() >= 5 && resources[4].getIdentifier() == "IOpenGL_Context")
-        maybe_opengl = &resources[4].getResource<megamol::frontend_resources::IOpenGL_Context>();
-
-    if (maybe_opengl)
-        maybe_opengl->activate(); // makes GL context current
-    
     if (!view_ptr) {
         std::cout << "error. module is not a view module. could not use as rendering entry point." << std::endl;
         return false;
@@ -180,9 +155,6 @@ bool view_init_rendering_state(megamol::core::Module::ptr_type module_ptr, std::
     megamol::core::view::view_consume_window_events(view, resources[2]);
     megamol::core::view::view_consume_framebuffer_events(view, resources[3]);
 
-    if (maybe_opengl)
-        maybe_opengl->close();
-    
     return true;
 }
 

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -69,7 +69,7 @@ void view_consume_framebuffer_events(AbstractView& view, megamol::frontend::Fron
 // this is a weird place to measure passed program time, but we do it here so we satisfy _mmcRenderViewContext and nobody else needs to know
 static std::chrono::high_resolution_clock::time_point render_view_context_timer_start;
 
-void view_poke_rendering(AbstractView& view) {
+void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageWrapper& result_image) {
     static bool started_timer = false;
     if (!started_timer) {
         render_view_context_timer_start = std::chrono::high_resolution_clock::now();
@@ -90,6 +90,7 @@ void view_poke_rendering(AbstractView& view) {
             dummyRenderViewContext.Time = view.DefaultTime(time);
 
         view.Render(dummyRenderViewContext);
+        result_image = view.GetRenderingResult();
     };
     
     render();
@@ -119,7 +120,7 @@ bool view_rendering_execution(
     megamol::core::view::view_consume_mouse_events(view, resources[1]);
     megamol::core::view::view_consume_window_events(view, resources[2]);
     megamol::core::view::view_consume_framebuffer_events(view, resources[3]);
-    megamol::core::view::view_poke_rendering(view);//, resources[4]);
+    megamol::core::view::view_poke_rendering(view, result_image);
     
     return true;
 }

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -148,14 +148,35 @@ static void logfile_handler(std::string const& option_name, cxxopts::ParseResult
     config.log_file = parsed_options[option_name].as<std::string>();
 };
 
+static const std::string accepted_log_level_strings = "('error', 'warn', 'warning', 'info', 'none', 'null', 'zero', 'all', '*')";
+static unsigned int parse_log_level(std::string const& value) {
+    if (value.front()=='-')
+        exit("log level value must be positive. seems to be negative: " + value);
+
+    unsigned int value_as_uint = 0;
+
+    try {
+        if (std::string(value).find_first_of("0123456789") != std::string::npos) {
+            value_as_uint = std::stoi(value);
+        } else {
+            value_as_uint = megamol::core::utility::log::Log::ParseLevelAttribute(value);
+        }
+    }
+    catch (...) {
+        exit("Could not parse valid log level string or positive integer from argument \"" + value + "\"");
+    }
+
+    return value_as_uint;
+}
+
 static void loglevel_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
 {
-    config.log_level = parsed_options[option_name].as<unsigned int>();
+    config.log_level = parse_log_level(parsed_options[option_name].as<std::string>());
 };
 
 static void echolevel_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
 {
-    config.echo_level = parsed_options[option_name].as<unsigned int>();
+    config.echo_level = parse_log_level(parsed_options[option_name].as<std::string>());
 };
 
 static void project_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
@@ -249,8 +270,8 @@ std::vector<OptionsListEntry> cli_options_list =
         , {resourcedir_option,   "Add resource directory(ies)",                                                     cxxopts::value<std::vector<std::string>>(), resourcedir_handler}
         , {shaderdir_option,     "Add shader directory(ies)",                                                       cxxopts::value<std::vector<std::string>>(), shaderdir_handler}
         , {logfile_option,       "Set log file",                                                                    cxxopts::value<std::string>(),              logfile_handler}
-        , {loglevel_option,      "Set logging level",                                                               cxxopts::value<unsigned int>(),             loglevel_handler}
-        , {echolevel_option,     "Set echo level",                                                                  cxxopts::value<unsigned int>(),             echolevel_handler}
+        , {loglevel_option,      "Set logging level, accepted values: "+accepted_log_level_strings,                 cxxopts::value<std::string>(),              loglevel_handler}
+        , {echolevel_option,     "Set echo level, accepted values see above",                                       cxxopts::value<std::string>(),              echolevel_handler}
         , {project_option,       "Project file(s) to load at startup",                                              cxxopts::value<std::vector<std::string>>(), project_handler}
         , {global_option,        "Set global key-value pair(s) in MegaMol environment, syntax: --global key:value", cxxopts::value<std::vector<std::string>>(), global_value_handler}
 
@@ -365,33 +386,6 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_config(Runt
         };
     };
 
-    // helper to make options that parse a log level
-    auto make_log_level_callback = [&](std::string const& optname) {
-        return [optname, &cli_options_from_configs](std::string value) -> VoidResult {
-
-            sane(value);
-
-            if (value.front()=='-')
-                return Error {"log level value string seems to be negative"};
-
-            unsigned int value_as_uint = 0;
-
-            try {
-                if (std::string(value).find_first_of("0123456789") != std::string::npos) {
-                    value_as_uint = std::stoi(value);
-                } else {
-                    value_as_uint = megamol::core::utility::log::Log::ParseLevelAttribute(value);
-                }
-            }
-            catch (...) {
-                return Error{"Could not parse valid log level string or positive integer from argument \"" + value + "\""};
-            }
-
-            add_cli(optname, std::to_string(value_as_uint));
-            return VoidResult{};
-        };
-    };
-
     std::vector<std::string> all_options_separate;
     for (auto& opt : cli_options_list) {
         // split "h,help"
@@ -487,13 +481,13 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_config(Runt
 
     lua_config_callbacks.add<VoidResult, std::string>(
         "mmSetLogLevel",
-        "(string level)\n\tSets the level of log events to include. Level values: ('error', 'warn', 'warning', 'info', 'none', 'null', 'zero', 'all', '*')",
-        { make_log_level_callback(loglevel_option) });
+        "(string level)\n\tSets the level of log events to include. Accepted values: "+accepted_log_level_strings,
+        { make_option_callback(loglevel_option) });
 
     lua_config_callbacks.add<VoidResult, std::string>(
         "mmSetEchoLevel",
-        "(string level)\n\tSets the level of log events to output to the console. Level values: ('error', 'warn', 'warning', 'info', 'none', 'null', 'zero', 'all', '*')",
-        { make_log_level_callback(echolevel_option) });
+        "(string level)\n\tSets the level of log events to output to the console. Accepted values: "+accepted_log_level_strings,
+        { make_option_callback(echolevel_option) });
 
     lua.AddCallbacks(lua_config_callbacks);
 

--- a/frontend/main/src/main.cpp
+++ b/frontend/main/src/main.cpp
@@ -224,9 +224,14 @@ int main(const int argc, const char** argv) {
     }
 
     auto frontend_resources = services.getProvidedResources();
-    graph.AddModuleDependencies(frontend_resources);
+    bool graph_resources_ok = graph.AddFrontendResources(frontend_resources);
+    if (!graph_resources_ok) {
+        log_error("Graph did not get resources he needs from frontend. Abort.");
+        run_megamol = false;
+    }
 
     // load project files via lua
+    if (graph_resources_ok)
     for (auto& file : config.project_files) {
         if (!projectloader_service.load_file(file)) {
             log("Project file \"" + file + "\" did not execute correctly");

--- a/frontend/main/src/main.cpp
+++ b/frontend/main/src/main.cpp
@@ -18,6 +18,7 @@
 #include "OpenGL_GLFW_Service.hpp"
 #include "Screenshot_Service.hpp"
 #include "ProjectLoader_Service.hpp"
+#include "ImagePresentation_Service.hpp"
 
 
 static void log(std::string const& text) {
@@ -117,6 +118,9 @@ int main(const int argc, const char** argv) {
     megamol::frontend::ProjectLoader_Service::Config projectloaderConfig;
     projectloader_service.setPriority(1);
 
+    megamol::frontend::ImagePresentation_Service imagepresentation_service;
+    megamol::frontend::ImagePresentation_Service::Config imagepresentationConfig;
+    imagepresentation_service.setPriority(3); // before render: do things after GL; post render: do things before GL
 #ifdef MM_CUDA_ENABLED
     megamol::frontend::CUDA_Service cuda_service;
     cuda_service.setPriority(24);
@@ -143,6 +147,7 @@ int main(const int argc, const char** argv) {
     services.add(screenshot_service, &screenshotConfig);
     services.add(framestatistics_service, &framestatisticsConfig);
     services.add(projectloader_service, &projectloaderConfig);
+    services.add(imagepresentation_service, &imagepresentationConfig);
 #ifdef MM_CUDA_ENABLED
     services.add(cuda_service, nullptr);
 #endif
@@ -198,7 +203,7 @@ int main(const int argc, const char** argv) {
         {
             services.preGraphRender(); // e.g. start frame timer, clear render buffers
 
-            graph.RenderNextFrame(); // executes graph views, those digest input events like keyboard/mouse, then render
+            imagepresentation_service.RenderNextFrame(); // executes graph views, those digest input events like keyboard/mouse, then render
 
             services.postGraphRender(); // render GUI, glfw swap buffers, stop frame timer
         }
@@ -212,6 +217,10 @@ int main(const int argc, const char** argv) {
     const std::function<bool()> render_next_frame_func = [&]() -> bool { return render_next_frame(); };
     services.getProvidedResources().push_back({"RenderNextFrame", render_next_frame_func});
 
+    // image presentation service needs to assign frontend resources to entry points
+    auto& frontend_resources = services.getProvidedResources();
+    services.getProvidedResources().push_back({"FrontendResources",frontend_resources});
+
     // distribute registered resources among registered services.
     const bool resources_ok = services.assignRequestedResources();
     // for each service we call their resource callbacks here:
@@ -223,7 +232,6 @@ int main(const int argc, const char** argv) {
         run_megamol = false;
     }
 
-    auto frontend_resources = services.getProvidedResources();
     bool graph_resources_ok = graph.AddFrontendResources(frontend_resources);
     if (!graph_resources_ok) {
         log_error("Graph did not get resources he needs from frontend. Abort.");

--- a/frontend/resources/include/ImagePresentationEntryPoints.h
+++ b/frontend/resources/include/ImagePresentationEntryPoints.h
@@ -1,0 +1,23 @@
+/*
+ * ImagePresentationEntryPoints.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace megamol {
+namespace frontend_resources {
+
+struct ImagePresentationEntryPoints {
+    std::function<bool(std::string, void*)> add_entry_point;
+    std::function<bool(std::string)> remove_entry_point;
+    std::function<bool(std::string, std::string)> rename_entry_point;
+    std::function<void()> clear_entry_points;
+};
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/resources/include/ImageWrapper.h
+++ b/frontend/resources/include/ImageWrapper.h
@@ -1,0 +1,77 @@
+/*
+ * ImageWrapper.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <string>
+#include <optional>
+#include <functional>
+
+namespace megamol {
+namespace frontend_resources {
+
+enum class WrappedImageType {
+    GLTexureHandle, // void* holds a GL texture handle
+    ByteArray       // void* holds a pointer to std::vector<byte>
+};
+
+// the idea is that each AbstractView (via the concrete View implementation)
+// fills an ImageWrapper for the frontend to use.
+// depending on the WrappedImageType and DataChannels the frontend knows
+// what it can do with each wrapped image
+//   - either use the contained texture directly for GL rendering
+//   - or forward the contained byte data to interested sources: show in window, write to screenshot file, send via network...
+// the ImageWrapper does not own the wrapped image, it acts more like a generic reference wrapper for GL or byte array images
+//
+// we expect the lifetime of an ImageWrapper instance to span from beeing returned by a view.Render() call to being presented to the user
+// thus, an ImageWrapper does not reference its wrapped texture data for longer than a frame
+struct ImageWrapper {
+
+    enum class DataChannels {
+        // for texture and byte array, tells us how many channels there are
+        RGB8,
+        RGBA8,
+    };
+    struct ImageSize {
+        size_t width = 0;
+        size_t height = 0;
+    };
+
+    ImageWrapper(ImageSize size, DataChannels channels, WrappedImageType type, const void* data);
+    ImageWrapper(std::string const& name);
+    ImageWrapper() = default;
+
+    WrappedImageType type       = WrappedImageType::ByteArray;
+    ImageSize        size       = {0, 0};
+    DataChannels     channels   = DataChannels::RGBA8;
+
+    void* referenced_image_handle = nullptr;
+
+    size_t channels_count() const;
+
+    std::string name = "";
+};
+
+template <WrappedImageType>
+ImageWrapper wrap_image(ImageWrapper::ImageSize size, const void* data = nullptr, ImageWrapper::DataChannels channels = ImageWrapper::DataChannels::RGBA8);
+
+template <>
+ImageWrapper wrap_image<WrappedImageType::GLTexureHandle>(ImageWrapper::ImageSize size, const void* data, ImageWrapper::DataChannels channels);
+template <>
+ImageWrapper wrap_image<WrappedImageType::ByteArray>(ImageWrapper::ImageSize size, const void* data, ImageWrapper::DataChannels channels);
+
+ImageWrapper wrap_image(ImageWrapper::ImageSize size, unsigned int gl_texture_handle, ImageWrapper::DataChannels channels);
+
+ImageWrapper wrap_image(ImageWrapper::ImageSize size, std::vector<unsigned char> const& byte_texture, ImageWrapper::DataChannels channels);
+
+size_t channels_count(ImageWrapper::DataChannels channels);
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/resources/src/ImageWrapper.cpp
+++ b/frontend/resources/src/ImageWrapper.cpp
@@ -1,0 +1,78 @@
+/*
+ * ImageWrapper.cpp
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+
+#include "ImageWrapper.h"
+
+#include <algorithm>
+#include <list>
+
+using namespace megamol::frontend_resources;
+
+ImageWrapper::ImageWrapper(ImageSize size, DataChannels channels, WrappedImageType type, const void* data)
+    : size{size}
+    , channels{channels}
+    , type{type}
+{
+    referenced_image_handle = const_cast<void*>(data);
+}
+
+ImageWrapper::ImageWrapper(std::string const& name)
+    : name{name}
+{}
+
+size_t ImageWrapper::channels_count() const {
+    return megamol::frontend_resources::channels_count(channels);
+}
+
+template <>
+ImageWrapper megamol::frontend_resources::wrap_image<WrappedImageType::GLTexureHandle>(
+    ImageWrapper::ImageSize size,
+    const void* data,
+    ImageWrapper::DataChannels channels)
+{
+    return ImageWrapper(size, channels, WrappedImageType::GLTexureHandle, data);
+}
+
+template <>
+ImageWrapper megamol::frontend_resources::wrap_image<WrappedImageType::ByteArray>(
+    ImageWrapper::ImageSize size,
+    const void* data,
+    ImageWrapper::DataChannels channels)
+{
+    return ImageWrapper(size, channels, WrappedImageType::ByteArray, data);
+}
+
+ImageWrapper megamol::frontend_resources::wrap_image(
+    ImageWrapper::ImageSize size,
+    unsigned int gl_texture_handle,
+    ImageWrapper::DataChannels channels)
+{
+    return wrap_image<WrappedImageType::GLTexureHandle>(size, reinterpret_cast<void*>(gl_texture_handle), channels);
+}
+
+ImageWrapper megamol::frontend_resources::wrap_image(
+    ImageWrapper::ImageSize size,
+    std::vector<unsigned char> const& byte_texture,
+    ImageWrapper::DataChannels channels)
+{
+    return wrap_image<WrappedImageType::ByteArray>(size, &byte_texture, channels);
+}
+
+size_t megamol::frontend_resources::channels_count(ImageWrapper::DataChannels channels) {
+    switch (channels) {
+    case ImageWrapper::DataChannels::RGB8:
+        return 3;
+        break;
+    case ImageWrapper::DataChannels::RGBA8:
+        return 4;
+        break;
+    default:
+        return 0;
+    }
+}
+

--- a/frontend/services/CMakeLists.txt
+++ b/frontend/services/CMakeLists.txt
@@ -15,15 +15,51 @@ if(BUILD_FRONTEND_SERVICES)
   # afterwards list the dependencies.
   #set(DEP_LIST "${DEP_LIST};BUILD_MMSTD_DATATOOLS_PLUGIN BUILD_CORE" CACHE INTERNAL "")
 
-  file(GLOB_RECURSE header_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "include/*.h" "include/*.hpp" "cuda/*h" "cuda/*hpp" "opengl_glfw/*.h"  "opengl_glfw/*.hpp" "service_collection/*.hpp" "gui/*.hpp" "lua_service_wrapper/*.hpp" "screenshot_service/*.hpp" "framestatistics_service/*.hpp" "project_loader/*.hpp")
-  file(GLOB_RECURSE source_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "cuda/*cpp" "opengl_glfw/*.cpp" "service_collection/*.cpp" "gui/*.cpp" "lua_service_wrapper/*.cpp" "screenshot_service/*.cpp" "framestatistics_service/*.cpp" "project_loader/*.cpp")
+  file(GLOB_RECURSE header_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "include/*.h"
+    "include/*.hpp"
+    "cuda/*h"
+    "cuda/*hpp"
+    "opengl_glfw/*.h"
+    "opengl_glfw/*.hpp"
+    "service_collection/*.hpp"
+    "gui/*.hpp"
+    "lua_service_wrapper/*.hpp"
+    "screenshot_service/*.hpp"
+    "framestatistics_service/*.hpp"
+    "project_loader/*.hpp"
+#   "service_template/*.hpp"
+    )
+  file(GLOB_RECURSE source_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "cuda/*cpp"
+    "opengl_glfw/*.cpp"
+    "service_collection/*.cpp"
+    "gui/*.cpp"
+    "lua_service_wrapper/*.cpp"
+    "screenshot_service/*.cpp"
+    "framestatistics_service/*.cpp"
+    "project_loader/*.cpp"
+#   "service_template/*.cpp"
+    )
 
   # Add target
   add_library(${PROJECT_NAME} STATIC ${header_files} ${source_files})
   set_target_properties(${PROJECT_NAME}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
     OUTPUT_NAME ${PROJECT_NAME})
-  target_include_directories(${PROJECT_NAME} PUBLIC "cuda" "opengl_glfw" "include" "service_collection" "gui" "lua_service_wrapper" "screenshot_service" "framestatistics_service" "project_loader")
+
+  target_include_directories(${PROJECT_NAME} PUBLIC
+    "include"
+    "cuda"
+    "opengl_glfw"
+    "service_collection"
+    "gui"
+    "lua_service_wrapper"
+    "screenshot_service"
+    "framestatistics_service"
+    "project_loader"
+#   "service_template"
+    )
 
   add_library(abstract_frontend_service INTERFACE)
   target_include_directories(abstract_frontend_service INTERFACE

--- a/frontend/services/CMakeLists.txt
+++ b/frontend/services/CMakeLists.txt
@@ -28,6 +28,7 @@ if(BUILD_FRONTEND_SERVICES)
     "screenshot_service/*.hpp"
     "framestatistics_service/*.hpp"
     "project_loader/*.hpp"
+    "image_presentation/*.hpp"
 #   "service_template/*.hpp"
     )
   file(GLOB_RECURSE source_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -39,6 +40,7 @@ if(BUILD_FRONTEND_SERVICES)
     "screenshot_service/*.cpp"
     "framestatistics_service/*.cpp"
     "project_loader/*.cpp"
+    "image_presentation/*.cpp"
 #   "service_template/*.cpp"
     )
 
@@ -58,6 +60,7 @@ if(BUILD_FRONTEND_SERVICES)
     "screenshot_service"
     "framestatistics_service"
     "project_loader"
+    "image_presentation"
 #   "service_template"
     )
 

--- a/frontend/services/gui/GUI_Service.cpp
+++ b/frontend/services/gui/GUI_Service.cpp
@@ -43,7 +43,6 @@ bool GUI_Service::init(const Config& config) {
     this->m_time = 0.0;
     this->m_framebuffer_size = glm::vec2(1.0f, 1.0f);
     this->m_window_size = glm::vec2(1.0f, 1.0f);
-    this->m_opengl_context_ptr = nullptr;
     this->m_megamol_graph = nullptr;
     this->m_gui = nullptr;
 
@@ -203,8 +202,8 @@ void GUI_Service::digestChangedRequestedResources() {
     const_cast<megamol::frontend_resources::MouseEvents*>(mouse_events)->buttons_events = pass_mouse_btn_events;
 
     /// IOpenGL_Context = resource index 4
-    this->m_opengl_context_ptr =
-        &this->m_requestedResourceReferences[4].getResource<megamol::frontend_resources::IOpenGL_Context>();
+    // IOpenGL_Context resource is not actively used, requesting IOpenGL_Context makes sure there is a GL context present and active.
+    //    this->m_requestedResourceReferences[4].getResource<megamol::frontend_resources::IOpenGL_Context>();
 
     /// FramebufferEvents = resource index 5
     auto framebuffer_events =
@@ -260,30 +259,22 @@ void GUI_Service::preGraphRender() {
     if (is_gui_nullptr) return;
     auto gui = this->m_gui->Get();
 
-    if (this->m_opengl_context_ptr) {
-        this->m_opengl_context_ptr->activate();
-
-        if (this->m_megamol_graph != nullptr) {
-            // Requires enabled OpenGL context, e.g. for textures used in parameters
-            gui->SynchronizeGraphs(this->m_megamol_graph);
-        }
-
-        gui->PreDraw(this->m_framebuffer_size, this->m_window_size, this->m_time);
-        this->m_opengl_context_ptr->close();
+    if (this->m_megamol_graph != nullptr) {
+        // Requires enabled OpenGL context, e.g. for textures used in parameters
+        gui->SynchronizeGraphs(this->m_megamol_graph);
     }
+
+    gui->PreDraw(this->m_framebuffer_size, this->m_window_size, this->m_time);
 }
 
 
 void GUI_Service::postGraphRender() {
 
     if (is_gui_nullptr) return;
+
     auto gui = this->m_gui->Get();
 
-    if (this->m_opengl_context_ptr) {
-        this->m_opengl_context_ptr->activate();
-        gui->PostDraw();
-        this->m_opengl_context_ptr->close();
-    }
+    gui->PostDraw();
 }
 
 

--- a/frontend/services/gui/GUI_Service.hpp
+++ b/frontend/services/gui/GUI_Service.hpp
@@ -75,7 +75,6 @@ private:
     glm::vec2 m_framebuffer_size;
     glm::vec2 m_window_size;
     megamol::core::MegaMolGraph* m_megamol_graph;
-    megamol::frontend_resources::IOpenGL_Context const* m_opengl_context_ptr;
     std::shared_ptr<megamol::gui::GUIWrapper> m_gui = nullptr;
     std::vector<std::string> m_queuedProjectFiles;
 

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -1,0 +1,220 @@
+/*
+ * ImagePresentation_Service.cpp
+ *
+ * Copyright (C) 2021 by MegaMol Team
+ * Alle Rechte vorbehalten.
+ */
+
+// search/replace ImagePresentation_Service with your class name
+// you should also delete the FAQ comments in these template files after you read and understood them
+#include "ImagePresentation_Service.hpp"
+
+
+#include "mmcore/view/AbstractView_EventConsumption.h"
+
+// local logging wrapper for your convenience until central MegaMol logger established
+#include "mmcore/utility/log/Log.h"
+
+static const std::string service_name = "ImagePresentation_Service: ";
+static void log(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteInfo(msg.c_str());
+}
+
+static void log_error(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
+}
+
+static void log_warning(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
+}
+
+namespace megamol {
+namespace frontend {
+
+ImagePresentation_Service::ImagePresentation_Service() {
+    // init members to default states
+}
+
+ImagePresentation_Service::~ImagePresentation_Service() {
+    // clean up raw pointers you allocated with new, which is bad practice and nobody does 
+}
+
+bool ImagePresentation_Service::init(void* configPtr) {
+    if (configPtr == nullptr)
+        return false;
+
+    return init(*static_cast<Config*>(configPtr));
+}
+
+bool ImagePresentation_Service::init(const Config& config) {
+
+    m_entry_points_registry_resource.add_entry_point =    [&](std::string name, void* module_raw_ptr)   -> bool { return add_entry_point(name, module_raw_ptr); };
+    m_entry_points_registry_resource.remove_entry_point = [&](std::string name)                         -> bool { return remove_entry_point(name); };
+    m_entry_points_registry_resource.rename_entry_point = [&](std::string oldName, std::string newName) -> bool { return rename_entry_point(oldName, newName); };
+    m_entry_points_registry_resource.clear_entry_points = [&]() { clear_entry_points(); };
+
+    this->m_providedResourceReferences =
+    {
+          {"ImagePresentationEntryPoints", m_entry_points_registry_resource} // used by MegaMolGraph to set entry points
+    };
+
+    this->m_requestedResourcesNames =
+    {
+          "FrontendResources" // std::vector<FrontendResource>
+    };
+
+    log("initialized successfully");
+    return true;
+}
+
+void ImagePresentation_Service::close() {
+}
+
+std::vector<FrontendResource>& ImagePresentation_Service::getProvidedResources() {
+    return m_providedResourceReferences;
+}
+
+const std::vector<std::string> ImagePresentation_Service::getRequestedResourceNames() const {
+    return m_requestedResourcesNames;
+}
+
+void ImagePresentation_Service::setRequestedResources(std::vector<FrontendResource> resources) {
+    this->m_requestedResourceReferences = resources;
+
+    m_frontend_resources_ptr = & m_requestedResourceReferences[0].getResource<std::vector<megamol::frontend::FrontendResource>>();
+}
+#define m_frontend_resources (*m_frontend_resources_ptr)
+
+void ImagePresentation_Service::updateProvidedResources() {
+}
+
+void ImagePresentation_Service::digestChangedRequestedResources() {
+
+}
+
+void ImagePresentation_Service::resetProvidedResources() {
+}
+
+void ImagePresentation_Service::preGraphRender() {
+}
+
+void ImagePresentation_Service::postGraphRender() {
+}
+
+void ImagePresentation_Service::RenderNextFrame() {
+    for (auto& entry : m_entry_points) {
+        entry.execute(entry.modulePtr, entry.entry_point_resources);
+    }
+}
+
+// clang-format off
+using FrontendResource = megamol::frontend::FrontendResource;
+using EntryPointExecutionCallback = megamol::frontend::ImagePresentation_Service::EntryPointExecutionCallback;
+
+using EntryPointInitFunctions =
+std::tuple<
+    // rendering execution function
+    EntryPointExecutionCallback,
+    // set inital state function
+    EntryPointExecutionCallback,
+    // get requested resources function
+    std::function<std::vector<std::string>()>
+>;
+// clang-format on
+static EntryPointInitFunctions get_init_execute_resources(void* ptr) {
+    if (auto module_ptr = static_cast<megamol::core::Module*>(ptr); module_ptr != nullptr) {
+        if (auto view_ptr = dynamic_cast<megamol::core::view::AbstractView*>(module_ptr); view_ptr != nullptr) {
+            return EntryPointInitFunctions{
+                std::function{megamol::core::view::view_rendering_execution},
+                std::function{megamol::core::view::view_init_rendering_state},
+                std::function{megamol::core::view::get_gl_view_runtime_resources_requests}
+            };
+        }
+    }
+
+    log_error("Fatal Error setting Graph Entry Point callback functions. Unknown Entry Point type.");
+    throw std::exception();
+}
+
+std::vector<FrontendResource> ImagePresentation_Service::map_resources(std::vector<std::string> const& requests) {
+    std::vector<FrontendResource> result;
+
+    for (auto& request: requests) {
+        auto find_it = std::find_if(m_frontend_resources.begin(), m_frontend_resources.end(),
+            [&](FrontendResource const& resource) { return resource.getIdentifier() == request; });
+        bool found_request = find_it != m_frontend_resources.end();
+
+
+        if (!found_request) {
+            log_error("could not find requested resource " + request);
+            return {};
+        }
+
+        result.push_back(*find_it);
+    }
+
+    return result;
+}
+
+bool ImagePresentation_Service::add_entry_point(std::string name, void* module_raw_ptr) {
+
+    auto [execute_etry, init_entry, entry_resource_requests] = get_init_execute_resources(module_raw_ptr);
+
+    auto resource_requests = entry_resource_requests();
+    auto resources = map_resources(resource_requests);
+
+    if (resources.empty() && !resource_requests.empty()) {
+        log_error("could not assign resources requested by entry point " + name + ". Entry point not created.");
+        return false;
+    }
+
+    m_entry_points.push_back(GraphEntryPoint{
+        name,
+        module_raw_ptr,
+        resources,
+        execute_etry,
+        });
+
+    auto& entry_point = m_entry_points.back();
+
+    if (!init_entry(entry_point.modulePtr, entry_point.entry_point_resources)) {
+        log_error("init function for entry point " + entry_point.moduleName + " failed. Entry point not created.");
+        m_entry_points.pop_back();
+        return false;
+    }
+
+    return true;
+}
+
+bool ImagePresentation_Service::remove_entry_point(std::string name) {
+
+    m_entry_points.remove_if([&](auto& entry) { return entry.moduleName == name; });
+
+    return true;
+}
+
+bool ImagePresentation_Service::rename_entry_point(std::string oldName, std::string newName) {
+
+    auto entry_it = std::find_if(m_entry_points.begin(), m_entry_points.end(),
+        [&](auto& entry) { return entry.moduleName == oldName; });
+
+    if (entry_it == m_entry_points.end()) {
+        return false;
+    }
+
+    entry_it->moduleName = newName;
+
+    return true;
+}
+
+bool ImagePresentation_Service::clear_entry_points() {
+    m_entry_points.clear();
+
+    return true;
+}
+
+} // namespace frontend
+} // namespace megamol

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -106,7 +106,7 @@ void ImagePresentation_Service::postGraphRender() {
 
 void ImagePresentation_Service::RenderNextFrame() {
     for (auto& entry : m_entry_points) {
-        entry.execute(entry.modulePtr, entry.entry_point_resources);
+        entry.execute(entry.modulePtr, entry.entry_point_resources, entry.execution_result_image.get());
     }
 }
 
@@ -160,6 +160,8 @@ std::vector<FrontendResource> ImagePresentation_Service::map_resources(std::vect
 }
 
 bool ImagePresentation_Service::add_entry_point(std::string name, void* module_raw_ptr) {
+    m_wrapped_images.push_back({name});
+    auto& image = m_wrapped_images.back();
 
     auto [execute_etry, init_entry, entry_resource_requests] = get_init_execute_resources(module_raw_ptr);
 
@@ -176,11 +178,12 @@ bool ImagePresentation_Service::add_entry_point(std::string name, void* module_r
         module_raw_ptr,
         resources,
         execute_etry,
+        image
         });
 
     auto& entry_point = m_entry_points.back();
 
-    if (!init_entry(entry_point.modulePtr, entry_point.entry_point_resources)) {
+    if (!init_entry(entry_point.modulePtr, entry_point.entry_point_resources, entry_point.execution_result_image)) {
         log_error("init function for entry point " + entry_point.moduleName + " failed. Entry point not created.");
         m_entry_points.pop_back();
         return false;

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -10,6 +10,7 @@
 #include "AbstractFrontendService.hpp"
 
 #include "ImagePresentationEntryPoints.h"
+#include "ImageWrapper.h"
 
 #include <list>
 
@@ -51,10 +52,12 @@ public:
     // bool shouldShutdown() const; // shutdown initially false
     // void setShutdown(const bool s = true);
 
+    using ImageWrapper = megamol::frontend_resources::ImageWrapper;
     using EntryPointExecutionCallback =
         std::function<bool(
               void*
             , std::vector<megamol::frontend::FrontendResource> const&
+            , ImageWrapper&
             )>;
 
 private:
@@ -75,6 +78,7 @@ private:
         std::vector<megamol::frontend::FrontendResource> entry_point_resources;
 
         EntryPointExecutionCallback execute;
+        std::reference_wrapper<ImageWrapper> execution_result_image;
     };
     std::list<GraphEntryPoint> m_entry_points;
 
@@ -82,6 +86,8 @@ private:
     bool remove_entry_point(std::string name);
     bool rename_entry_point(std::string oldName, std::string newName);
     bool clear_entry_points();
+
+    std::list<ImageWrapper> m_wrapped_images;
 
     std::vector<megamol::frontend::FrontendResource> map_resources(std::vector<std::string> const& requests);
     const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -1,0 +1,92 @@
+/*
+ * ImagePresentation_Service.hpp
+ *
+ * Copyright (C) 2021 by MegaMol Team
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include "AbstractFrontendService.hpp"
+
+#include "ImagePresentationEntryPoints.h"
+
+#include <list>
+
+namespace megamol {
+namespace frontend {
+
+class ImagePresentation_Service final : public AbstractFrontendService {
+public:
+
+    struct Config {
+    };
+
+    std::string serviceName() const override { return "ImagePresentation_Service"; }
+
+    ImagePresentation_Service();
+    ~ImagePresentation_Service();
+
+    bool init(const Config& config);
+    bool init(void* configPtr) override;
+    void close() override;
+
+    std::vector<FrontendResource>& getProvidedResources() override;
+    const std::vector<std::string> getRequestedResourceNames() const override;
+    void setRequestedResources(std::vector<FrontendResource> resources) override;
+
+    void updateProvidedResources() override;
+    void digestChangedRequestedResources() override;
+    void resetProvidedResources() override;
+    void preGraphRender() override;
+    void postGraphRender() override;
+
+    // the Image Presentation Service is special in that it manages the objects (Graph Entry Points, or possibly other objects)
+    // that are triggered to render something into images.
+    // The resulting images are then presented in some appropriate way: drawn into a window, written to disk, sent via network, ...
+    void RenderNextFrame();
+    // int setPriority(const int p) // priority initially 0
+    // int getPriority() const;
+    //
+    // bool shouldShutdown() const; // shutdown initially false
+    // void setShutdown(const bool s = true);
+
+    using EntryPointExecutionCallback =
+        std::function<bool(
+              void*
+            , std::vector<megamol::frontend::FrontendResource> const&
+            )>;
+
+private:
+
+    std::vector<FrontendResource> m_providedResourceReferences;
+    std::vector<std::string> m_requestedResourcesNames;
+    std::vector<FrontendResource> m_requestedResourceReferences;
+
+    // for each View in the MegaMol graph we create a GraphEntryPoint with corresponding callback for resource/input consumption
+    // the ImagePresentation Service makes sure that the (lifetime and rendering) resources/dependencies requested by the module
+    // are satisfied, which means that the execute() callback for the entry point is provided the requested
+    // dependencies/resources for rendering
+    megamol::frontend_resources::ImagePresentationEntryPoints m_entry_points_registry_resource; // resorce to add/remove entry points
+
+    struct GraphEntryPoint {
+        std::string moduleName;
+        void* modulePtr = nullptr;
+        std::vector<megamol::frontend::FrontendResource> entry_point_resources;
+
+        EntryPointExecutionCallback execute;
+    };
+    std::list<GraphEntryPoint> m_entry_points;
+
+    bool add_entry_point(std::string name, void* module_raw_ptr);
+    bool remove_entry_point(std::string name);
+    bool rename_entry_point(std::string oldName, std::string newName);
+    bool clear_entry_points();
+
+    std::vector<megamol::frontend::FrontendResource> map_resources(std::vector<std::string> const& requests);
+    const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;
+
+};
+
+} // namespace frontend
+} // namespace megamol

--- a/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
+++ b/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
@@ -18,8 +18,6 @@
 #include "GUIState.h"
 #include "GlobalValueStore.h"
 
-#include "mmcore/view/AbstractView_EventConsumption.h"
-
 // local logging wrapper for your convenience until central MegaMol logger established
 #include "mmcore/utility/log/Log.h"
 static void log(const char* text) {
@@ -434,11 +432,7 @@ void Lua_Service_Wrapper::fill_graph_manipulation_callbacks(void* callbacks_coll
                 return Error{"graph could not create module for: " + baseName + " , " + className + " , " + instanceName};
             }
 
-            if (!graph.SetGraphEntryPoint(
-                instanceName,
-                megamol::core::view::get_gl_view_runtime_resources_requests(),
-                megamol::core::view::view_rendering_execution,
-                megamol::core::view::view_init_rendering_state))
+            if (!graph.SetGraphEntryPoint(instanceName))
             {
                 return Error{"graph could not set graph entry point for: " + baseName + " , " + className + " , " + instanceName};
             }

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -32,19 +32,25 @@
 #    endif
 #endif
 
-#include "mmcore/utility/log/Log.h"
-
 #include <functional>
 #include <iostream>
 
+#include "mmcore/utility/log/Log.h"
+
+static const std::string service_name = "OpenGL_GLFW_Service: ";
 static void log(std::string const& text) {
-    const std::string msg = "OpenGL_GLFW_Service: " + text;
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteInfo(msg.c_str());
 }
 
 static void log_error(std::string const& text) {
-    const std::string msg = "OpenGL_GLFW_Service: " + text;
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
+}
+
+static void log_warning(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
 }
 
 // See: https://github.com/glfw/glfw/issues/1630

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -504,6 +504,10 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
         {"WindowManipulation", m_windowManipulation}
     };
 
+    m_requestedResourcesNames = {
+          "FrameStatistics"
+    };
+
     m_pimpl->last_time = std::chrono::system_clock::now();
 
     log("initialized successfully");
@@ -715,10 +719,12 @@ std::vector<FrontendResource>& OpenGL_GLFW_Service::getProvidedResources() {
 }
 
 const std::vector<std::string> OpenGL_GLFW_Service::getRequestedResourceNames() const {
-    return {"FrameStatistics"};
+    return m_requestedResourcesNames;
 }
 
 void OpenGL_GLFW_Service::setRequestedResources(std::vector<FrontendResource> resources) {
+    m_requestedResourceReferences = resources;
+
     m_pimpl->frame_statistics = &const_cast<megamol::frontend_resources::FrameStatistics&>(resources[0].getResource<megamol::frontend_resources::FrameStatistics>());
 }
 

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.hpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.hpp
@@ -136,6 +136,8 @@ private:
     // this holds references to the event structs we fill. the events are passed to the renderers/views using
     // const std::vector<FrontendResource>& getModuleResources() override
     std::vector<FrontendResource> m_renderResourceReferences;
+    std::vector<std::string> m_requestedResourcesNames;
+    std::vector<FrontendResource> m_requestedResourceReferences;
 };
 
 } // namespace frontend

--- a/frontend/services/project_loader/ProjectLoader_Service.hpp
+++ b/frontend/services/project_loader/ProjectLoader_Service.hpp
@@ -52,6 +52,8 @@ private:
     std::vector<FrontendResource> m_providedResourceReferences;
     std::vector<std::string> m_requestedResourcesNames;
     std::vector<FrontendResource> m_requestedResourceReferences;
+
+    bool m_digestion_recursion = false;
 };
 
 } // namespace frontend

--- a/frontend/services/screenshot_service/Screenshot_Service.cpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.cpp
@@ -18,14 +18,23 @@
 #include "mmcore/utility/graphics/ScreenShotComments.h"
 #include "vislib/sys/FastFile.h"
 
-
-// local logging wrapper for your convenience
 #include "mmcore/utility/log/Log.h"
-static void log(const char* text) {
-    const std::string msg = "Screenshot_Service: " + std::string(text);
+
+static const std::string service_name = "Screenshot_Service: ";
+static void log(std::string const& text) {
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteInfo(msg.c_str());
 }
-static void log(std::string text) { log(text.c_str()); }
+
+static void log_error(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
+}
+
+static void log_warning(std::string const& text) {
+    const std::string msg = service_name + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
+}
 
 // need this to pass GL context to screenshot source. this a hack and needs to be properly designed.
 static megamol::core::MegaMolGraph* megamolgraph_ptr = nullptr;

--- a/frontend/services/screenshot_service/Screenshot_Service.cpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.cpp
@@ -9,7 +9,6 @@
 
  // to grab GL front buffer
 #include <glad/glad.h>
-#include "IOpenGL_Context.h"
 #include "GUIState.h"
 
 #include "mmcore/MegaMolGraph.h"
@@ -29,7 +28,6 @@ static void log(const char* text) {
 static void log(std::string text) { log(text.c_str()); }
 
 // need this to pass GL context to screenshot source. this a hack and needs to be properly designed.
-static megamol::frontend_resources::IOpenGL_Context* gl_context_ptr = nullptr;
 static megamol::core::MegaMolGraph* megamolgraph_ptr = nullptr;
 static megamol::frontend_resources::GUIState* guistate_resources_ptr = nullptr;
 
@@ -129,9 +127,6 @@ void megamol::frontend_resources::GLScreenshotSource::set_read_buffer(ReadBuffer
 }
 
 megamol::frontend_resources::ImageData megamol::frontend_resources::GLScreenshotSource::take_screenshot() const {
-    if (gl_context_ptr)
-        gl_context_ptr->activate();
-
     // TODO: in FBO-based rendering the FBO object carries its size and we dont need to look it up
     // simpler and more correct approach would be to observe Framebuffer_Events resource
     // but this is our naive implementation for now
@@ -148,9 +143,6 @@ megamol::frontend_resources::ImageData megamol::frontend_resources::GLScreenshot
 
     for (auto& pixel : result.image)
         pixel.a = 255;
-
-    if (gl_context_ptr)
-        gl_context_ptr->close();
 
     return std::move(result);
 }
@@ -213,7 +205,6 @@ const std::vector<std::string> Screenshot_Service::getRequestedResourceNames() c
 }
 
 void Screenshot_Service::setRequestedResources(std::vector<FrontendResource> resources) {
-    gl_context_ptr = const_cast<megamol::frontend_resources::IOpenGL_Context*>(&resources[0].getResource<megamol::frontend_resources::IOpenGL_Context>());
     megamolgraph_ptr = const_cast<megamol::core::MegaMolGraph*>(&resources[1].getResource<megamol::core::MegaMolGraph>());
     guistate_resources_ptr = const_cast<megamol::frontend_resources::GUIState*>(&resources[2].getResource<megamol::frontend_resources::GUIState>());
 }

--- a/frontend/services/screenshot_service/Screenshot_Service.hpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.hpp
@@ -15,9 +15,6 @@
 namespace megamol {
 namespace frontend {
 
-// for detailed service API documentation see Template_Service.{hpp,cpp}
-// 
-// 
 class Screenshot_Service final : public AbstractFrontendService {
 public:
 

--- a/frontend/services/service_collection/FrontendServiceCollection.cpp
+++ b/frontend/services/service_collection/FrontendServiceCollection.cpp
@@ -11,11 +11,21 @@
 #include <iostream>
 
 #include "mmcore/utility/log/Log.h"
-static void log(const char* text) {
-    const std::string msg = "FrontendServiceCollection: " + std::string(text) + "\n";
+
+static void log(std::string const& text) {
+    const std::string msg = "FrontendServiceCollection: " + text;
     megamol::core::utility::log::Log::DefaultLog.WriteInfo(msg.c_str());
 }
-static void log(std::string text) { log(text.c_str()); }
+
+static void log_error(std::string const& text) {
+    const std::string msg = "FrontendServiceCollection: " + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
+}
+
+static void log_warning(std::string const& text) {
+    const std::string msg = "FrontendServiceCollection: " + text;
+    megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
+}
 
 namespace megamol {
 namespace frontend {
@@ -36,7 +46,7 @@ namespace frontend {
     bool FrontendServiceCollection::init() {
         for_each_service {
             if (!service.service->init(service.service_config)) {
-                log(service.service->serviceName() + " failed init");
+                log_error(service.service->serviceName() + " failed init");
                 return false;
             }
         }
@@ -82,7 +92,7 @@ namespace frontend {
                     resources.push_back(*modulePtr);
                 } else {
                     // if a requested resource can not be found we fail and should stop program execution
-                    std::cout << "could not find resource: " << name << " for service: " << service.get().serviceName() << std::endl;
+                    log_error("could not find resource: \"" + name + "\" for service: " + service.get().serviceName());
                     return false;
                 }
             }

--- a/frontend/services/service_template/Template_Service.cpp
+++ b/frontend/services/service_template/Template_Service.cpp
@@ -13,18 +13,19 @@
 // local logging wrapper for your convenience until central MegaMol logger established
 #include "mmcore/utility/log/Log.h"
 
+static const std::string service_name = "Template_Service: ";
 static void log(std::string const& text) {
-    const std::string msg = "Template_Service: " + text;
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteInfo(msg.c_str());
 }
 
 static void log_error(std::string const& text) {
-    const std::string msg = "Template_Service: " + text;
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
 }
 
 static void log_warning(std::string const& text) {
-    const std::string msg = "Template_Service: " + text;
+    const std::string msg = service_name + text;
     megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
 }
 

--- a/frontend/services/service_template/Template_Service.hpp
+++ b/frontend/services/service_template/Template_Service.hpp
@@ -115,7 +115,7 @@ public:
     void resetProvidedResources() override;
 
     // gets called before graph rendering, you may prepare rendering with some API, e.g. set frame-timers, etc
-    void preGraphRender() override;  
+    void preGraphRender() override;
     // clean up after rendering, e.g. render gui over graph rendering, stop and show frame-timers in GLFW window, swap buffers, glClear for next framebuffer
     void postGraphRender() override;
 

--- a/plugins/gui/src/GUIWindows.cpp
+++ b/plugins/gui/src/GUIWindows.cpp
@@ -962,9 +962,7 @@ bool megamol::gui::GUIWindows::SynchronizeGraphs(megamol::core::MegaMolGraph* me
             } break;
             case (Graph::QueueAction::CREATE_GRAPH_ENTRY): {
                 if (megamol_graph != nullptr) {
-                    megamol_graph->SetGraphEntryPoint(data.name_id,
-                        megamol::core::view::get_gl_view_runtime_resources_requests(),
-                        megamol::core::view::view_rendering_execution, megamol::core::view::view_init_rendering_state);
+                    megamol_graph->SetGraphEntryPoint(data.name_id);
                 } else if ((this->core_instance != nullptr) &&
                            core_instance->IsmmconsoleFrontendCompatible()) { /// mmconsole
                     /* XXX Currently not supported by core graph

--- a/plugins/gui/src/GUIWindows.h
+++ b/plugins/gui/src/GUIWindows.h
@@ -39,7 +39,6 @@
 #include "mmcore/utility/ResourceWrapper.h"
 #include "mmcore/utility/graphics/ScreenShotComments.h"
 #include "mmcore/versioninfo.h"
-#include "mmcore/view/AbstractView_EventConsumption.h"
 
 #include "vislib/math/Rectangle.h"
 


### PR DESCRIPTION
Refactoring of PR #755. Depends on PR #775.
The start of this PR is commit 9c27a01 "add ImagePresentation Service: pokes rendering of graph entry points"

* Reorganize management of Graph Entry Points in Frontend around ImagePresentation Service - collects rendering results from views in textures
* Proof of Concept: View3DGL and View2DGL output rendering result as `ImageWrapper` object to ImagePresentation Service
* Depends on PR #748
* Prepares frontend for PR #744 

## Summary of Changes
Pull MegaMolGraph Entry Points into separate Service - the Image Presentation -, give each Graph Entry Point a Texture that the corresponding View writes rendering results into.
This enables rendering and screenshots independent of GLFW Window size and will be implemented in a later PR. In the long term, enables sophisticated Split-View like layouting of View results in the ImGui or using some other layouting mechanism. 

## References and Context
Depends on refactoring of all relevant Views to export their FBO. The Frontend<->View interface minimizes data copying by simply wrapping the texture object of the view using a `ImageWrapper` object, which takes a non-owning reference to the wrapped texture. Currently, only View3DGL and View2DGL are hooked into the frontend image mechanism, but connecting more views should not be too difficult (see `GetRenderingResult()` in `AbstractView.h`, `View3DGL.h` and `View2DGL.h`).

The frontend images are designed as zero-copy wrappers (`ImageWrapper`) and are able to generalize over Views that render images into CPU Buffers and into OpenGL Textures. 

## Test Instructions
Not immediately testable since this PR provides infrastructure for the Camera redesign. Make sure that all your important projects load and render correctly.
