### PR TITLE
Cuda fixes

### DIFF
--- a/cmake/msvc.cmake
+++ b/cmake/msvc.cmake
@@ -1,12 +1,9 @@
 #message(WARNING "setting msvc compiler flags")
 
-set(COMMON_CXX_FLAGS "/DNOMINMAX /W3 /openmp /MP /GR /permissive- /Zc:twoPhase-")
+set(COMMON_CXX_FLAGS "/DNOMINMAX /W3 /openmp /MP /GR /permissive- /Zc:twoPhase- /utf-8")
 if (DISABLE_WARNINGS)
   set(COMMON_CXX_FLAGS "${COMMON_CXX_FLAGS} /w")
 endif()
-
-add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 set(CMAKE_CXX_FLAGS_DEBUG "${COMMON_CXX_FLAGS} /MDd /Od /DDEBUG /D_DEBUG /Zi" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_CXX_FLAGS} /MD /DNDEBUG /D_NDEBUG /Ob2 /Ox /Oi" CACHE STRING "" FORCE)

--- a/plugins/molecularmaps/CMakeLists.txt
+++ b/plugins/molecularmaps/CMakeLists.txt
@@ -14,8 +14,8 @@ megamol_plugin(molecularmaps
 
 if (molecularmaps_PLUGIN_ENABLED)
 
-  if(NOT CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
-    message(FATAL_ERROR "Molecularmaps currently only supports CUDA Version 8 or above. The version found was CUDA ${CUDA_VERSION_MAJOR} (${CMAKE_CUDA_COMPILER_VERSION}). Please turn off the Molecularmaps plugin or install a correct version of CUDA." )
+  if(NOT CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    message(FATAL_ERROR "Molecularmaps currently only supports CUDA Version 11 or above. The version found was CUDA ${CUDA_VERSION_MAJOR} (${CMAKE_CUDA_COMPILER_VERSION}). Please turn off the Molecularmaps plugin or install a correct version of CUDA." )
   endif()
 
   set(CMAKE_CUDA_ARCHITECTURES 52)

--- a/plugins/molecularmaps/src/MapGenerator.cpp
+++ b/plugins/molecularmaps/src/MapGenerator.cpp
@@ -4271,9 +4271,7 @@ bool MapGenerator::Render(core::view::CallRender3DGL& call) {
     // Determine the data that is rendered based on the Display mode and
     // update the renderer with the new data.
     if (this->display_param.Param<param::EnumParam>()->Value() == DisplayMode::PROTEIN) {
-        if (this->display_param.Param<param::EnumParam>()->Value() == DisplayMode::PROTEIN) {
-            this->triMeshRenderer.update(&this->faces, &this->vertices, &this->vertexColors, &this->normals);
-        }
+        this->triMeshRenderer.update(&this->faces, &this->vertices, &this->vertexColors, &this->normals);
     } else if (this->display_param.Param<param::EnumParam>()->Value() == DisplayMode::SHADOW) {
         // Get the AO texture.
         auto vector = this->aoCalculator.getVertexShadows();

--- a/plugins/molecularmaps/src/MapGenerator.cpp
+++ b/plugins/molecularmaps/src/MapGenerator.cpp
@@ -3772,15 +3772,14 @@ bool MapGenerator::Render(core::view::CallRender3DGL& call) {
     glDisable(GL_CULL_FACE);
 
     // Get the bounding box, the view direction and the up direction of the camera.
-    cam_type::matrix_type viewTemp, projTemp;
-    call.GetCamera(this->cam);
-    cam.calc_matrices(this->cam_snapshot, viewTemp, projTemp, thecam::snapshot_content::all);
-    glm::vec4 eye_vec = cam.view_vector();
-    glm::vec4 eye_up = cam.up_vector();
-
+    auto cam = call.GetCamera();
     auto bbox = call.AccessBoundingBoxes().BoundingBox();
-    auto eye_dir = vec3f(eye_vec.x, eye_vec.y, eye_vec.z);
-    auto up_dir = vec3f(eye_up.x, eye_up.y, eye_up.z);
+
+    auto dir = cam.getPose().direction;
+    auto dirUp = cam.getPose().up;
+
+    vec3f eye_dir = vec3f(dir.x,dir.y,dir.z);
+    vec3f up_dir = vec3f(dirUp.x, dirUp.y, dirUp.z);
 
     // Has the input data changed or the shader been reloaded?
     if (this->lastDataHash != ctmd->DataHash() || this->computeButton.IsDirty() || shaderReloaded ||
@@ -3806,27 +3805,37 @@ bool MapGenerator::Render(core::view::CallRender3DGL& call) {
             pdb_name = splitString(pdb_name, '\\').back();
             pdb_name = splitString(pdb_name, '/').back();
         }
-        vislib::TString prev_file_path;
+        std::filesystem::path prev_file_path;
         if (this->store_png_path.IsDirty()) {
             prev_file_path = this->store_png_path.Param<param::FilePathParam>()->Value();
             this->store_png_path.ResetDirty();
         }
-        prev_file_path.Append(A2T(pdb_name.c_str()));
-        prev_file_path.Append(_T(".png"));
+        prev_file_path.append(pdb_name.c_str());
+        prev_file_path.append(".png");
         this->store_png_path.Param<param::FilePathParam>()->SetValue(prev_file_path, false);
 
-        prev_file_path.Clear();
+        prev_file_path.clear();
         if (this->store_png_values_path.IsDirty()) {
             prev_file_path = this->store_png_values_path.Param<param::FilePathParam>()->Value();
             this->store_png_values_path.ResetDirty();
         }
-        prev_file_path.Append(A2T(pdb_name.c_str()));
-        prev_file_path.Append(_T("_values.dat"));
+        prev_file_path.append(pdb_name.c_str());
+        prev_file_path.append("_values.dat");
         this->store_png_values_path.Param<param::FilePathParam>()->SetValue(prev_file_path, false);
 
         // Get the colour tables.
-        Color::ReadColorTableFromFile(cut_colour_param.Param<param::FilePathParam>()->Value(), cut_colour_table);
-        Color::ReadColorTableFromFile(group_colour_param.Param<param::FilePathParam>()->Value(), group_colour_table);
+        {
+            auto* wPath = cut_colour_param.Param<param::FilePathParam>()->Value().c_str();
+            vislib::StringA path;
+            path.Append(W2A(wPath));
+            Color::ReadColorTableFromFile(path, cut_colour_table);
+        }
+        {
+            auto* wPath = group_colour_param.Param<param::FilePathParam>()->Value().c_str();
+            vislib::StringA path;
+            path.Append(W2A(wPath));
+            Color::ReadColorTableFromFile(path, group_colour_table);
+        }
 
         if (ctmd->Count() > 0 && ctmd->Objects()[0].GetVertexCount() > 0) {
             // Create local copy of the mesh.
@@ -4192,15 +4201,17 @@ bool MapGenerator::Render(core::view::CallRender3DGL& call) {
         this->store_png_fbo.GetColourTexture(&this->store_png_data[0], 0, GL_RGB, GL_UNSIGNED_BYTE);
 
         if (writeValues) {
-            this->writeValueImage(
-                this->store_png_values_path.Param<param::FilePathParam>()->Value(), *ctmd, this->store_png_data);
+            auto* wPath = this->store_png_values_path.Param<param::FilePathParam>()->Value().c_str();
+            vislib::TString path;
+            path.Append(W2T(wPath));
+            this->writeValueImage(path, *ctmd, this->store_png_data);
         }
 
         this->store_png_image.Image() =
             new vislib::graphics::BitmapImage(this->store_png_fbo.GetWidth(), this->store_png_fbo.GetHeight(), 3U,
                 vislib::graphics::BitmapImage::CHANNELTYPE_BYTE, static_cast<const void*>(&this->store_png_data[0]));
         this->store_png_image.Image()->FlipVertical();
-        if (this->store_png_image.Save(T2A(this->store_png_path.Param<param::FilePathParam>()->Value()))) {
+        if (this->store_png_image.Save(this->store_png_path.Param<param::FilePathParam>()->Value().c_str())) {
             core::utility::log::Log::DefaultLog.WriteMsg(core::utility::log::Log::LEVEL_INFO,
                 "%s: Stored molecular surface map to file: %s", this->ClassName(),
                 T2A(this->store_png_path.Param<param::FilePathParam>()->Value()));

--- a/plugins/molecularmaps/src/MapGenerator.h
+++ b/plugins/molecularmaps/src/MapGenerator.h
@@ -688,12 +688,6 @@ namespace molecularmaps {
         /** min and max values of the buffer */
         std::pair<float, float> bufferMinMax;
 
-        /** the camera object */
-        core::view::Camera_2 cam;
-
-        /** the current camera snapshot */
-        cam_type::snapshot_type cam_snapshot;
-
         /** enables the shutdown of megamol when a screenshot is stored */
         core::param::ParamSlot close_after_screen_store_param;
 

--- a/plugins/molecularmaps/src/TriangleMeshRenderer.cpp
+++ b/plugins/molecularmaps/src/TriangleMeshRenderer.cpp
@@ -201,13 +201,10 @@ bool TriangleMeshRenderer::Render(core::view::CallRender3DGL& call, bool lightin
     }
     shader->use();
 
-    core::view::Camera_2 cam;
-    call.GetCamera(cam);
-    cam_type::snapshot_type snapshot;
-    cam_type::matrix_type view_mat, proj_mat;
-    cam.calc_matrices(snapshot, view_mat, proj_mat, core::thecam::snapshot_content::all);
-    glm::mat4 view = view_mat;
-    glm::mat4 proj = proj_mat;
+    auto cam = call.GetCamera();
+    glm::mat4 view = cam.getViewMatrix();
+    glm::mat4 proj = cam.getProjectionMatrix();
+    auto view_vector = cam.getPose().direction;
 
     glm::vec3 light_direction = glm::vec3(0.75f, -1.0f, 0.0f);
     if (!lighting) {
@@ -217,8 +214,7 @@ bool TriangleMeshRenderer::Render(core::view::CallRender3DGL& call, bool lightin
     glUniformMatrix4fv(shader->getUniformLocation("view"), 1, GL_FALSE, glm::value_ptr(view));
     glUniformMatrix4fv(shader->getUniformLocation("proj"), 1, GL_FALSE, glm::value_ptr(proj));
     glUniform3f(shader->getUniformLocation("light_direction"), light_direction.x, light_direction.y, light_direction.z);
-    glUniform3f(shader->getUniformLocation("viewVec"), snapshot.view_vector.x(), snapshot.view_vector.y(),
-        snapshot.view_vector.z());
+    glUniform3f(shader->getUniformLocation("viewVec"), view_vector.x, view_vector.y, view_vector.z);
 
     glDrawElements(GL_TRIANGLES, static_cast<uint32_t>(this->faces->size()), GL_UNSIGNED_INT, nullptr);
 

--- a/plugins/protein_cuda/CMakeLists.txt
+++ b/plugins/protein_cuda/CMakeLists.txt
@@ -12,9 +12,12 @@ megamol_plugin(protein_cuda
 
 if (protein_cuda_PLUGIN_ENABLED)
 
-  if (NOT CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
-    message(FATAL_ERROR "Protein CUDA currently only supports CUDA Version 8 or above. The version found was CUDA ${CMAKE_CUDA_COMPILER_VERSION}. Please turn off the Protein CUDA plugin or install a correct version of CUDA.")
+  if (NOT CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    message(FATAL_ERROR "Protein CUDA currently only supports CUDA Version 11 or above. The version found was CUDA ${CMAKE_CUDA_COMPILER_VERSION}. Please turn off the Protein CUDA plugin or install a correct version of CUDA.")
   endif ()
+
+  set(CMAKE_CUDA_ARCHITECTURES 52)
+  set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS} -O3")
 
   get_filename_component(CUDA_COMPILER_DIRECTORY "${CMAKE_CUDA_COMPILER}" DIRECTORY)
   get_filename_component(CUDA_BIN_DIR ${CMAKE_CUDA_COMPILER} DIRECTORY)
@@ -39,7 +42,7 @@ if (protein_cuda_PLUGIN_ENABLED)
 
   # Target definition
   target_sources(protein_cuda PRIVATE ${cuda_header_files} ${cuda_source_files})
-  set_target_properties(protein_cuda PROPERTIES CUDA_STANDARD 14)
+  set_target_properties(protein_cuda PROPERTIES CUDA_STANDARD 17)
   target_include_directories(protein_cuda PUBLIC "src/helper_includes" "${CUDA_BIN_DIR}/../include")
   target_link_libraries(protein_cuda PRIVATE cufft)
 


### PR DESCRIPTION
## Summary of Changes
Fixed the molecularmaps plugin so that it works with the new camera.
Fixed the compiler flags for the CUDA compiler (nvcc) for the molecularmaps, as well as the protein_cuda, plugin.
Updated the minium required CUDA version to 11.0 as c++17 is required now.
