### PR TITLE
Fix examples install path and add install option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,10 @@ if (EXAMPLES)
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif ()
-  install(DIRECTORY "${EXAMPLES_DIR}" DESTINATION "${CMAKE_INSTALL_PREFIX}" PATTERN ".git" EXCLUDE)
+  option(EXAMPLES_INSTALL "Install examples" ON)
+  if (EXAMPLES_INSTALL)
+    install(DIRECTORY "${EXAMPLES_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/examples" PATTERN ".git" EXCLUDE)
+  endif ()
 endif ()
 
 # Validate dependencies


### PR DESCRIPTION
## Summary of Changes
- Fix examples install path: When using a custom examples download dir, the dir name was used for install. Now, examples are always installed to install_dir/examples.
- Add option to skip examples install