### PR TITLE
Update shaderfactory with line translator

### DIFF
--- a/core/include/mmcore/utility/ShaderFactory.h
+++ b/core/include/mmcore/utility/ShaderFactory.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <string>
 
-#include "msf/compiler_options.h"
+#include "msf/ShaderFactoryOptionsOpenGL.h"
 
 #include "glad/glad.h"
 
@@ -18,17 +18,13 @@
 
 namespace megamol::core::utility {
 
-glowl::GLSLProgram::ShaderSourceList::value_type make_glowl_shader_source(
-    std::filesystem::path const& shader_source_path, megamol::shaderfactory::compiler_options const& options);
-
+std::unique_ptr<glowl::GLSLProgram> make_glowl_shader(std::string const& label,
+    msf::ShaderFactoryOptionsOpenGL const& options, const std::vector<std::filesystem::path>& paths);
 
 template<typename... Paths>
 std::enable_if_t<(std::is_convertible_v<Paths, std::filesystem::path> && ...), std::unique_ptr<glowl::GLSLProgram>>
-make_glowl_shader(std::string const& label, megamol::shaderfactory::compiler_options const& options, Paths... paths) {
-    auto program = std::make_unique<glowl::GLSLProgram>(
-        glowl::GLSLProgram::ShaderSourceList{make_glowl_shader_source(paths, options)...});
-    program->setDebugLabel(label);
-    return program;
+make_glowl_shader(std::string const& label, msf::ShaderFactoryOptionsOpenGL const& options, Paths... paths) {
+    return make_glowl_shader(label, options, std::vector<std::filesystem::path>{paths...});
 }
 
 } // end namespace megamol::core::utility

--- a/core/include/mmcore/utility/ShaderFactory.h
+++ b/core/include/mmcore/utility/ShaderFactory.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "msf/LineTranslator.h"
 #include "msf/ShaderFactoryOptionsOpenGL.h"
 
 #include "glad/glad.h"
@@ -18,13 +19,22 @@
 
 namespace megamol::core::utility {
 
-std::unique_ptr<glowl::GLSLProgram> make_glowl_shader(std::string const& label,
-    msf::ShaderFactoryOptionsOpenGL const& options, const std::vector<std::filesystem::path>& paths);
+glowl::GLSLProgram::ShaderSourceList::value_type make_glowl_shader_source(
+    std::filesystem::path const& shader_source_path, msf::ShaderFactoryOptionsOpenGL const& options,
+    msf::LineTranslator& translator);
 
 template<typename... Paths>
 std::enable_if_t<(std::is_convertible_v<Paths, std::filesystem::path> && ...), std::unique_ptr<glowl::GLSLProgram>>
 make_glowl_shader(std::string const& label, msf::ShaderFactoryOptionsOpenGL const& options, Paths... paths) {
-    return make_glowl_shader(label, options, std::vector<std::filesystem::path>{paths...});
+    msf::LineTranslator translator;
+    try {
+        auto program = std::make_unique<glowl::GLSLProgram>(
+            glowl::GLSLProgram::ShaderSourceList{make_glowl_shader_source(paths, options, translator)...});
+        program->setDebugLabel(label);
+        return program;
+    } catch (glowl::GLSLProgramException const& ex) {
+        throw glowl::GLSLProgramException(translator.translateErrorLog(ex.what()));
+    }
 }
 
 } // end namespace megamol::core::utility

--- a/core/src/utility/ShaderFactory.cpp
+++ b/core/src/utility/ShaderFactory.cpp
@@ -6,16 +6,34 @@
 #include "stdafx.h"
 #include "mmcore/utility/ShaderFactory.h"
 
-#include "msf/compiler.h"
-#include "msf/compiler_utils.h"
+#include "msf/LineTranslator.h"
+#include "msf/ShaderFactory.h"
+#include "msf/ShaderFactoryUtils.h"
 
+static msf::ShaderFactory msf_factory;
 
-static megamol::shaderfactory::compiler msf_cp;
+std::unique_ptr<glowl::GLSLProgram> megamol::core::utility::make_glowl_shader(std::string const& label,
+    msf::ShaderFactoryOptionsOpenGL const& options, const std::vector<std::filesystem::path>& paths) {
 
-glowl::GLSLProgram::ShaderSourceList::value_type megamol::core::utility::make_glowl_shader_source(
-    std::filesystem::path const& shader_source_path, megamol::shaderfactory::compiler_options const& options) {
-    auto const shader_string = msf_cp.preprocess(shader_source_path, options);
-    auto const type = megamol::shaderfactory::get_shader_type_ogl(shader_source_path);
+    glowl::GLSLProgram::ShaderSourceList source_list;
+    std::vector<msf::LineTranslator> translators;
 
-    return std::make_pair(static_cast<glowl::GLSLProgram::ShaderType>(type), shader_string);
+    // TODO: BUG!!! All translators will use the same ids for different files!!!
+    for (const auto& path : paths) {
+        auto const shader_string = translators.emplace_back(msf_factory.preprocess(path, options)).getCleanShader();
+        auto const type = msf::getShaderTypeInt(path);
+        source_list.emplace_back(std::make_pair(static_cast<glowl::GLSLProgram::ShaderType>(type), shader_string));
+    }
+
+    try {
+        auto program = std::make_unique<glowl::GLSLProgram>(source_list);
+        program->setDebugLabel(label);
+        return program;
+    } catch (const glowl::GLSLProgramException& e) {
+        std::string error = e.what();
+        for (const auto& t : translators) {
+            error = t.translateErrorLog(error);
+        }
+        throw glowl::GLSLProgramException(error);
+    }
 }

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -596,7 +596,7 @@ function(require_external NAME)
 
       add_external_project(megamol-shader-factory STATIC
         GIT_REPOSITORY https://github.com/UniStuttgart-VISUS/megamol-shader-factory.git
-        GIT_TAG "bc3aa63cd4c22a11adfd2caa6f51ef5cab65df7e"
+        GIT_TAG "v0.4"
         BUILD_BYPRODUCTS
         "<INSTALL_DIR>/${MEGAMOL_SHADER_FACTORY_LIB}"
         DEPENDS glad)

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -596,7 +596,7 @@ function(require_external NAME)
 
       add_external_project(megamol-shader-factory STATIC
         GIT_REPOSITORY https://github.com/UniStuttgart-VISUS/megamol-shader-factory.git
-        GIT_TAG "04c3d154fa17a6fa885bf57d4f1e194cae3e9422"
+        GIT_TAG "bc3aa63cd4c22a11adfd2caa6f51ef5cab65df7e"
         BUILD_BYPRODUCTS
         "<INSTALL_DIR>/${MEGAMOL_SHADER_FACTORY_LIB}"
         DEPENDS glad)

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -589,50 +589,25 @@ function(require_external NAME)
       require_external(glad)
 
       if(WIN32)
-        set(MEGAMOL_SHADER_FACTORY_LIB "lib/megamol-shader-factory.lib")
-        set(GLSLANG_LIB "lib/glslang$<$<CONFIG:Debug>:d>.lib")
-        set(GENERICCODEGEN_LIB "lib/GenericCodeGen$<$<CONFIG:Debug>:d>.lib")
-        set(MACHINEINDEPENDENT_LIB "lib/MachineIndependent$<$<CONFIG:Debug>:d>.lib")
-        set(OSDEPENDENT_LIB "lib/OSDependent$<$<CONFIG:Debug>:d>.lib")
-        set(OGLCOMPILER_LIB "lib/OGLCompiler$<$<CONFIG:Debug>:d>.lib")
-        set(SPIRV_LIB "lib/SPIRV$<$<CONFIG:Debug>:d>.lib")
+        set(MEGAMOL_SHADER_FACTORY_LIB "lib/libmsf_bundle.lib")
       else()
-        include(GNUInstallDirs)
-        set(MEGAMOL_SHADER_FACTORY_LIB "${CMAKE_INSTALL_LIBDIR}/libmegamol-shader-factory.a")
-        set(GLSLANG_LIB "${CMAKE_INSTALL_LIBDIR}/libglslang.a")
-        set(GENERICCODEGEN_LIB "lib/libGenericCodeGen.a")
-        set(MACHINEINDEPENDENT_LIB "lib/libMachineIndependent.a")
-        set(OSDEPENDENT_LIB "lib/libOSDependent.a")
-        set(OGLCOMPILER_LIB "lib/libOGLCompiler.a")
-        set(SPIRV_LIB "lib/libSPIRV.a")
+        set(MEGAMOL_SHADER_FACTORY_LIB "lib/libmsf_bundle.a")
       endif()
-
-      external_get_property(glad INSTALL_DIR)
 
       add_external_project(megamol-shader-factory STATIC
         GIT_REPOSITORY https://github.com/UniStuttgart-VISUS/megamol-shader-factory.git
-        GIT_TAG "v0.3"
+        GIT_TAG "b546e6c5f709a314602dedf08a032353bd59ea80"
         BUILD_BYPRODUCTS
         "<INSTALL_DIR>/${MEGAMOL_SHADER_FACTORY_LIB}"
-        "<INSTALL_DIR>/${GLSLANG_LIB}"
-        "<INSTALL_DIR>/${GENERICCODEGEN_LIB}"
-        "<INSTALL_DIR>/${MACHINEINDEPENDENT_LIB}"
-        "<INSTALL_DIR>/${OSDEPENDENT_LIB}"
-        "<INSTALL_DIR>/${OGLCOMPILER_LIB}"
-        "<INSTALL_DIR>/${SPIRV_LIB}"
-        DEPENDS glad
-        CMAKE_ARGS
-          -DGLAD_IS_SHARED=OFF
-          -DGLAD_PATH=${INSTALL_DIR})
-
-      external_get_property(megamol-shader-factory INSTALL_DIR)
+        DEPENDS glad)
 
       add_external_library(megamol-shader-factory
         LIBRARY ${MEGAMOL_SHADER_FACTORY_LIB}
-        INTERFACE_LIBRARIES glad ${INSTALL_DIR}/$<CONFIG>/${GLSLANG_LIB} ${INSTALL_DIR}/$<CONFIG>/${SPIRV_LIB} ${INSTALL_DIR}/$<CONFIG>/${MACHINEINDEPENDENT_LIB} ${INSTALL_DIR}/$<CONFIG>/${OGLCOMPILER_LIB} ${INSTALL_DIR}/$<CONFIG>/${OSDEPENDENT_LIB} ${INSTALL_DIR}/$<CONFIG>/${GENERICCODEGEN_LIB})
+        INTERFACE_LIBRARIES glad)
       if(UNIX)
         target_link_libraries(megamol-shader-factory INTERFACE "stdc++fs")
       endif()
