### PR TITLE
status badges on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 
 ![](docs/logo.png)
 
+MegaMol is a visualization middleware used to visualize point-based molecular data sets. This software is developed within the Collaborative Research Center 716, subproject ​D.3 at the ​[Visualization Research Center (VISUS)](https://www.visus.uni-stuttgart.de/en) of the University of Stuttgart and at the ​Computer Graphics and Visualization Group of the TU Dresden.  
+
+MegaMol succeeds MolCloud, which has been developed at the University of Stuttgart in order to visualize point-based data sets. MegaMol is written in C++, and uses an OpenGL as Rendering-API and GLSL-Shader. It supports the operating systems Microsoft Windows and Linux, each in 64-bit version. In large parts, MegaMol is based on VISlib, a C++-class library for scientific visualization, which has also been developed at the University of Stuttgart. 
+
+[![Build Status - Azure DevOps Server at VIS[US]][build-button]][build-link]
+<!-- [![Current release][release-button]][release-link] -->
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.][project-button]][project-link] 
+[![License: BSD-3-Clause][license-button]][license-link]
+[![Recent Commit Activity][commit-button]][commit-link]
+
 [build-button]: https://img.shields.io/github/checks-status/UniStuttgart-VISUS/megamol/master?label=Azure%20Pipelines&logo=Azure%20Pipelines
 [build-link]: https://tfs.visus.uni-stuttgart.de/tfs/VIS(US)/MegaMol/_build/latest?definitionId=32&branchName=master
 [release-button]: https://img.shields.io/github/v/release/UniStuttgart-VISUS/megamol
@@ -11,16 +21,6 @@
 [license-link]: LICENSE
 [commit-button]: https://img.shields.io/github/commit-activity/m/UniStuttgart-VISUS/megamol
 [commit-link]: https://github.com/UniStuttgart-VISUS/megamol/commits/master
