### PR TITLE
fix for issue #878

### DIFF
--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -1854,6 +1854,9 @@ void megamol::gui::Graph::Draw(GraphState_t& state) {
             }
 
             ImGui::EndTabItem();
+
+        } else {
+            this->gui_canvas_hovered = false;
         }
 
         ImGui::PopID();

--- a/frontend/services/gui/src/graph/Graph.h
+++ b/frontend/services/gui/src/graph/Graph.h
@@ -164,6 +164,9 @@ namespace gui {
         bool IsCanvasHoverd() const {
             return this->gui_canvas_hovered;
         }
+        bool IsModuleHovered() const {
+            return (this->gui_graph_state.interact.module_hovered_uid != GUI_INVALID_ID);
+        }
 
         void SetLayoutGraph(bool layout = true) {
             this->gui_graph_layout = ((layout) ? (1) : (0));

--- a/frontend/services/gui/src/graph/Graph.h
+++ b/frontend/services/gui/src/graph/Graph.h
@@ -161,7 +161,7 @@ namespace gui {
         ImGuiID GetDropSlot() const {
             return this->gui_graph_state.interact.slot_dropped_uid;
         }
-        bool IsCanvasHoverd() const {
+        bool IsCanvasHovered() const {
             return this->gui_canvas_hovered;
         }
         bool IsModuleHovered() const {

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -180,10 +180,11 @@ void megamol::gui::Configurator::PopUps() {
 
         ImGuiID selected_callslot_uid = selected_graph_ptr->GetSelectedCallSlot();
         ImGuiID selected_group_uid = selected_graph_ptr->GetSelectedGroup();
+        bool is_any_module_hovered = selected_graph_ptr->IsModuleHovered();
 
         bool valid_double_click =
             (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHoverd() &&
-                (selected_group_uid == GUI_INVALID_ID) && (!this->show_module_list_popup));
+                (selected_group_uid == GUI_INVALID_ID) && (!this->show_module_list_popup) && (!is_any_module_hovered));
         bool valid_double_click_callslot =
             (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHoverd() &&
                 (selected_callslot_uid != GUI_INVALID_ID) &&

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -183,10 +183,10 @@ void megamol::gui::Configurator::PopUps() {
         bool is_any_module_hovered = selected_graph_ptr->IsModuleHovered();
 
         bool valid_double_click =
-            (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHoverd() &&
+            (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHovered() &&
                 (selected_group_uid == GUI_INVALID_ID) && (!this->show_module_list_popup) && (!is_any_module_hovered));
         bool valid_double_click_callslot =
-            (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHoverd() &&
+            (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && selected_graph_ptr->IsCanvasHovered() &&
                 (selected_callslot_uid != GUI_INVALID_ID) &&
                 ((!this->show_module_list_popup) || (this->last_selected_callslot_uid != selected_callslot_uid)));
 


### PR DESCRIPTION
- Fix for issue #878: Reset local graph state indicating graph canvas hovering.
- Plus: Prevent module pop-up when double-clicked on modules in graph.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