+      target_compile_definitions(megamol-shader-factory INTERFACE MSF_OPENGL_INCLUDE_GLAD)
 
   # qhull
   elseif(NAME STREQUAL "qhull")

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -596,7 +596,7 @@ function(require_external NAME)
 
       add_external_project(megamol-shader-factory STATIC
         GIT_REPOSITORY https://github.com/UniStuttgart-VISUS/megamol-shader-factory.git
-        GIT_TAG "b546e6c5f709a314602dedf08a032353bd59ea80"
+        GIT_TAG "c9f572c09fbacc847d8d8dfb4ef7c78315645011"
         BUILD_BYPRODUCTS
         "<INSTALL_DIR>/${MEGAMOL_SHADER_FACTORY_LIB}"
         DEPENDS glad)

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -589,14 +589,14 @@ function(require_external NAME)
       require_external(glad)
 
       if(WIN32)
-        set(MEGAMOL_SHADER_FACTORY_LIB "lib/libmsf_bundle.lib")
+        set(MEGAMOL_SHADER_FACTORY_LIB "lib/msf_combined.lib")
       else()
-        set(MEGAMOL_SHADER_FACTORY_LIB "lib/libmsf_bundle.a")
+        set(MEGAMOL_SHADER_FACTORY_LIB "lib/libmsf_combined.a")
       endif()
 
       add_external_project(megamol-shader-factory STATIC
         GIT_REPOSITORY https://github.com/UniStuttgart-VISUS/megamol-shader-factory.git
-        GIT_TAG "c9f572c09fbacc847d8d8dfb4ef7c78315645011"
+        GIT_TAG "04c3d154fa17a6fa885bf57d4f1e194cae3e9422"
         BUILD_BYPRODUCTS
         "<INSTALL_DIR>/${MEGAMOL_SHADER_FACTORY_LIB}"
         DEPENDS glad)

