### PR TITLE
Frontend: Tiling + Explicit View Render Input

### DIFF
--- a/core/include/mmcore/view/AbstractView.h
+++ b/core/include/mmcore/view/AbstractView.h
@@ -124,6 +124,11 @@ public:
     virtual void SetCamera(Camera camera, bool isMutable = true);
 
     /**
+     * Return the current camera
+     */
+    virtual Camera GetCamera() const;
+
+    /**
     * ...
     */
     virtual void CalcCameraClippingPlanes(float border);

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -9,6 +9,8 @@
 
 #include "AbstractView.h"
 #include "FrontendResource.h"
+
+#include "RenderInput.h"
 #include "ImageWrapper.h"
 
 namespace megamol {
@@ -24,7 +26,7 @@ namespace view {
     MEGAMOLCORE_API void view_consume_mouse_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_window_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_framebuffer_events(AbstractView & view, megamol::frontend::FrontendResource const& resource);
-    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageWrapper& result_image);
+    MEGAMOLCORE_API void view_poke_rendering(AbstractView& view, megamol::frontend_resources::RenderInput const& render_input, megamol::frontend_resources::ImageWrapper& result_image);
 
     // to do this right we should be able to as a view object which runtime resources it expects (keyboard inputs, gl context)
     // and just pass those resources to the view when rendering a frame

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -29,7 +29,7 @@ namespace view {
     // to do this right we should be able to as a view object which runtime resources it expects (keyboard inputs, gl context)
     // and just pass those resources to the view when rendering a frame
     // until we implement the 'optimal' approach, this is the best we can do
-    MEGAMOLCORE_API std::vector<std::string> get_gl_view_runtime_resources_requests();
+    MEGAMOLCORE_API std::vector<std::string> get_view_runtime_resources_requests();
 
     MEGAMOLCORE_API bool view_rendering_execution(
           void* module_ptr

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -25,7 +25,6 @@ namespace view {
     MEGAMOLCORE_API void view_consume_keyboard_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_mouse_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_consume_window_events(AbstractView& view, megamol::frontend::FrontendResource const& resource);
-    MEGAMOLCORE_API void view_consume_framebuffer_events(AbstractView & view, megamol::frontend::FrontendResource const& resource);
     MEGAMOLCORE_API void view_poke_rendering(AbstractView& view, megamol::frontend_resources::RenderInput const& render_input, megamol::frontend_resources::ImageWrapper& result_image);
 
     // to do this right we should be able to as a view object which runtime resources it expects (keyboard inputs, gl context)

--- a/core/include/mmcore/view/AbstractView_EventConsumption.h
+++ b/core/include/mmcore/view/AbstractView_EventConsumption.h
@@ -37,14 +37,6 @@ namespace view {
         , megamol::frontend_resources::ImageWrapper& result_image
     );
 
-    // before rendering the first frame views need to know the current framebuffer size
-    // because they may have beed added to the graph after the initial framebuffer size event, we need this init callback to give them that info
-    MEGAMOLCORE_API bool view_init_rendering_state(
-          void* module_ptr
-        , std::vector<megamol::frontend::FrontendResource> const& resources
-        , megamol::frontend_resources::ImageWrapper& result_image
-    );
-
 } /* end namespace view */
 } /* end namespace core */
 } /* end namespace megamol */

--- a/core/src/view/AbstractView.cpp
+++ b/core/src/view/AbstractView.cpp
@@ -154,6 +154,10 @@ void megamol::core::view::AbstractView::SetCamera(Camera camera, bool isMutable)
     _cameraIsMutable = isMutable;
 }
 
+megamol::core::view::Camera megamol::core::view::AbstractView::GetCamera() const {
+    return _camera;
+}
+
 void megamol::core::view::AbstractView::CalcCameraClippingPlanes(float border) {
     if (_cameraIsMutable) {
         auto cam_pose = _camera.get<Camera::Pose>();

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -68,17 +68,21 @@ void view_poke_rendering(AbstractView& view, megamol::frontend_resources::Render
         started_timer = true;
     }
 
-    const auto render = [&]() {
-        const double instanceTime = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now() - render_view_context_timer_start)
-            .count() / static_cast<double>(1000);
+    const double instanceTime_sec = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::high_resolution_clock::now() - render_view_context_timer_start)
+        .count() / static_cast<double>(1000);
 
-        const double time = view.DefaultTime(instanceTime);
+    const double time_sec = view.DefaultTime(instanceTime_sec);
 
-        result_image = view.Render(time, instanceTime);
-    };
-    
-    render();
+    // copy render inputs from frontend so we can update time
+    auto renderinput = render_input;
+
+    renderinput.instanceTime_sec = instanceTime_sec;
+    renderinput.time_sec = time_sec;
+
+    view.Resize(renderinput.local_view_framebuffer_resolution.x, renderinput.local_view_framebuffer_resolution.y);
+
+    result_image = view.Render(renderinput.time_sec, renderinput.instanceTime_sec);
 }
 
 std::vector<std::string> get_view_runtime_resources_requests() {
@@ -108,8 +112,6 @@ bool view_rendering_execution(
     
     return true;
 }
-
-
 
 } /* end namespace view */
 } /* end namespace core */

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -118,47 +118,7 @@ bool view_rendering_execution(
     return true;
 }
 
