### PR TITLE
Frontend 3: Pull Screenshots from Entry Points

### DIFF
--- a/frontend/resources/include/Screenshots.h
+++ b/frontend/resources/include/Screenshots.h
@@ -13,7 +13,7 @@
 namespace megamol {
 namespace frontend_resources {
 
-struct ImageData {
+struct ScreenshotImageData {
     struct Pixel {
         std::uint8_t r = 255;
         std::uint8_t g = 0;
@@ -50,7 +50,7 @@ struct ImageData {
 
 class IScreenshotSource {
 public:
-    virtual ImageData take_screenshot() const = 0;
+    virtual ScreenshotImageData const& take_screenshot() const = 0;
 
     ~IScreenshotSource() = default;
 };
@@ -58,10 +58,10 @@ public:
 class IImageDataWriter {
 public:
     bool write_screenshot(IScreenshotSource const& image_source, std::filesystem::path const& filename) const {
-        return this->write_image(std::move(image_source.take_screenshot()), filename);
+        return this->write_image(image_source.take_screenshot(), filename);
     }
 
-    virtual bool write_image(ImageData image, std::filesystem::path const& filename) const = 0;
+    virtual bool write_image(ScreenshotImageData const& image, std::filesystem::path const& filename) const = 0;
 
     ~IImageDataWriter() = default;
 };
@@ -72,15 +72,15 @@ public:
 
     void set_read_buffer(ReadBuffer buffer);
 
-    ImageData take_screenshot() const override;
+    ScreenshotImageData const& take_screenshot() const override;
 
 private:
     ReadBuffer m_read_buffer = FRONT;
 };
 
-class ImageDataToPNGWriter : public IImageDataWriter {
+class ScreenshotImageDataToPNGWriter : public IImageDataWriter {
 public:
-    bool write_image(ImageData image, std::filesystem::path const& filename) const override;
+    bool write_image(ScreenshotImageData const& image, std::filesystem::path const& filename) const override;
 };
 
 

--- a/frontend/resources/include/Screenshots.h
+++ b/frontend/resources/include/Screenshots.h
@@ -66,6 +66,18 @@ public:
     ~IImageDataWriter() = default;
 };
 
+struct ImageWrapper;
+class ImageWrapperScreenshotSource : public IScreenshotSource {
+public:
+    ImageWrapperScreenshotSource() = default;
+    ImageWrapperScreenshotSource(ImageWrapper const& image);
+
+    ScreenshotImageData const& take_screenshot() const override;
+
+private:
+    ImageWrapper* m_image = nullptr;
+};
+
 class GLScreenshotSource : public IScreenshotSource {
 public:
     enum ReadBuffer { FRONT, BACK, COLOR_ATT0, COLOR_ATT1, COLOR_ATT2, COLOR_ATT3};

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -136,6 +136,8 @@ private:
     std::function<ViewportTile()> m_viewport_tile_handler;
 
     void fill_lua_callbacks();
+
+    std::function<bool(std::string const&, std::string const&)> m_entrypointToPNG_trigger;
 };
 
 } // namespace frontend

--- a/frontend/services/image_presentation/ImageWrapper_to_ByteArray.hpp
+++ b/frontend/services/image_presentation/ImageWrapper_to_ByteArray.hpp
@@ -1,0 +1,35 @@
+/*
+ * ImageWrapper_to_ByteArray.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include "ImageWrapper.h"
+
+#include <vector>
+
+namespace megamol {
+namespace frontend_resources {
+
+    using byte = unsigned char;
+    struct byte_texture {
+        std::vector<byte> texture;
+        std::vector<byte>* texture_ptr = nullptr;
+        bool texture_owned = false;
+        ImageWrapper* image_wrapper_ptr = nullptr;
+
+        byte_texture(ImageWrapper const& image);
+
+        byte_texture& operator=(ImageWrapper const& image);
+
+        std::vector<byte> const& as_byte_vector();
+
+        private:
+        void from_image(ImageWrapper const& image);
+    };
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/services/screenshot_service/Screenshot_Service.cpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.cpp
@@ -48,6 +48,8 @@ static megamol::core::MegaMolGraph* megamolgraph_ptr = nullptr;
 static megamol::frontend_resources::GUIState* guistate_resources_ptr = nullptr;
 static bool screenshot_show_privacy_note = true;
 
+static unsigned char default_alpha_value = 0;
+
 static void PNGAPI pngErrorFunc(png_structp pngPtr, png_const_charp msg) {
     log("PNG Error: " + std::string(msg));
 }
@@ -164,7 +166,7 @@ megamol::frontend_resources::ScreenshotImageData const& megamol::frontend_resour
     glReadPixels(0, 0, fbWidth, fbHeight, GL_RGBA, GL_UNSIGNED_BYTE, result.image.data());
 
     for (auto& pixel : result.image)
-        pixel.a = 255;
+        pixel.a = default_alpha_value;
 
     return result;
 }

--- a/frontend/services/screenshot_service/Screenshot_Service.cpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.cpp
@@ -66,7 +66,7 @@ static void PNGAPI pngFlushFileFunc(png_structp pngPtr) {
     f->Flush();
 }
 
-static bool write_png_to_file(megamol::frontend_resources::ImageData const& image, std::filesystem::path const& filename) {
+static bool write_png_to_file(megamol::frontend_resources::ScreenshotImageData const& image, std::filesystem::path const& filename) {
     vislib::sys::FastFile file;
     try {
         // open final image file
@@ -148,7 +148,7 @@ void megamol::frontend_resources::GLScreenshotSource::set_read_buffer(ReadBuffer
     }
 }
 
-megamol::frontend_resources::ImageData megamol::frontend_resources::GLScreenshotSource::take_screenshot() const {
+megamol::frontend_resources::ScreenshotImageData const& megamol::frontend_resources::GLScreenshotSource::take_screenshot() const {
     // TODO: in FBO-based rendering the FBO object carries its size and we dont need to look it up
     // simpler and more correct approach would be to observe Framebuffer_Events resource
     // but this is our naive implementation for now
@@ -157,7 +157,7 @@ megamol::frontend_resources::ImageData megamol::frontend_resources::GLScreenshot
     GLint fbWidth = viewport_dims[2];
     GLint fbHeight = viewport_dims[3];
 
-    ImageData result;
+    static ScreenshotImageData result;
     result.resize(static_cast<size_t>(fbWidth), static_cast<size_t>(fbHeight));
 
     glReadBuffer(m_read_buffer);
@@ -166,11 +166,11 @@ megamol::frontend_resources::ImageData megamol::frontend_resources::GLScreenshot
     for (auto& pixel : result.image)
         pixel.a = 255;
 
-    return std::move(result);
+    return result;
 }
 
-bool megamol::frontend_resources::ImageDataToPNGWriter::write_image(ImageData image, std::filesystem::path const& filename) const {
-    return write_png_to_file(std::move(image), filename);
+bool megamol::frontend_resources::ScreenshotImageDataToPNGWriter::write_image(ScreenshotImageData const& image, std::filesystem::path const& filename) const {
+    return write_png_to_file(image, filename);
 }
 
 namespace megamol {

--- a/frontend/services/screenshot_service/Screenshot_Service.hpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.hpp
@@ -59,6 +59,7 @@ private:
     megamol::frontend_resources::ScreenshotImageDataToPNGWriter m_toFileWriter_resource;
 
     std::function<bool(std::filesystem::path const&)> m_frontbufferToPNG_trigger;
+    std::function<bool(megamol::frontend_resources::ImageWrapper const&, std::filesystem::path const&)> m_imagewrapperToPNG_trigger;
 
     std::vector<FrontendResource> m_providedResourceReferences;
     std::vector<std::string> m_requestedResourcesNames;

--- a/frontend/services/screenshot_service/Screenshot_Service.hpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.hpp
@@ -56,7 +56,7 @@ public:
 
 private:
     megamol::frontend_resources::GLScreenshotSource m_frontbufferSource_resource;
-    megamol::frontend_resources::ImageDataToPNGWriter m_toFileWriter_resource;
+    megamol::frontend_resources::ScreenshotImageDataToPNGWriter m_toFileWriter_resource;
 
     std::function<bool(std::filesystem::path const&)> m_frontbufferToPNG_trigger;
 


### PR DESCRIPTION
Adds `mmScreenshotEntryPoint(view, filename)` to write result images of entry point views as screenshots. 

## Summary of Changes
* Refactors Screenshot Service, pass Screenshot data as `const&`
* Adds `byte_texture` and `ImageWrapper`->`byte_texture` conversion
* Writes `byte_texture` to screenshots
* Provides `mmScreenshotEntryPoint(view, filename)` for Lua scripting

## References and Context
This pulls screenshots directly from entry points, ignoring the GUI overlay. Also enables screenshots of arbitrary size when entry point rendering gets decoupled from the GLFW window resolution. `mmScreenshotEntryPoint(view, filename)` can be condensed to simply `mmScreenshot(filename [, view])` when at some point the Lua Lambda Callbacks allow for optional arguments.

## Test Instructions
Load your project and execute `mmScreenshotEntryPoint(view, filename)` via Lua, either in a project file or via remote console.