### PR TITLE
OpenGL: Linux remote X11

### DIFF
--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -77,6 +77,7 @@ static std::string global_option      = "g,global";
 // --project and loose project files are both valid ways to provide lua project files
 static std::string project_files_option = "project-files";
 static std::string host_option          = "host";
+static std::string opengl_context_option= "opengl";
 static std::string khrdebug_option      = "khrdebug";
 static std::string vsync_option         = "vsync";
 static std::string window_option        = "w,window";
@@ -208,6 +209,28 @@ static void host_handler(std::string const& option_name, cxxopts::ParseResult co
     config.lua_host_address = parsed_options[option_name].as<std::string>();
 };
 
+
+static void opengl_context_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
+{
+    auto string = parsed_options[option_name].as<std::string>();
+
+    std::regex version("(\\d+).(\\d+)(core|compat)?");
+    std::smatch match;
+    if (std::regex_match(string, match, version)) {
+        unsigned int major = std::stoul(match[1].str(), nullptr, 10);
+        unsigned int minor = std::stoul(match[2].str(), nullptr, 10);
+        bool profile = false;
+
+        if (match[3].matched) {
+            profile = match[3].str() == std::string("core");
+        }
+
+        config.opengl_context_version = {{major, minor, profile}};
+    } else {
+        exit("opengl option needs to be in the following format: major.minor[core|compat]");
+    }
+};
+
 static void khrdebug_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
 {
     config.opengl_khr_debug = parsed_options[option_name].as<bool>();
@@ -276,6 +299,7 @@ std::vector<OptionsListEntry> cli_options_list =
         , {global_option,        "Set global key-value pair(s) in MegaMol environment, syntax: --global key:value", cxxopts::value<std::vector<std::string>>(), global_value_handler}
 
         , {host_option,          "Address of lua host server",                                                      cxxopts::value<std::string>(),              host_handler         }
+        , {opengl_context_option,"OpenGL context to request: major.minor[core|compat], e.g. --opengl 3.2compat",    cxxopts::value<std::string>(),              opengl_context_handler}
         , {khrdebug_option,      "Enable OpenGL KHR debug messages",                                                cxxopts::value<bool>(),                     khrdebug_handler     }
         , {vsync_option,         "Enable VSync in OpenGL window",                                                   cxxopts::value<bool>(),                     vsync_handler        }
         , {window_option,        "Set the window size and position, syntax: --window WIDTHxHEIGHT[+POSX+POSY]",     cxxopts::value<std::string>(),              window_handler       }

--- a/frontend/main/src/main.cpp
+++ b/frontend/main/src/main.cpp
@@ -64,8 +64,11 @@ int main(const int argc, const char** argv) {
     megamol::frontend::OpenGL_GLFW_Service gl_service;
     megamol::frontend::OpenGL_GLFW_Service::Config openglConfig;
     openglConfig.windowTitlePrefix = "MegaMol";
-    openglConfig.versionMajor = 4;
-    openglConfig.versionMinor = 5;
+    if (config.opengl_context_version.has_value()) {
+        openglConfig.versionMajor         = std::get<0>(config.opengl_context_version.value());
+        openglConfig.versionMinor         = std::get<1>(config.opengl_context_version.value());
+        openglConfig.glContextCoreProfile = std::get<2>(config.opengl_context_version.value());
+    }
     openglConfig.enableKHRDebug = config.opengl_khr_debug;
     openglConfig.enableVsync = config.opengl_vsync;
     // pass window size and position

--- a/frontend/resources/include/RuntimeConfig.h
+++ b/frontend/resources/include/RuntimeConfig.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <tuple>
 #include <optional>
 
 namespace megamol {
@@ -45,6 +46,8 @@ struct RuntimeConfig {
     bool lua_host_port_retry = true;
     bool opengl_khr_debug = false;
     bool opengl_vsync = false;
+    std::optional<std::tuple<unsigned int /*major*/, unsigned int /*minor*/, bool /*true=>core, false=>compat*/>>
+        opengl_context_version = {{4, 6, false/*compat*/}};
     std::optional<std::pair<unsigned int /*width*/,unsigned int /*height*/>> window_size = std::nullopt; // if not set, GLFW service will open window with 3/4 of monitor resolution 
     std::optional<std::pair<unsigned int /*x*/,unsigned int /*y*/>>          window_position = std::nullopt;
     enum WindowMode {

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -413,16 +413,23 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
         m_pimpl->config.windowPlacement.y = mon_y;
     }
 
-    // TODO: OpenGL context hints? version? core profile?
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, m_pimpl->config.versionMajor);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, m_pimpl->config.versionMinor);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, m_pimpl->config.glContextCoreProfile ? GLFW_OPENGL_CORE_PROFILE : GLFW_OPENGL_COMPAT_PROFILE);
     glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, m_pimpl->config.enableKHRDebug ? GLFW_TRUE : GLFW_FALSE);