-bool view_init_rendering_state(
-      void* module_ptr
-    , std::vector<megamol::frontend::FrontendResource> const& resources
-    , megamol::frontend_resources::ImageWrapper& result_image
-) {
-    megamol::core::view::AbstractView* view_ptr =
-        dynamic_cast<megamol::core::view::AbstractView*>(static_cast<megamol::core::Module*>(module_ptr));
 
-    if (!view_ptr) {
-        std::cout << "error. module is not a view module. could not use as rendering entry point." << std::endl;
-        return false;
-    }
-    
-    megamol::core::view::AbstractView& view = *view_ptr;
-
-    // fake resize events for view to consume
-    auto& framebuffer_events = const_cast<megamol::frontend_resources::FramebufferEvents&>(resources[3].getResource<megamol::frontend_resources::FramebufferEvents>());
-    auto& framebuffer_size = framebuffer_events.previous_state;
-    framebuffer_events.size_events.push_back(framebuffer_size);
-    
-    auto& window_events = const_cast<megamol::frontend_resources::WindowEvents&>(resources[2].getResource<megamol::frontend_resources::WindowEvents>());
-    auto& window_width = window_events.previous_state.width;
-    auto& window_height = window_events.previous_state.height;
-    if(window_width <= 1 || window_height <= 1) {
-        window_width = framebuffer_size.width;
-        window_height = framebuffer_size.height;
-    }
-    window_events.size_events.push_back({window_width, window_height});
-    
-    auto& mouse_events = const_cast<megamol::frontend_resources::MouseEvents&>(resources[1].getResource<megamol::frontend_resources::MouseEvents>());
-    mouse_events.position_events.push_back({
-        mouse_events.previous_state.x_cursor_position,
-        mouse_events.previous_state.y_cursor_position});
-
-    // resources are in order of initial requests from get_gl_view_runtime_resources_requests()
-    megamol::core::view::view_consume_mouse_events(view, resources[1]);
-    megamol::core::view::view_consume_window_events(view, resources[2]);
-    megamol::core::view::view_consume_framebuffer_events(view, resources[3]);
-
-    return true;
-}
 
 } /* end namespace view */
 } /* end namespace core */

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -68,7 +68,7 @@ void view_consume_framebuffer_events(AbstractView& view, megamol::frontend::Fron
 // this is a weird place to measure passed program time, but we do it here so we satisfy _mmcRenderViewContext and nobody else needs to know
 static std::chrono::high_resolution_clock::time_point render_view_context_timer_start;
 
-void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageWrapper& result_image) {
+void view_poke_rendering(AbstractView& view, megamol::frontend_resources::RenderInput const& render_input, megamol::frontend_resources::ImageWrapper& result_image) {
     static bool started_timer = false;
     if (!started_timer) {
         render_view_context_timer_start = std::chrono::high_resolution_clock::now();
@@ -89,7 +89,7 @@ void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageW
 }
 
 std::vector<std::string> get_view_runtime_resources_requests() {
-    return {"KeyboardEvents", "MouseEvents", "WindowEvents", "FramebufferEvents"};
+    return {"ViewRenderInput", "KeyboardEvents", "MouseEvents", "WindowEvents"};
 }
 
 bool view_rendering_execution(
@@ -107,12 +107,11 @@ bool view_rendering_execution(
     
     megamol::core::view::AbstractView& view = *view_ptr;
     
-    // resources are in order of initial requests from get_gl_view_runtime_resources_requests()
-    megamol::core::view::view_consume_keyboard_events(view, resources[0]);
-    megamol::core::view::view_consume_mouse_events(view, resources[1]);
-    megamol::core::view::view_consume_window_events(view, resources[2]);
-    megamol::core::view::view_consume_framebuffer_events(view, resources[3]);
-    megamol::core::view::view_poke_rendering(view, result_image);
+    // resources are in order of initial requests from get_view_runtime_resources_requests()
+    megamol::core::view::view_consume_keyboard_events(view, resources[1]);
+    megamol::core::view::view_consume_mouse_events(view, resources[2]);
+    megamol::core::view::view_consume_window_events(view, resources[3]);
+    megamol::core::view::view_poke_rendering(view, resources[0].getResource<megamol::frontend_resources::RenderInput>(), result_image);
     
     return true;
 }

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -82,6 +82,33 @@ void view_poke_rendering(AbstractView& view, megamol::frontend_resources::Render
 
     view.Resize(renderinput.local_view_framebuffer_resolution.x, renderinput.local_view_framebuffer_resolution.y);
 
+    auto camera = view.GetCamera();
+
+    Camera::AspectRatio aspect = {renderinput.global_framebuffer_resolution.x / static_cast<float>(renderinput.global_framebuffer_resolution.y)};
+    Camera::ImagePlaneTile tile = {renderinput.local_tile_relative_begin, renderinput.local_tile_relative_end};
+
+    switch (camera.getProjectionType()) {
+        case Camera::ProjectionType::ORTHOGRAPHIC:{
+            auto intrinsics = camera.get<Camera::OrthographicParameters>();
+            intrinsics.aspect = aspect;
+            intrinsics.image_plane_tile = tile;
+            camera.setOrthographicProjection(intrinsics);
+            break;
+        }
+        case Camera::ProjectionType::PERSPECTIVE: {
+            auto intrinsics = camera.get<Camera::PerspectiveParameters>();
+            intrinsics.aspect = aspect;
+            intrinsics.image_plane_tile = tile;
+            camera.setPerspectiveProjection(intrinsics);
+            break;
+        }
+        case Camera::ProjectionType::UNKNOWN:
+        default:
+            break;
+    }
+
+    view.SetCamera(camera);
+
     result_image = view.Render(renderinput.time_sec, renderinput.instanceTime_sec);
 }
 

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -58,13 +58,6 @@ void view_consume_window_events(AbstractView& view, megamol::frontend::FrontendR
     }
 }
 
-void view_consume_framebuffer_events(AbstractView& view, megamol::frontend::FrontendResource const& resource) {
-    GET_RESOURCE(FramebufferEvents)//{
-        for (auto& e: events.size_events)
-            view.Resize(static_cast<unsigned int>(e.width), static_cast<unsigned int>(e.height));
-    }
-}
-
 // this is a weird place to measure passed program time, but we do it here so we satisfy _mmcRenderViewContext and nobody else needs to know
 static std::chrono::high_resolution_clock::time_point render_view_context_timer_start;
 

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -10,7 +10,6 @@
 #include "Framebuffer_Events.h"
 #include "KeyboardMouse_Events.h"
 #include "Window_Events.h"
-#include "IOpenGL_Context.h"
 
 #include <chrono>
 
@@ -89,7 +88,7 @@ void view_poke_rendering(AbstractView& view, megamol::frontend_resources::ImageW
     render();
 }
 
-std::vector<std::string> get_gl_view_runtime_resources_requests() {
+std::vector<std::string> get_view_runtime_resources_requests() {
     return {"KeyboardEvents", "MouseEvents", "WindowEvents", "FramebufferEvents"};
 }
 

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -119,6 +119,8 @@ static std::string remote_rendernode_zmq_source_option = "rendernode-zmq-source"
 static std::string remote_headnode_broadcast_quit_option    = "headnode-broadcast-quit";
 static std::string remote_headnode_broadcast_project_option = "headnode-broadcast-project";
 static std::string remote_headnode_connect_at_start_option  = "headnode-connect-at-start";
+static std::string framebuffer_option   = "framebuffer";
+static std::string viewport_tile_option = "tile";
 static std::string help_option          = "h,help";
 
 static void files_exist(std::vector<std::string> vec, std::string const& type) {
@@ -412,6 +414,44 @@ static void window_handler(std::string const& option_name, cxxopts::ParseResult 
     }
 };
 
+static void framebuffer_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
+{
+    auto string = parsed_options[option_name].as<std::string>();
+    // WIDTHxHEIGHT
+    std::regex geometry("(\\d+)x(\\d+)");
+    std::smatch match;
+    if (std::regex_match(string, match, geometry)) {
+        unsigned int width = std::stoul(match[1].str(), nullptr, 10);
+        unsigned int height = std::stoul(match[2].str(), nullptr, 10);
+        config.local_framebuffer_resolution = {{width, height}};
+    } else {
+        exit("framebuffer option needs to be in the following format: WIDTHxHEIGHT, e.g. 200x100");
+    }
+};
+
+static void viewport_tile_handler(std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config)
+{
+    auto string = parsed_options[option_name].as<std::string>();
+    // x,y;LWIDTHxLHEIGHT;GWIDTHxGHEIGHT
+    std::regex geometry("(\\d+),(\\d+):(\\d+)x(\\d+):(\\d+)x(\\d+)");
+    std::smatch match;
+    if (std::regex_match(string, match, geometry)) {
+        using UintPair = std::pair<unsigned int, unsigned int>;
+
+        auto read_pair = [&](int index) {
+            return UintPair{std::stoul(match[index].str(), nullptr, 10), std::stoul(match[index+1].str(), nullptr, 10)};
+        };
+
+        UintPair start_pixel       = read_pair(1);
+        UintPair local_resolution  = read_pair(3);
+        UintPair global_resolution = read_pair(5);
+
+        config.local_viewport_tile = {global_resolution, start_pixel, local_resolution};
+    } else {
+        exit("viewport tile option needs to be in the following format: x,y:LWIDTHxLHEIGHT:GWIDTHxGHEIGHT, e.g. 0,0:200x100:400x200");
+    }
+};
+
 using OptionsListEntry = std::tuple<std::string, std::string, std::shared_ptr<cxxopts::Value>, std::function<void(std::string const&, cxxopts::ParseResult const&, megamol::frontend::RuntimeConfig&)>>;
 
 std::vector<OptionsListEntry> cli_options_list =
@@ -453,6 +493,11 @@ std::vector<OptionsListEntry> cli_options_list =
         , {remote_headnode_broadcast_quit_option,   "Headnode broadcasts mmQuit to rendernodes on shutdown",                    cxxopts::value<bool>(), remote_head_broadcast_quit_handler}
         , {remote_headnode_broadcast_project_option,"Headnode broadcasts initial graph state after project loading at startup", cxxopts::value<bool>(), remote_head_broadcast_project_handler}
         , {remote_headnode_connect_at_start_option, "Headnode starts sender thread at startup",                                 cxxopts::value<bool>(), remote_head_connect_at_start_handler}
+        , {framebuffer_option,   "Size of framebuffer, syntax: --framebuffer WIDTHxHEIGHT",                         cxxopts::value<std::string>(),              framebuffer_handler}
+        , {viewport_tile_option, "Geometry of local viewport tile, syntax: --tile x,y:LWIDTHxLHEIGHT:GWIDTHxGHEIGHT"
+                                 "where x,y is the lower left start pixel of the local tile, "
+                                 "LWIDTHxLHEIGHT is the local framebuffer resolution, "
+                                 "GWIDTHxGHEIGHT is the global framebuffer resolution",                             cxxopts::value<std::string>(),              viewport_tile_handler}
         , {help_option,          "Print help message",                                                              cxxopts::value<bool>(),                     empty_handler}
     };
 

--- a/frontend/main/src/main.cpp
+++ b/frontend/main/src/main.cpp
@@ -127,6 +127,14 @@ int main(const int argc, const char** argv) {
 
     megamol::frontend::ImagePresentation_Service imagepresentation_service;
     megamol::frontend::ImagePresentation_Service::Config imagepresentationConfig;
+    imagepresentationConfig.local_framebuffer_resolution = config.local_framebuffer_resolution;
+    imagepresentationConfig.local_viewport_tile = config.local_viewport_tile.has_value()
+        ? std::make_optional(megamol::frontend::ImagePresentation_Service::Config::Tile{
+            config.local_viewport_tile.value().global_framebuffer_resolution,
+            config.local_viewport_tile.value().tile_start_pixel,
+            config.local_viewport_tile.value().tile_resolution
+        })
+        : std::nullopt;
     imagepresentation_service.setPriority(3); // before render: do things after GL; post render: do things before GL
     megamol::frontend::Command_Service command_service;
 #ifdef MM_CUDA_ENABLED

--- a/frontend/main/src/main.cpp
+++ b/frontend/main/src/main.cpp
@@ -22,8 +22,6 @@
 #include "ImagePresentation_Service.hpp"
 #include "Remote_Service.hpp"
 
-#include <glad/glad.h> /// XXX see temporary fix below
-
 
 static void log(std::string const& text) {
     const std::string msg = "Main: " + text;
@@ -225,8 +223,6 @@ int main(const int argc, const char** argv) {
 
             imagepresentation_service.RenderNextFrame(); // executes graph views, those digest input events like keyboard/mouse, then render
 
-            /// XXX temporary fix to make sure that everything that happens post-draw ends up in default window fbo...
-            glBindFramebuffer(GL_FRAMEBUFFER, 0);
             services.postGraphRender(); // render GUI, glfw swap buffers, stop frame timer
         }
 

--- a/frontend/resources/CMakeLists.txt
+++ b/frontend/resources/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #  # afterwards list the dependencies.
 #  set(DEP_LIST "${DEP_LIST};BUILD_MMSTD_DATATOOLS_PLUGIN BUILD_CORE" CACHE INTERNAL "")
 
+require_external(glm)
+
 require_external(json)
 if (ENABLE_CUESDK)
   require_external(CUESDK)
@@ -35,7 +37,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   #$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
   #$<INSTALL_INTERFACE:include/>
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC json)
+target_link_libraries(${PROJECT_NAME} PUBLIC json glm)
 if (ENABLE_CUESDK)
   target_link_libraries(${PROJECT_NAME} PUBLIC CUESDK)
 endif()

--- a/frontend/resources/include/RenderInput.h
+++ b/frontend/resources/include/RenderInput.h
@@ -1,0 +1,33 @@
+/*
+ * RenderInput.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include <glm/glm.hpp>
+#include <optional>
+
+namespace megamol {
+namespace frontend_resources {
+
+struct RenderInput {
+    glm::uvec2 global_framebuffer_resolution{0, 0}; //< e.g. overall powerwall resolution when tiling, not intended to be used by view
+    glm::uvec2 local_view_framebuffer_resolution{0, 0}; //< resolution with which the View should render into own framebuffer
+
+    glm::dvec2 local_tile_relative_begin{0.0, 0.0}, local_tile_relative_end{1.0, 1.0}; //< relative start and end of image tile in global framebuffer this view is rendering with local resolution. local resolution and effective tile resolution can differ. the view framebuffer should have local resolution.
+
+    struct CameraMatrices {
+        glm::mat4 view;
+        glm::mat4 projection;
+    };
+    std::optional<CameraMatrices> camera_matrices_override = std::nullopt; //< if camera matrices are overridden, this view still needs to render in local resolution
+
+    double instanceTime_sec = 0.0; //< monotone high resolution time in seconds since first frame rendering of some (any) view
+    double time_sec = 0.0; //< time computed by view::TimeControl(instanceTime)
+};
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/resources/include/RuntimeConfig.h
+++ b/frontend/resources/include/RuntimeConfig.h
@@ -67,6 +67,16 @@ struct RuntimeConfig {
     bool screenshot_show_privacy_note = true;
     bool show_version_note = true;
 
+    struct Tile {
+        UintPair global_framebuffer_resolution; // e.g. whole powerwall resolution, needed for tiling
+        UintPair tile_start_pixel;
+        UintPair tile_resolution;
+    };
+    std::optional<Tile> local_viewport_tile = std::nullopt; // defaults to local framebuffer == local tile
+
+    // e.g. window resolution or powerwall projector resolution, will be applied to all views/entry points
+    std::optional<UintPair> local_framebuffer_resolution = std::nullopt;
+
     bool remote_headnode                        = false;
     bool remote_rendernode                      = false;
     bool remote_mpirendernode                   = false;

--- a/frontend/resources/include/RuntimeConfig.h
+++ b/frontend/resources/include/RuntimeConfig.h
@@ -25,6 +25,7 @@ struct RuntimeConfig {
     // general stuff
     using Path = std::string;
     using StringPair = std::pair<std::string/*Config*/, std::string/*Value*/>;
+    using UintPair = std::pair<unsigned int, unsigned int>;
 
     std::vector<Path> configuration_files = {"megamol_config.lua"};               // set only via (multiple) --config in CLI
     std::vector<std::string> configuration_file_contents = {};
@@ -51,8 +52,8 @@ struct RuntimeConfig {
     bool opengl_vsync = false;
     std::optional<std::tuple<unsigned int /*major*/, unsigned int /*minor*/, bool /*true=>core, false=>compat*/>>
         opengl_context_version = {{4, 6, false/*compat*/}};
-    std::optional<std::pair<unsigned int /*width*/,unsigned int /*height*/>> window_size = std::nullopt; // if not set, GLFW service will open window with 3/4 of monitor resolution 
-    std::optional<std::pair<unsigned int /*x*/,unsigned int /*y*/>>          window_position = std::nullopt;
+    std::optional<UintPair> window_size = std::nullopt; // if not set, GLFW service will open window with 3/4 of monitor resolution 
+    std::optional<UintPair> window_position = std::nullopt;
     enum WindowMode {
         fullscreen   = 1 << 0,
         nodecoration = 1 << 1,

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -250,6 +250,8 @@ void ImagePresentation_Service::present_images_to_glfw_window(std::vector<ImageW
     static glfw_window_blit glfw_sink;
     // TODO: glfw_window_blit destuctor gets called after GL context died
 
+    glfw_sink.set_framebuffer_active();
+
     // glfw sink needs to know current glfw framebuffer size
     auto framebuffer_width = window_framebuffer_events.previous_state.width;
     auto framebuffer_height = window_framebuffer_events.previous_state.height;

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -81,7 +81,7 @@ bool ImagePresentation_Service::init(const Config& config) {
         , "RegisterLuaCallbacks"
     };
 
-    m_framebuffer_size_from_resource_handler = [&]() -> std::pair<unsigned int, unsigned int> {
+    m_framebuffer_size_handler = [&]() -> UintPair {
         return {m_window_framebuffer_size.first, m_window_framebuffer_size.second};
     };
 
@@ -189,7 +189,7 @@ namespace {
         megamol::frontend_resources::RenderInput render_input;
 
         // sets (local) fbo resolution of render_input from various sources
-        std::function<std::pair<unsigned int, unsigned int>()> render_input_framebuffer_size_handler;
+        std::function<ImagePresentation_Service::UintPair()> render_input_framebuffer_size_handler;
 
         void update() override {
             auto fbo_size = render_input_framebuffer_size_handler();
@@ -220,7 +220,7 @@ std::tuple<
         // which are not global resources but managed for each entry point individually
         if (request == "ViewRenderInput") {
             unique_data = std::make_unique<ViewRenderInputs>();
-            accessViewRenderInput(unique_data).render_input_framebuffer_size_handler = m_framebuffer_size_from_resource_handler;
+            accessViewRenderInput(unique_data).render_input_framebuffer_size_handler = m_framebuffer_size_handler;
 
             // wrap render input for view in locally handled resource
             resources.push_back({request, accessViewRenderInput(unique_data).render_input});
@@ -346,7 +346,7 @@ void ImagePresentation_Service::fill_lua_callbacks() {
             }
 
             accessViewRenderInput(entry_it->entry_point_data).render_input_framebuffer_size_handler =
-            [=]() -> std::pair<unsigned int, unsigned int> {
+            [=]() -> UintPair {
                 return {width, height};
             };
 

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -146,8 +146,6 @@ using EntryPointInitFunctions =
 std::tuple<
     // rendering execution function
     EntryPointExecutionCallback,
-    // set inital state function
-    EntryPointExecutionCallback,
     // get requested resources function
     std::function<std::vector<std::string>()>
 >;
@@ -157,7 +155,6 @@ static EntryPointInitFunctions get_init_execute_resources(void* ptr) {
         if (auto view_ptr = dynamic_cast<megamol::core::view::AbstractView*>(module_ptr); view_ptr != nullptr) {
             return EntryPointInitFunctions{
                 std::function{megamol::core::view::view_rendering_execution},
-                std::function{megamol::core::view::view_init_rendering_state},
                 std::function{megamol::core::view::get_gl_view_runtime_resources_requests}
             };
         }
@@ -188,7 +185,7 @@ std::vector<FrontendResource> ImagePresentation_Service::map_resources(std::vect
 }
 
 bool ImagePresentation_Service::add_entry_point(std::string name, void* module_raw_ptr) {
-    auto [execute_etry, init_entry, entry_resource_requests] = get_init_execute_resources(module_raw_ptr);
+    auto [execute_etry, entry_resource_requests] = get_init_execute_resources(module_raw_ptr);
 
     auto resource_requests = entry_resource_requests();
     auto resources = map_resources(resource_requests);
@@ -207,12 +204,6 @@ bool ImagePresentation_Service::add_entry_point(std::string name, void* module_r
         });
 
     auto& entry_point = m_entry_points.back();
-
-    if (!init_entry(entry_point.modulePtr, entry_point.entry_point_resources, entry_point.execution_result_image)) {
-        log_error("init function for entry point " + entry_point.moduleName + " failed. Entry point not created.");
-        m_entry_points.pop_back();
-        return false;
-    }
 
     return true;
 }

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -155,7 +155,7 @@ static EntryPointInitFunctions get_init_execute_resources(void* ptr) {
         if (auto view_ptr = dynamic_cast<megamol::core::view::AbstractView*>(module_ptr); view_ptr != nullptr) {
             return EntryPointInitFunctions{
                 std::function{megamol::core::view::view_rendering_execution},
-                std::function{megamol::core::view::get_gl_view_runtime_resources_requests}
+                std::function{megamol::core::view::get_view_runtime_resources_requests},
             };
         }
     }

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -65,6 +65,10 @@ public:
             , ImageWrapper&
             )>;
 
+    struct RenderInputsUpdate {
+        virtual ~RenderInputsUpdate(){};
+    };
+
 private:
 
     std::vector<FrontendResource> m_providedResourceReferences;
@@ -81,6 +85,8 @@ private:
         std::string moduleName;
         void* modulePtr = nullptr;
         std::vector<megamol::frontend::FrontendResource> entry_point_resources;
+        // pimpl to some implementation handling rendering input data
+        std::unique_ptr<RenderInputsUpdate> entry_point_data = std::make_unique<RenderInputsUpdate>();
 
         EntryPointExecutionCallback execute;
         ImageWrapper execution_result_image;
@@ -95,7 +101,11 @@ private:
     std::list<ImagePresentationSink> m_presentation_sinks;
     void present_images_to_glfw_window(std::vector<ImageWrapper> const& images);
 
-    std::vector<megamol::frontend::FrontendResource> map_resources(std::vector<std::string> const& requests);
+    std::tuple<
+        std::vector<FrontendResource>,
+        std::unique_ptr<RenderInputsUpdate>
+    >
+    map_resources(std::vector<std::string> const& requests);
     const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;
 
 };

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -21,8 +21,24 @@ namespace frontend {
 class ImagePresentation_Service final : public AbstractFrontendService {
 public:
     using UintPair = std::pair<unsigned int, unsigned int>;
+    using DoublePair = std::pair<double, double>;
+
+    struct ViewportTile {
+        UintPair global_resolution;
+        DoublePair tile_start_normalized;
+        DoublePair tile_end_normalized;
+    };
 
     struct Config {
+        struct Tile {
+            UintPair global_framebuffer_resolution; // e.g. whole powerwall resolution, needed for tiling
+            UintPair tile_start_pixel;
+            UintPair tile_resolution;
+        };
+        std::optional<Tile> local_viewport_tile = std::nullopt; // defaults to local framebuffer == local tile
+
+        // e.g. window resolution or powerwall projector resolution, will be applied to all views/entry points
+        std::optional<UintPair> local_framebuffer_resolution = std::nullopt;
     };
 
     std::string serviceName() const override { return "ImagePresentation_Service"; }

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -67,6 +67,7 @@ public:
 
     struct RenderInputsUpdate {
         virtual ~RenderInputsUpdate(){};
+        virtual void update() {};
     };
 
 private:
@@ -108,6 +109,9 @@ private:
     map_resources(std::vector<std::string> const& requests);
     const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;
 
+    // feeds view render inputs with framebuffer size from FramebufferEvents resource, if not configured otherwise
+    std::pair<unsigned int, unsigned int> m_window_framebuffer_size = {0, 0};
+    std::function<std::pair<unsigned int, unsigned int>()> m_framebuffer_size_from_resource_handler;
 };
 
 } // namespace frontend

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -112,6 +112,8 @@ private:
     // feeds view render inputs with framebuffer size from FramebufferEvents resource, if not configured otherwise
     std::pair<unsigned int, unsigned int> m_window_framebuffer_size = {0, 0};
     std::function<std::pair<unsigned int, unsigned int>()> m_framebuffer_size_from_resource_handler;
+
+    void fill_lua_callbacks();
 };
 
 } // namespace frontend

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -129,6 +129,7 @@ private:
     // feeds view render inputs with framebuffer size from FramebufferEvents resource, if not configured otherwise
     UintPair m_window_framebuffer_size = {0, 0};
     std::function<UintPair()> m_framebuffer_size_handler;
+    std::function<ViewportTile()> m_viewport_tile_handler;
 
     void fill_lua_callbacks();
 };

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -20,6 +20,7 @@ namespace frontend {
 
 class ImagePresentation_Service final : public AbstractFrontendService {
 public:
+    using UintPair = std::pair<unsigned int, unsigned int>;
 
     struct Config {
     };
@@ -110,8 +111,8 @@ private:
     const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;
 
     // feeds view render inputs with framebuffer size from FramebufferEvents resource, if not configured otherwise
-    std::pair<unsigned int, unsigned int> m_window_framebuffer_size = {0, 0};
-    std::function<std::pair<unsigned int, unsigned int>()> m_framebuffer_size_from_resource_handler;
+    UintPair m_window_framebuffer_size = {0, 0};
+    std::function<UintPair()> m_framebuffer_size_handler;
 
     void fill_lua_callbacks();
 };

--- a/frontend/services/image_presentation/ImagePresentation_Sinks.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Sinks.cpp
@@ -27,6 +27,11 @@ glfw_window_blit::~glfw_window_blit() {
     gl_fbo_handle = 0;
 }
 
+void glfw_window_blit::set_framebuffer_active() {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_ACCUM_BUFFER_BIT);
+}
+
 void glfw_window_blit::set_framebuffer_size(unsigned int width, unsigned int height) {
     fbo_width = width;
     fbo_height = height;

--- a/frontend/services/image_presentation/ImagePresentation_Sinks.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Sinks.hpp
@@ -16,6 +16,7 @@ namespace megamol::frontend {
         glfw_window_blit();
         ~glfw_window_blit();
 
+        void set_framebuffer_active();
         void set_framebuffer_size(unsigned int width, unsigned int height);
         void blit_texture(unsigned int gl_texture_handle, unsigned int texture_width, unsigned int texture_height);
     };

--- a/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
+++ b/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
@@ -275,8 +275,8 @@ void Lua_Service_Wrapper::fill_frontend_resources_callbacks(void* callbacks_coll
         }});
 
     callbacks.add<VoidResult, int, int>(
-        "mmSetFramebufferSize",
-        "(int width, int height)\n\tSet framebuffer dimensions to width x height.",
+        "mmSetWindowFramebufferSize",
+        "(int width, int height)\n\tSet framebuffer dimensions of window to width x height.",
         {[&](int width, int height) -> VoidResult
         {
             if (width <= 0 || height <= 0) {

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -337,7 +337,6 @@ void megamol::frontend_resources::WindowManipulation::set_swap_interval(const un
 
 void megamol::frontend_resources::WindowManipulation::swap_buffers() const {
     glfwSwapBuffers(reinterpret_cast<GLFWwindow*>(window_ptr));
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_ACCUM_BUFFER_BIT);
 }
 
 void megamol::frontend_resources::WindowManipulation::set_fullscreen(const Fullscreen action) const {


### PR DESCRIPTION
Implements **Tiling** for MPI Remote cases (**Powerwall**).
Restructures Image Presentation and View Render Poking to pass a `RenderInput` struct to view event consumption. In the long term we want to pass `RenderInput` to `view.Render()`, but for this we would need to touch all views (again). The curent changes allow to feed arbitrary information to a view. This enables us to tell the view to render in some framebuffer resolution independent of window resolution, as well as pass tiling and camera matrix information to the view.

## Summary of Changes
Restructures `ImagePresentation_Service` and `AbstractView_EventConsumption` to handle and pass around `RenderInput` to views, along with housekeeping of now view-specific render input information.
Introduces `mmSetViewFramebufferSize(string view, int width, int height)` Lua command to set framebuffer resolution for views.
Introduces `--framebuffer` and `--tile` CLI options to set View Framebuffer size and Camera Tile information from CLI, respectively.

## References and Context
Implements Remote Tiling and prepares Camera Matrix injection for VR.

## Bugs, TODO
* **infovis.lua** example not working
    * SplitViewGL not tiling-aware
    * View2DGL Camera State (zoom, pan) not remote synced (via param serialization)
    * Brushing not remote synced
    * Note that remote sync of the graph currently serializes module parameters on the headnode and deserializes them on the rendernode
* **GUI** not tiling-aware?
* **GUI** rendering can not be disabled, leads to bad performance? => restructure for new frontend rendering presentation/blending
* **Screenshots** are still fed from frontbuffer. allow to screenshot ImageWrappers of Entry Point rendering results or some frontend FBO where rendering results got blended into for final presentation.

## Test Instructions
Open your favorite projects and experiment with window-independent view framebuffer resolution via remote console. Note that screenshot are still written from the GL front/backbuffer and not from View Rendering Result Textures yet.

![grafik](https://user-images.githubusercontent.com/44215465/134960383-65196c04-f601-424b-a96f-9af0007f8b9b.png)

Setting up a remote MPI tiling example is more tricky and is provided by the `powerwall_config.lua` configuration file in the `examples/powerwall` directory. Basically you start a bunch of MPI rendernodes with appropriate tiling settings and connect a headnode as remote control. Dont forget to compile your MegaMol with `ENABLE_MPI` activated in CMake and the correct `MPI_GUESS_LIBRARY_NAME` (MSMPI on Windows).

https://user-images.githubusercontent.com/44215465/134998270-71c7a293-b3e2-4dce-84b5-e9fdb6486bdc.mp4

```
Headnode:    ./megamol.exe --headnode -c megamol_config.lua -c ../examples/powerwall/powerwall_config.lua
Rendernodes: mpiexec.exe -n 4 megamol.exe --mpi --rendernode -c megamol_config.lua -c ../examples/powerwall/powerwall_config.lua
```
Beware that when passing config files explicitly to megamol via `-c` you need to pass all config files in the order of evaluation. In this case MegaMol will not implicitly load default config files. The powerwall config file starts a local tiling setup on your machine both for headnode and rendernodes. If the config thinks it runs in the powerwall environment, it will set up a tiling using the powerwall geometry.