### PR TITLE
Fix datraw path separator

### DIFF
--- a/plugins/mmstd_volume/datraw/src/datRaw.c
+++ b/plugins/mmstd_volume/datraw/src/datRaw.c
@@ -31,12 +31,6 @@
 
 #define DATRAW_MAX(x, y)  ((x) > (y) ? (x) : (y))
 
-#ifdef _WIN32
-#define DIR_SEP '\\'
-#else
-#define DIR_SEP '/'
-#endif
-
 static char *dupstr(const char *s)
 {
     char *dup;
@@ -55,14 +49,14 @@ static char *dirname(char *path)
     static char* dot = ".";
     char *s;
 
-    s = path != NULL ? strrchr(path, DIR_SEP) : NULL;
+    s = path != NULL ? strrchr(path, '/') : NULL;
 
     if (!s) {
         return dot;
     } else if (s == path) {
         return path;
     } else if (s[1] == '\0') {
-        while (s != path && *s != DIR_SEP) s--;
+        while (s != path && *s != '/') s--;
         s[1] = '\0';
         return path;
     } else {


### PR DESCRIPTION
## Summary of Changes
- Fix Bug where on Windows the path to raw file from within the dat file is interpreted as relative to the MegaMol work dir. This was "fixed" for Windows only by patching the example files.
- Use uniform path separators for all systems. Paths given from MegaMol into the dat raw reader are also '/'-style on Windows, so assume always '/'-style separators within dat files as well.
- Fixed examples here: https://github.com/UniStuttgart-VISUS/megamol-examples/commit/1ed9de741076e9896440f05985f9502c7ff3bfca