### PR TITLE
Easy Resource Access In Modules

### DIFF
--- a/core/include/mmcore/Module.h
+++ b/core/include/mmcore/Module.h
@@ -17,6 +17,7 @@
 #include "mmcore/api/MegaMolCore.std.h"
 
 #include "FrontendResource.h"
+#include "FrontendResourcesMap.h"
 
 
 namespace megamol {
@@ -219,8 +220,8 @@ private:
     friend class ::megamol::core::AbstractNamedObjectContainer;
 
 protected:
-    /* requested frontend resources are provided in order of the initial request */
-    std::vector<megamol::frontend::FrontendResource> frontend_resources;
+    // usage: auto const& resource = frontend_resources.get<ResourceType>()
+    megamol::frontend_resources::FrontendResourcesMap frontend_resources;
 };
 
 

--- a/core/src/Module.cpp
+++ b/core/src/Module.cpp
@@ -53,7 +53,7 @@ Module::~Module(void) {
 bool Module::Create(std::vector<megamol::frontend::FrontendResource> resources) {
     using megamol::core::utility::log::Log;
 
-    this->frontend_resources = resources;
+    this->frontend_resources = {resources}; // put resources in hash map using type hashes of present resources
 
     ASSERT(this->instance() != NULL);
     if (!this->created) {

--- a/core/src/ResourceTestModule.cpp
+++ b/core/src/ResourceTestModule.cpp
@@ -10,16 +10,10 @@ megamol::core::ResourceTestModule::~ResourceTestModule() {
 
 
 bool megamol::core::ResourceTestModule::create() {
-    auto fit = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-        [](auto const& el) { return el.getIdentifier() == "CUDA_Context"; });
-
-    if (fit != this->frontend_resources.end()) {
-        core::utility::log::Log::DefaultLog.WriteInfo("[ResourceTestModule] Got CUDA context");
-
-        auto& cuda_res = fit->getResource<frontend_resources::CUDA_Context>();
-        if (cuda_res.ctx_ != nullptr) {
-            core::utility::log::Log::DefaultLog.WriteInfo("[ResourceTestModule] CUDA context pointer exists");
-        }
+    // we requested this resource, so it is either available or program execution halted before we got here
+    auto& cuda_res = frontend_resources.get<frontend_resources::CUDA_Context>();
+    if (cuda_res.ctx_ != nullptr) {
+        core::utility::log::Log::DefaultLog.WriteInfo("[ResourceTestModule] CUDA context pointer exists");
     }
 
     return true;

--- a/core/src/view/AbstractView.cpp
+++ b/core/src/view/AbstractView.cpp
@@ -589,17 +589,9 @@ std::string view::AbstractView::determineCameraFilePath(void) const {
     std::string path;
     if (!this->GetCoreInstance()->IsmmconsoleFrontendCompatible()) {
         // new frontend
-        const auto fit = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-            [](auto const& el) { return el.getIdentifier() == "LuaScriptPaths"; });
-
-        if (fit != this->frontend_resources.end()) {
-            core::utility::log::Log::DefaultLog.WriteInfo("[AbstractView] Got script paths");
-            const auto& paths = fit->getResource<megamol::frontend_resources::ScriptPaths>().lua_script_paths;
-            if (!paths.empty()) {
-                path = paths[0];
-            } else {
-                return path;
-            }
+        const auto& paths = frontend_resources.get<megamol::frontend_resources::ScriptPaths>().lua_script_paths;
+        if (!paths.empty()) {
+            path = paths[0];
         } else {
             return path;
         }

--- a/core/src/view/AbstractView3D.cpp
+++ b/core/src/view/AbstractView3D.cpp
@@ -574,7 +574,7 @@ bool AbstractView3D::create(void) {
 
     if (!this->GetCoreInstance()->IsmmconsoleFrontendCompatible()) {
         // new frontend has global key-value resource
-        auto maybe = this->frontend_resources[0].getResource<megamol::frontend_resources::GlobalValueStore>().maybe_get(arcball_key);
+        auto maybe = this->frontend_resources.get<megamol::frontend_resources::GlobalValueStore>().maybe_get(arcball_key);
         if (maybe.has_value()) {
             this->_arcballDefault = vislib::CharTraitsA::ParseBool(maybe.value().c_str());
         }

--- a/core/src/view/special/ScreenShooter.cpp
+++ b/core/src/view/special/ScreenShooter.cpp
@@ -943,15 +943,10 @@ bool view::special::ScreenShooter::triggerButtonClicked(param::ParamSlot& slot) 
             vi = dynamic_cast<ViewInstance*>(ano.get());
             av = dynamic_cast<AbstractView*>(ano.get());
         } else {
-            auto resource_it = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-                [&](megamol::frontend::FrontendResource& dep) { return (dep.getIdentifier() == "MegaMolGraph"); });
-            if (resource_it != this->frontend_resources.end()) {
-                if (auto megamolgraph_ptr = &resource_it->getResource<megamol::core::MegaMolGraph>()) {
-                    auto module_ptr = megamolgraph_ptr->FindModule(std::string(mvn.PeekBuffer()));
-                    vi = dynamic_cast<ViewInstance*>(module_ptr.get());
-                    av = dynamic_cast<AbstractView*>(module_ptr.get());
-                }
-            }
+            auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
+            auto module_ptr = megamolgraph.FindModule(std::string(mvn.PeekBuffer()));
+            vi = dynamic_cast<ViewInstance*>(module_ptr.get());
+            av = dynamic_cast<AbstractView*>(module_ptr.get());
         }
 
         if (vi != nullptr) {
@@ -1018,14 +1013,9 @@ param::ParamSlot* view::special::ScreenShooter::findTimeParam(view::AbstractView
             AbstractNamedObjectContainer* anoc = dynamic_cast<AbstractNamedObjectContainer*>(view->RootModule().get());
             timeSlot = dynamic_cast<param::ParamSlot*>(anoc->FindNamedObject(vislib::StringA(name)).get());
         } else {
-            auto resource_it = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-                [&](megamol::frontend::FrontendResource& dep) { return (dep.getIdentifier() == "MegaMolGraph"); });
-            if (resource_it != this->frontend_resources.end()) {
-                if (auto megamolgraph_ptr = &resource_it->getResource<megamol::core::MegaMolGraph>()) {
-                    std::string fullname = std::string(view->Name().PeekBuffer()) + "::" + std::string(name.PeekBuffer());
-                    timeSlot = megamolgraph_ptr->FindParameterSlot(fullname);
-                }
-            }
+            auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
+            std::string fullname = std::string(view->Name().PeekBuffer()) + "::" + std::string(name.PeekBuffer());
+            timeSlot = megamolgraph.FindParameterSlot(fullname);
         }
     }
 

--- a/frontend/resources/include/FrontendResource.h
+++ b/frontend/resources/include/FrontendResource.h
@@ -11,6 +11,7 @@
 #include <any>
 #include <functional>
 #include <optional>
+#include <typeinfo>
 
 namespace megamol {
 namespace frontend {
@@ -21,6 +22,7 @@ public:
     FrontendResource()
         : identifier{""}
         , resource{}
+        , type_hash{0}
     {}
 
     template <typename T>
@@ -28,7 +30,7 @@ public:
 
     template <typename T>
     FrontendResource(const std::string& identifier, const T& resource)
-        : identifier{identifier}, resource{std::reference_wrapper<const T>(resource)} {}
+        : identifier{identifier}, resource{std::reference_wrapper<const T>(resource)}, type_hash{typeid(T).hash_code()} {}
 
     const std::string& getIdentifier() const { return identifier; }
 
@@ -44,9 +46,14 @@ public:
         //}
     }
 
+    std::size_t getHash() const {
+        return type_hash;
+    }
+
 private:
     std::string identifier;
     std::any resource;
+    std::size_t type_hash = 0;
 };
 
 

--- a/frontend/resources/include/FrontendResourcesMap.h
+++ b/frontend/resources/include/FrontendResourcesMap.h
@@ -1,0 +1,55 @@
+/*
+ * FrontendResourcesMap.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include "FrontendResource.h"
+
+#include <vector>
+#include <map>
+#include <string>
+#include <iostream>
+
+namespace megamol {
+namespace frontend_resources {
+
+struct FrontendResourcesMap {
+    FrontendResourcesMap() = default;
+
+    FrontendResourcesMap (std::vector<frontend::FrontendResource> const& resources) {
+        for (auto& resource : resources) {
+            auto hash = resource.getHash();
+            auto already_exists = this->resources.count(hash) != 0 && this->resources.at(hash).getIdentifier() != resource.getIdentifier();
+            if (already_exists) {
+                auto msg = std::string("FrontendResourcesMap: Fatal Error: ")
+                    + "\n\tresource type hash " + std::to_string(hash)
+                    + " already present in map, introduced by resource " + this->resources.at(hash).getIdentifier()
+                    + "\n\tcan not add resource " + resource.getIdentifier()
+                    + "\n\tbecause that would lead to ambiguous map entries for your resources "
+                    + "\n\tstopping program execution ";
+
+                std::cout << msg << std::endl;
+                std::cerr << msg << std::endl;
+                std::exit(1);
+            } else {
+                this->resources.insert({hash, resource});
+            }
+        }
+    }
+
+    // hash map lookup for resource using resource type id
+    template <typename ResourceType>
+    ResourceType const& get() const {
+        return resources.at(typeid(ResourceType).hash_code()).getResource<ResourceType>();
+    }
+
+    private:
+    std::map<std::size_t, frontend::FrontendResource> resources;
+};
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/plugins/cinematic/src/CinematicView.cpp
+++ b/plugins/cinematic/src/CinematicView.cpp
@@ -642,14 +642,8 @@ bool CinematicView::render_to_file_write() {
         if (this->GetCoreInstance()->IsmmconsoleFrontendCompatible()) {
             project = this->GetCoreInstance()->SerializeGraph();
         } else {
-            auto megamolgraph_it = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-                [&](megamol::frontend::FrontendResource& dep) { return (dep.getIdentifier() == "MegaMolGraph"); });
-            if (megamolgraph_it != this->frontend_resources.end()) {
-                if (auto megamolgraph_ptr = &megamolgraph_it->getResource<megamol::core::MegaMolGraph>()) {
-                    project =
-                        const_cast<megamol::core::MegaMolGraph*>(megamolgraph_ptr)->Convenience().SerializeGraph();
-                }
-            }
+            auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
+            project = const_cast<megamol::core::MegaMolGraph&>(megamolgraph).Convenience().SerializeGraph();
         }
 
         megamol::core::utility::graphics::ScreenShotComments ssc(project);

--- a/plugins/cinematic/src/TimeLineRenderer.cpp
+++ b/plugins/cinematic/src/TimeLineRenderer.cpp
@@ -95,21 +95,16 @@ bool TimeLineRenderer::create(void) {
         std::wstring texture_filename = std::wstring(fullfilename.PeekBuffer());
         loaded_texture = this->utils.LoadTextureFromFile(this->texture_id, texture_filename);
     } else {
-        auto resource_it = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-            [&](megamol::frontend::FrontendResource& dep) { return (dep.getIdentifier() == "RuntimeConfig"); });
-        if (resource_it != this->frontend_resources.end()) {
-            std::string texture_filepath;
-            auto resource_directories =
-                resource_it->getResource<megamol::frontend_resources::RuntimeConfig>().resource_directories;
-            for (auto& resource_directory : resource_directories) {
-                auto found_filepath = megamol::core::utility::FileUtils::SearchFileRecursive(
-                    resource_directory, texture_shortfilename);
-                if (!found_filepath.empty()) {
-                    texture_filepath = found_filepath;
-                }
+        std::string texture_filepath;
+        auto resource_directories = frontend_resources.get<megamol::frontend_resources::RuntimeConfig>().resource_directories;
+        for (auto& resource_directory : resource_directories) {
+            auto found_filepath = megamol::core::utility::FileUtils::SearchFileRecursive(
+                resource_directory, texture_shortfilename);
+            if (!found_filepath.empty()) {
+                texture_filepath = found_filepath;
             }
-            loaded_texture = this->utils.LoadTextureFromFile(this->texture_id, texture_filepath);
         }
+        loaded_texture = this->utils.LoadTextureFromFile(this->texture_id, texture_filepath);
     }
 
     if (!loaded_texture) {

--- a/plugins/gui/src/OverlayRenderer.cpp
+++ b/plugins/gui/src/OverlayRenderer.cpp
@@ -282,15 +282,8 @@ bool OverlayRenderer::onParameterName(param::ParamSlot& slot) {
 
     // Check megamol graph for available parameter:
     megamol::core::param::AbstractParam* param_ptr = nullptr;
-    const megamol::core::MegaMolGraph* megamolgraph_ptr = nullptr;
-    auto megamolgraph_it = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-        [&](megamol::frontend::FrontendResource& dep) { return (dep.getIdentifier() == "MegaMolGraph"); });
-    if (megamolgraph_it != this->frontend_resources.end()) {
-        megamolgraph_ptr = &megamolgraph_it->getResource<megamol::core::MegaMolGraph>();
-    }
-    if (megamolgraph_ptr != nullptr) {
-        param_ptr = megamolgraph_ptr->FindParameter(std::string(parameter_name.PeekBuffer()));
-    }
+    auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
+    param_ptr = megamolgraph.FindParameter(std::string(parameter_name.PeekBuffer()));
     // Alternatively, check core instance graph for available parameter:
     if (param_ptr == nullptr) {
         auto core_parameter_ptr = this->GetCoreInstance()->FindParameter(parameter_name, false, false);

--- a/plugins/optix_hpg/src/optix/Renderer.cpp
+++ b/plugins/optix_hpg/src/optix/Renderer.cpp
@@ -238,14 +238,12 @@ bool megamol::optix_hpg::Renderer::GetExtents(CallRender3DCUDA& call) {
 
 
 bool megamol::optix_hpg::Renderer::create() {
-    auto const fit = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-        [](auto const& el) { return el.getIdentifier() == frontend_resources::CUDA_Context_Req_Name; });
-
-    if (fit == this->frontend_resources.end())
+    auto& cuda_res = frontend_resources.get<frontend_resources::CUDA_Context>();
+    if (cuda_res.ctx_ != nullptr) {
+        optix_ctx_ = std::make_unique<Context>(cuda_res);
+    } else {
         return false;
-
-    optix_ctx_ = std::make_unique<Context>(fit->getResource<frontend_resources::CUDA_Context>());
-
+    }
     return true;
 }
 

--- a/plugins/optix_hpg/src/optix/TransitionCalculator.cpp
+++ b/plugins/optix_hpg/src/optix/TransitionCalculator.cpp
@@ -35,14 +35,12 @@ megamol::optix_hpg::TransitionCalculator::~TransitionCalculator() {
 
 
 bool megamol::optix_hpg::TransitionCalculator::create() {
-    auto const fit = std::find_if(this->frontend_resources.begin(), this->frontend_resources.end(),
-        [](auto const& el) { return el.getIdentifier() == frontend_resources::CUDA_Context_Req_Name; });
-
-    if (fit == this->frontend_resources.end())
+    auto& cuda_res = frontend_resources.get<frontend_resources::CUDA_Context>();
+    if (cuda_res.ctx_ != nullptr) {
+        optix_ctx_ = std::make_unique<Context>(cuda_res);
+    } else {
         return false;
-
-    optix_ctx_ = std::make_unique<Context>(fit->getResource<frontend_resources::CUDA_Context>());
-
+    }
     return true;
 }
 


### PR DESCRIPTION
Easier frontend resources access for modules via `std::map<resource_type_hash, FrontendResource>`. 
Resource lookup boils down to `auto& resource = frontend_resources_map.get<ResourceType>()`

## Summary of Changes
* `FrontendResource` now also carries the hash code of the contained resource type
* Add `FrontendResourcesMap` class which uses hash codes as keys for map lookup
* Refactor MegaMol Module and depending classes to use new `frontend_resources_map` for easy resource access

## References and Context
In search for better usability of frontend resources in graph modules, this is a solution that allows resource access via its type, for the cost of a hash map lookup at runtime. Keep in mind that the module author is free to look up his resources in create() and keep pointers to them, eliminating costly looksups at runtime. Thhis solution suffers from edge-cases where different resources may have identical hashes - in these cases, the `FrontendResourcesMap` implementation halts MegaMol execution.

## Test Instructions
Run MegaMol.