+    // context profiles available since 3.2
+    bool has_profiles = m_pimpl->config.versionMajor > 3 || m_pimpl->config.versionMajor == 3 && m_pimpl->config.versionMinor >= 2;
+    if (has_profiles)
+        glfwWindowHint(GLFW_OPENGL_PROFILE, m_pimpl->config.glContextCoreProfile ? GLFW_OPENGL_CORE_PROFILE : GLFW_OPENGL_COMPAT_PROFILE);
+
+    std::string profile_name =
+        has_profiles
+            ? ((m_pimpl->config.glContextCoreProfile ? "Core" : "Compatibility") + std::string(" Profile"))
+            : "";
 
     log("Requesting OpenGL "
         + std::to_string(m_pimpl->config.versionMajor) + "."
         + std::to_string(m_pimpl->config.versionMinor) + " "
-        + (m_pimpl->config.glContextCoreProfile ? "Core" : "Compatibility") + " Profile"
+        + profile_name
         + (m_pimpl->config.enableKHRDebug ? ", Debug Context" : "" )
     );
 

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -53,6 +53,12 @@ static void log_warning(std::string const& text) {
     megamol::core::utility::log::Log::DefaultLog.WriteWarn(msg.c_str());
 }
 
+static void glfw_error_callback(int error, const char* description)
+{
+    log_error("[GLFW Error] " + std::to_string(error) + ": " + description);
+}
+
+
 // See: https://github.com/glfw/glfw/issues/1630
 static int fixGlfwKeyboardMods(int mods, int key, int action) {
     if (key == GLFW_KEY_LEFT_SHIFT || key == GLFW_KEY_RIGHT_SHIFT) {
@@ -324,6 +330,8 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
     }
     m_pimpl->config = config;
 
+    glfwSetErrorCallback(glfw_error_callback);
+
     bool success_glfw = glfwInit();
     if (!success_glfw) {
         log_error("could not initialize GLFW for OpenGL window. \nmaybe your machine is using outdated graphics hardware, drivers or you are working remotely?");
@@ -411,6 +419,13 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
     glfwWindowHint(GLFW_OPENGL_PROFILE, m_pimpl->config.glContextCoreProfile ? GLFW_OPENGL_CORE_PROFILE : GLFW_OPENGL_COMPAT_PROFILE);
     glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, m_pimpl->config.enableKHRDebug ? GLFW_TRUE : GLFW_FALSE);
 
+    log("Requesting OpenGL "
+        + std::to_string(m_pimpl->config.versionMajor) + "."
+        + std::to_string(m_pimpl->config.versionMinor) + " "
+        + (m_pimpl->config.glContextCoreProfile ? "Core" : "Compatibility") + " Profile"
+        + (m_pimpl->config.enableKHRDebug ? ", Debug Context" : "" )
+    );
+
     auto& window_ptr = m_pimpl->glfwContextWindowPtr;
     window_ptr = ::glfwCreateWindow(initial_width, initial_height,
         m_pimpl->config.windowTitlePrefix.c_str(), nullptr, nullptr);
@@ -445,6 +460,13 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
     gladLoadGLX(display, DefaultScreen(display));
     XCloseDisplay(display);
 #endif
+
+    log(std::string("OpenGL Context Info")
+        + "\n\tVersion:  " + reinterpret_cast<const char*>(glGetString(GL_VERSION))
+        + "\n\tVendor:   " + reinterpret_cast<const char*>(glGetString(GL_VENDOR))
+        + "\n\tRenderer: " + reinterpret_cast<const char*>(glGetString(GL_RENDERER))
+        + "\n\tGLSL:     " + reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION))
+    );
 
     if (m_pimpl->config.enableKHRDebug) {
         glEnable(GL_DEBUG_OUTPUT);


### PR DESCRIPTION
Trying to figure out and fix why MegaMol does not start via remote X session.

* Xming on Windows Subsystem for Linux provides only GLX version 1.2
* GLFW needs GLX 1.3 to start, see https://github.com/glfw/glfw/issues/829

## Summary of Changes
* Be verbose about GLFW errors and OpenGL context
* CLI option `--opengl` to specify OpenGL version and profile, e.g. `--opengl 3.2compat`
* Bumps requested OpenGL version to 4.6 Compatibility

## Test Instructions
Test via Linux remote X session or Windows WSL.