-
-MegaMol is a visualization middleware used to visualize point-based molecular data sets. This software is developed within the Collaborative Research Center 716, subproject ​D.3 at the ​[Visualization Research Center (VISUS)](https://www.visus.uni-stuttgart.de/en) of the University of Stuttgart and at the ​Computer Graphics and Visualization Group of the TU Dresden.  
-
-MegaMol succeeds MolCloud, which has been developed at the University of Stuttgart in order to visualize point-based data sets. MegaMol is written in C++, and uses an OpenGL as Rendering-API and GLSL-Shader. It supports the operating systems Microsoft Windows and Linux, each in 64-bit version. In large parts, MegaMol is based on VISlib, a C++-class library for scientific visualization, which has also been developed at the University of Stuttgart. 
-
-[![Build Status - Azure DevOps Server at VIS(US)](build-button)](build-link)
-<!-- [![Current release](release-button)](release-link) -->
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](project-button)](project-link) 
-[![License: BSD-3-Clause](license-button)](license-link)
-[![Recent Commit Activity](commit-button)](commit-link)
 
 ## Manual
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 
-![](docs/logo.png)  
+![](docs/logo.png)
+
+[build-button]: https://img.shields.io/github/checks-status/UniStuttgart-VISUS/megamol/master?label=Azure%20Pipelines&logo=Azure%20Pipelines
+[build-link]: https://tfs.visus.uni-stuttgart.de/tfs/VIS(US)/MegaMol/_build/latest?definitionId=32&branchName=master
+[release-button]: https://img.shields.io/github/v/release/UniStuttgart-VISUS/megamol
+[release-link]: https://github.com/UniStuttgart-VISUS/megamol/tags
+[project-button]: https://www.repostatus.org/badges/latest/active.svg
+[project-link]: https://www.repostatus.org/#active
+[license-button]: https://img.shields.io/github/license/UniStuttgart-VISUS/megamol
+[license-link]: LICENSE
+[commit-button]: https://img.shields.io/github/commit-activity/m/UniStuttgart-VISUS/megamol
+[commit-link]: https://github.com/UniStuttgart-VISUS/megamol/commits/master
 
 MegaMol is a visualization middleware used to visualize point-based molecular data sets. This software is developed within the Collaborative Research Center 716, subproject ​D.3 at the ​[Visualization Research Center (VISUS)](https://www.visus.uni-stuttgart.de/en) of the University of Stuttgart and at the ​Computer Graphics and Visualization Group of the TU Dresden.  
 
 MegaMol succeeds MolCloud, which has been developed at the University of Stuttgart in order to visualize point-based data sets. MegaMol is written in C++, and uses an OpenGL as Rendering-API and GLSL-Shader. It supports the operating systems Microsoft Windows and Linux, each in 64-bit version. In large parts, MegaMol is based on VISlib, a C++-class library for scientific visualization, which has also been developed at the University of Stuttgart. 
 
-[![Build Status](https://img.shields.io/github/checks-status/UniStuttgart-VISUS/megamol/master?label=Azure%20Pipelines&logo=Azure%20Pipelines)](https://tfs.visus.uni-stuttgart.de/tfs/VIS(US)/MegaMol/_build/latest?definitionId=32&branchName=master)
-[![Current release](https://img.shields.io/github/v/release/UniStuttgart-VISUS/megamol)](https://github.com/UniStuttgart-VISUS/megamol/tags)
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) 
-[![BSD3 license](https://img.shields.io/github/license/UniStuttgart-VISUS/megamol)](LICENSE)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/UniStuttgart-VISUS/megamol)](https://github.com/UniStuttgart-VISUS/megamol/commits/master)
+[![Build Status - Azure DevOps Server at VIS(US)](build-button)](build-link)
+<!-- [![Current release](release-button)](release-link) -->
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](project-button)](project-link) 
+[![License: BSD-3-Clause](license-button)](license-link)
+[![Recent Commit Activity](commit-button)](commit-link)
 
 ## Manual
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ MegaMol is a visualization middleware used to visualize point-based molecular da
 
 MegaMol succeeds MolCloud, which has been developed at the University of Stuttgart in order to visualize point-based data sets. MegaMol is written in C++, and uses an OpenGL as Rendering-API and GLSL-Shader. It supports the operating systems Microsoft Windows and Linux, each in 64-bit version. In large parts, MegaMol is based on VISlib, a C++-class library for scientific visualization, which has also been developed at the University of Stuttgart. 
 
+[![Build Status](https://img.shields.io/github/checks-status/UniStuttgart-VISUS/megamol/master?label=Azure%20Pipelines&logo=Azure%20Pipelines)](https://tfs.visus.uni-stuttgart.de/tfs/VIS(US)/MegaMol/_build/latest?definitionId=32&branchName=master)
+[![Current release](https://img.shields.io/github/v/release/UniStuttgart-VISUS/megamol)](https://github.com/UniStuttgart-VISUS/megamol/tags)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) 
+[![BSD3 license](https://img.shields.io/github/license/UniStuttgart-VISUS/megamol)](LICENSE)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/UniStuttgart-VISUS/megamol)](https://github.com/UniStuttgart-VISUS/megamol/commits/master)
 
 ## Manual
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ MegaMol is a visualization middleware used to visualize point-based molecular da
 MegaMol succeeds MolCloud, which has been developed at the University of Stuttgart in order to visualize point-based data sets. MegaMol is written in C++, and uses an OpenGL as Rendering-API and GLSL-Shader. It supports the operating systems Microsoft Windows and Linux, each in 64-bit version. In large parts, MegaMol is based on VISlib, a C++-class library for scientific visualization, which has also been developed at the University of Stuttgart. 
 
 [![Build Status - Azure DevOps Server at VIS[US]][build-button]][build-link]
-<!-- [![Current release][release-button]][release-link] -->
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.][project-button]][project-link] 
 [![License: BSD-3-Clause][license-button]][license-link]
 [![Recent Commit Activity][commit-button]][commit-link]
+<!-- [![Current release][release-button]][release-link] -->
 
 [build-button]: https://img.shields.io/github/checks-status/UniStuttgart-VISUS/megamol/master?label=Azure%20Pipelines&logo=Azure%20Pipelines
 [build-link]: https://tfs.visus.uni-stuttgart.de/tfs/VIS(US)/MegaMol/_build/latest?definitionId=32&branchName=master


### PR DESCRIPTION
(Re-)Added some status badges for Readme.md

## Summary of Changes
Using custom shields.io badge for build status, since self hosted azure devops at visus prevents build badge access...

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
