### PR TITLE
Fix and refactor MMFTDataWriter

### DIFF
--- a/plugins/mmstd_datatools/src/table/MMFTDataWriter.h
+++ b/plugins/mmstd_datatools/src/table/MMFTDataWriter.h
@@ -1,8 +1,7 @@
-/*
- * MMFTDataWriter.h
- *
- * Copyright (C) 2016 by CGV (TU Dresden)
- * Alle Rechte vorbehalten.
+/**
+ * MegaMol
+ * Copyright (c) 2016, MegaMol Dev Team
+ * All rights reserved.
  */
 #ifndef MEGAMOL_DATATOOLS_MMFTDATAWRITER_H_INCLUDED
 #define MEGAMOL_DATATOOLS_MMFTDATAWRITER_H_INCLUDED
@@ -10,28 +9,22 @@
 
 #include "mmcore/AbstractDataWriter.h"
 #include "mmcore/CallerSlot.h"
-#include "mmstd_datatools/table/TableDataCall.h"
 #include "mmcore/param/ParamSlot.h"
+#include "mmstd_datatools/table/TableDataCall.h"
 
-
-namespace megamol {
-namespace stdplugin {
-namespace datatools {
-namespace table {
-
+namespace megamol::stdplugin::datatools::table {
 
     /**
      * MMFTDataWriter (MegaMol Particle List Dump) file writer
      */
     class MMFTDataWriter : public core::AbstractDataWriter {
     public:
-
         /**
          * Answer the name of this module.
          *
          * @return The name of this module.
          */
-        static const char *ClassName(void) {
+        static const char* ClassName() {
             return "MMFTDataWriter";
         }
 
@@ -40,7 +33,7 @@ namespace table {
          *
          * @return A human readable description of this module.
          */
-        static const char *Description(void) {
+        static const char* Description() {
             return "Binary float table data file writer";
         }
 
@@ -49,7 +42,7 @@ namespace table {
          *
          * @return 'true' if the module is available, 'false' otherwise.
          */
-        static bool IsAvailable(void) {
+        static bool IsAvailable() {
             return true;
         }
 
@@ -58,36 +51,35 @@ namespace table {
          *
          * @return false
          */
-        static bool SupportQuickstart(void) {
+        static bool SupportQuickstart() {
             return false;
         }
 
         /** Ctor. */
-        MMFTDataWriter(void);
+        MMFTDataWriter();
 
         /** Dtor. */
-        virtual ~MMFTDataWriter(void);
+        ~MMFTDataWriter() override;
 
     protected:
-
         /**
          * Implementation of 'Create'.
          *
          * @return 'true' on success, 'false' otherwise.
          */
-        virtual bool create(void);
+        bool create() override;
 
         /**
          * Implementation of 'Release'.
          */
-        virtual void release(void);
+        void release() override;
 
         /**
          * The main function
          *
          * @return True on success
          */
-        virtual bool run(void);
+        bool run() override;
 
         /**
          * Function querying the writers capabilities
@@ -96,21 +88,16 @@ namespace table {
          *
          * @return True on success
          */
-        virtual bool getCapabilities(core::DataWriterCtrlCall& call);
+        bool getCapabilities(core::DataWriterCtrlCall& call) override;
 
     private:
-
         /** The file name of the file to be written */
         core::param::ParamSlot filenameSlot;
 
         /** The slot asking for data */
         core::CallerSlot dataSlot;
-
     };
 
-} /* end namespace table */
-} /* end namespace datatools */
-} /* end namespace stdplugin */
-} /* end namespace megamol */
+} // namespace megamol::stdplugin::datatools::table
 
-#endif /* MEGAMOL_DATATOOLS_MMFTDATAWRITER_H_INCLUDED */
+#endif // MEGAMOL_DATATOOLS_MMFTDATAWRITER_H_INCLUDED


### PR DESCRIPTION
## Summary of Changes
- vislib FastFile will mess up files if the file is not correctly closed manually!!!
- Refactor MMFTDataWriter to use std::ostream and remove vislib completely from it.