### PR TITLE
Fix crash in view modules with uninitialized fbo

### DIFF
--- a/core/src/view/View2DGL.cpp
+++ b/core/src/view/View2DGL.cpp
@@ -421,6 +421,8 @@ bool view::View2DGL::create(void) {
     this->_firstImg = true;
 
     this->_fbo = std::make_shared<vislib::graphics::gl::FramebufferObject>();
+    this->_fbo->Create(1, 1, GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE,
+        vislib::graphics::gl::FramebufferObject::ATTACHMENT_TEXTURE, GL_DEPTH_COMPONENT);
 
     return true;
 }

--- a/core/src/view/View3DGL.cpp
+++ b/core/src/view/View3DGL.cpp
@@ -423,6 +423,8 @@ bool View3DGL::create(void) {
     AbstractView3D::create();
 
     this->_fbo = std::make_shared<vislib::graphics::gl::FramebufferObject>();
+    this->_fbo->Create(1, 1, GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE,
+        vislib::graphics::gl::FramebufferObject::ATTACHMENT_TEXTURE, GL_DEPTH_COMPONENT);
 
     this->_cursor2d.SetButtonCount(3);
 


### PR DESCRIPTION
Fixes a crash that occurs when creating new 3DViewGL and 2DViewGL modules in configurator without render call 

## Summary of Changes
Adds fbo creation to create function in 3DViewGL and 2DViewGL (using dummy size 1x1)

## Test Instructions
Try creating View modules in any possible order and context in the configurator.