--- a/plugins/doc_megamol101/src/SimplestSphereRenderer.cpp
+++ b/plugins/doc_megamol101/src/SimplestSphereRenderer.cpp
@@ -66,7 +66,7 @@ bool SimplestSphereRenderer::create() {
 
     using namespace megamol::core::utility::log;
 
-    auto const shader_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+    auto const shader_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
     try {
         simpleShader = core::utility::make_glowl_shader(

--- a/plugins/infovis/src/HistogramRenderer2D.cpp
+++ b/plugins/infovis/src/HistogramRenderer2D.cpp
@@ -65,7 +65,7 @@ bool HistogramRenderer2D::create() {
         return false;
     this->font.SetBatchDrawMode(true);
 
-    auto const shader_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+    auto const shader_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
     try {
         calcHistogramProgram =

--- a/plugins/infovis/src/InfovisAmortizedRenderer.cpp
+++ b/plugins/infovis/src/InfovisAmortizedRenderer.cpp
@@ -107,7 +107,7 @@ std::vector<glm::fvec3> InfovisAmortizedRenderer::calculateHammersley(int until,
 }
 
 bool InfovisAmortizedRenderer::makeShaders() {
-    auto const shader_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+    auto const shader_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
     try {
         amort_reconstruction_shdr_array[0] = core::utility::make_glowl_shader("amort_reconstruction0", shader_options,

--- a/plugins/infovis/src/ParallelCoordinatesRenderer2D.cpp
+++ b/plugins/infovis/src/ParallelCoordinatesRenderer2D.cpp
@@ -231,7 +231,7 @@ bool ParallelCoordinatesRenderer2D::create(void) {
     font.SetBatchDrawMode(true);
 #endif
 
-    auto const shader_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+    auto const shader_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
     try {
         drawAxesProgram = core::utility::make_glowl_shader("pc_axes_draw_axes", shader_options,

--- a/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis/src/ScatterplotMatrixRenderer2D.cpp
@@ -291,7 +291,7 @@ ScatterplotMatrixRenderer2D::~ScatterplotMatrixRenderer2D() {
 }
 
 bool ScatterplotMatrixRenderer2D::create() {
-    auto const shader_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+    auto const shader_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
     try {
         minimalisticAxisShader = core::utility::make_glowl_shader("splom_axis_minimalistic", shader_options,

--- a/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
+++ b/plugins/mmstd_volume/src/RaycastVolumeRenderer.cpp
@@ -115,7 +115,7 @@ RaycastVolumeRenderer::~RaycastVolumeRenderer() {
 bool RaycastVolumeRenderer::create() {
     try {
         // create shader program
-        auto const shdr_cp_options = shaderfactory::compiler_options(this->GetCoreInstance()->GetShaderPaths());
+        auto const shdr_cp_options = msf::ShaderFactoryOptionsOpenGL(this->GetCoreInstance()->GetShaderPaths());
 
         rvc_dvr_shdr = core::utility::make_glowl_shader("RaycastVolumeRenderer-Compute", shdr_cp_options,
             std::filesystem::path("RaycastVolumeRenderer-Compute.comp.glsl"));


### PR DESCRIPTION
## Summary of Changes
- Update to new shader factory interface.
- Use Line Translator to fix shader compilation an AMD and Intel
- For changes in shaderfactory see: https://github.com/UniStuttgart-VISUS/megamol-shader-factory/pull/4

## Test Instructions
Test on AMD and Intel.
