### PR TITLE
Add clang-format check to CI run

### DIFF
--- a/.ci/check_files.sh
+++ b/.ci/check_files.sh
@@ -2,8 +2,11 @@
 
 EXIT_CODE=0
 
-find . -type f -print0 | while read -d $'\0' file
-do
+# Store a list of files which are changed in the current branch compared to the common merge base with master.
+changed_files=$(git diff --name-only master...HEAD)
+git_root=$(git rev-parse --show-toplevel)
+
+find . -type f -print0 | while read -d $'\0' file; do
   # only process file if mime type is text
   mime=$(file -b --mime-type "$file")
   if ! [[ $mime == "text/"* ]]; then
@@ -30,6 +33,30 @@ do
   if [[ $fileinfo == *"BOM"* ]]; then
     EXIT_CODE=1
     echo "ERROR: File starts with BOM: $file"
+    continue
+  fi
+
+  # Get absolute file path and path relative to git root (for comparison with changed_files).
+  # Assume we are always anywhere within the git work dir and just remove git_root based on string pattern.
+  file_abs="$(cd "$(dirname "$file")"; pwd -P)/$(basename "$file")"
+  file_git="${file_abs##"$git_root/"}"
+
+  # If the current file is not changed within this git branch skip the following tests
+  if [[ $changed_files != *"$file_git"* ]]; then
+    continue
+  fi
+
+  # Check if file ends with newline
+  if [[ -n "$(tail -c 1 "$file")" ]]; then
+    EXIT_CODE=1
+    echo "ERROR: File does not end with new line: $file"
+    continue
+  fi
+
+  # Check if file contains tabs
+  if grep -qP "\t" "$file"; then
+    EXIT_CODE=1
+    echo "ERROR: File contains tabs: $file"
     continue
   fi
 done

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,3 +101,26 @@ jobs:
     displayName: 'Run File Checks'
     inputs:
       filePath: '.ci/check_files.sh'
+
+- job: ClangFormatCheck
+  displayName: 'Run ClangFormat Check'
+  pool:
+    name: 'default'
+    demands:
+    - Agent.OS -equals Linux
+    - cmake
+    - megamol_build_enabled
+  steps:
+  - task: CMake@1
+    displayName: 'CMake Configure'
+    inputs:
+      cmakeArgs: '..'
+  - task: CMake@1
+    displayName: 'CMake run ClangFormat'
+    inputs:
+      cmakeArgs: '--build . --target clangformat_all'
+  - task: Bash@3
+    displayName: 'Check for changes with git'
+    inputs:
+      targetType: 'inline'
+      script: git diff --exit-code

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,5 +1,8 @@
 include(CMakeParseArguments)
 
+# bundle target for all clangformat runs
+add_custom_target(clangformat_all)
+
 function(add_clang_format TARGET)
   cmake_parse_arguments(args "" "STYLE" "FILES" ${ARGN})
 
@@ -33,6 +36,7 @@ function(add_clang_format TARGET)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         VERBATIM)
       add_dependencies(${TARGET} "${TARGET}_clangformat")
+      add_dependencies(clangformat_all "${TARGET}_clangformat")
     else()
       message(WARNING "clang-format version ${CLANG_FORMAT_VERSION} is too old.\n"
         "Please download and install a current version from http://releases.llvm.org/download.html\n"


### PR DESCRIPTION
## Summary of Changes
- add clang-format check to CI run
- check for tabs and missing final newline on all files changed within a git branch