### PR TITLE
Frontend Optional Resources

### DIFF
--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -20,6 +20,7 @@
 #include "mmcore/RootModuleNamespace.h"
 
 #include "FrontendResource.h"
+#include "FrontendResourcesLookup.h"
 #include "ImagePresentationEntryPoints.h"
 #include "CommandRegistry.h"
 
@@ -118,8 +119,6 @@ private:
 
     bool delete_call(CallDeletionRequest_t const& request);
 
-    std::vector<megamol::frontend::FrontendResource> get_requested_resources(std::vector<std::string> resource_requests);
-
 
     // the dummy_namespace must be above the call_list_ and module_list_ because it needs to be destroyed AFTER all
     // calls and modules during ~MegaMolGraph()
@@ -131,7 +130,7 @@ private:
     /** List of call that this graph owns */
     CallList_t call_list_;
 
-    std::vector<megamol::frontend::FrontendResource> provided_resources;
+    megamol::frontend_resources::FrontendResourcesLookup provided_resources_lookup;
 
     // for each View in the MegaMol graph we create a GraphEntryPoint
     // that entry point is used by the Image Presentation Service to

--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -26,66 +26,12 @@
 namespace megamol {
 namespace core {
 
-class MEGAMOLCORE_API MegaMolGraph { //: public serializable, public deferrable_construction {
-
-    // todo: where do the descriptionmanagers go?
-    // todo: what about the view / job descriptions?
+class MEGAMOLCORE_API MegaMolGraph {
 public:
-    // todo: constructor(s)? see serialization
-    // todo: probably get rid of RootModuleNamespace altogether
-
-    ///////////////////////////// types ////////////////////////////////////////
-
-
-
-    //////////////////////////// ctor / dtor ///////////////////////////////
-
-    /**
-     * Bare construction as stub for deserialization
-     */
     MegaMolGraph(megamol::core::CoreInstance& core, factories::ModuleDescriptionManager const& moduleProvider,
         factories::CallDescriptionManager const& callProvider);
 
-    /**
-     * No copy-construction. This can only be a legal operation, if we allow deep-copy of Modules in graph.
-     */
-    MegaMolGraph(MegaMolGraph const& rhs) = delete;
-
-    /**
-     * Same argument as for copy-construction.
-     */
-    MegaMolGraph& operator=(MegaMolGraph const& rhs) = delete;
-
-    /**
-     * A move of the graph should be OK, even without changing state of Modules in graph.
-     */
-    MegaMolGraph(MegaMolGraph&& rhs) noexcept;
-
-    /**
-     * Same is true for move-assignment.
-     */
-    MegaMolGraph& operator=(MegaMolGraph&& rhs) noexcept;
-
-    /**
-     * Construction from serialized string.
-     */
-    // MegaMolGraph(std::string const& descr);
-
-    /** dtor */
     virtual ~MegaMolGraph();
-
-    //////////////////////////// END ctor / dtor ///////////////////////////////
-
-
-    //////////////////////////// Satisfy some abstract requirements ///////////////////////////////
-
-
-    // TODO: the 'serializable' and 'deferrable construction' concepts result in basically the same implementation?
-    // serializable
-
-    // deferrable_construction
-
-    //////////////////////////// Modules and Calls loaded from DLLs ///////////////////////////////
 
 private:
     const factories::ModuleDescriptionManager& ModuleProvider();
@@ -151,14 +97,7 @@ public:
         }
     };
 
-    // Create View ?
-
-    // Create Chain Call ?
-
-    // int ListInstatiations(lua_State* L);
-
 private:
-    // get invalidated and the user is helpless
     [[nodiscard]] ModuleList_t::iterator find_module(std::string const& name);
     [[nodiscard]] ModuleList_t::iterator find_module_by_prefix(std::string const& name);
 
@@ -203,78 +142,6 @@ private:
     megamol::frontend_resources::CommandRegistry* m_command_registry = nullptr;
 
     MegaMolGraph_Convenience convenience_functions;
-
-    ////////////////////////// old interface stuff //////////////////////////////////////////////
-public:
-    // TODO: pull necessary 'old' functions to active section above
-    /*
-        bool QueueChainCallInstantiation(const std::string className, const std::string chainStart, const
-    std::string to); bool QueueParamValueChange(const std::string id, const std::string value);
-        // a JSON serialization of all the requests as above (see updateListener)
-        bool QueueGraphChange(const std::string changes);
-        /// @return group id 0 is invalid and means failure
-        uint32_t CreateParamGroup(const std::string name, int size);
-        bool QueueParamGroupValue(const std::string groupName, const std::string id, const std::string value);
-        bool QueueParamGroupValue(uint32_t groupId, const std::string id, const std::string value);
-        bool QueueUpdateFlush();
-        bool AnythingQueued();
-
-        // todo: for everything below, RO version AND RW version? or would we just omit the const and imply the user
-    needs
-        // to lock?
-        ////////////////////////////
-
-        // vislib::SmartPtr<param::AbstractParam> FindParameter(const std::string name, bool quiet = false) const;
-
-        // todo: optionally ask for the parameters of a specific module (name OR module pointer?)
-        inline void EnumerateParameters(std::function<void(const Module&, param::ParamSlot&)> cb) const;
-
-        // todo: optionally pass Module instead of name
-        template <class A, class C>
-        typename std::enable_if<std::is_convertible<A*, Module*>::value && std::is_convertible<C*, Call*>::value,
-            bool>::type
-        EnumerateCallerSlots(std::string module_name, std::function<void(C&)> cb) const;
-
-        // WHY??? this is just EnumerateParameters(FindModule()...) GET RID OF IT!
-        template <class A>
-        typename std::enable_if<std::is_convertible<A*, Module*>::value, bool>::type EnumerateParameterSlots(
-            std::string module_name, std::function<void(param::ParamSlot&)> cb) const;
-
-        size_t GetGlobalParameterHash(void) const;
-
-        // probably just throws everything away?
-        void Cleanup(void);
-
-        // serialize into... JSON? WHY THE FUCK IS THIS IN THE ROOTMODULENAMESPACE!
-        std::string SerializeGraph(void) const;
-
-        // replace the whole graph with whatever is in serialization
-        void Deserialize(std::string othergraph);
-
-        // nope, see below!
-        // void NotifyParameterValueChange(param::ParamSlot& slot) const;
-        // void RegisterParamUpdateListener(param::ParamUpdateListener* pul);
-        // void UnregisterParamUpdateListener(param::ParamUpdateListener* pul);
-
-        // accumulate the stuff the queues ask from the graph and give out a JSON diff right afterwards
-        // bitfield says what (params, modules, whatnot) - and also reports whether something did not happen
-        /// @return some ID to allow for removal of the listener later
-        uint32_t RegisterGraphUpdateListener(
-            std::function<void(std::string, uint32_t field)> func, int32_t serviceBitfield);
-        void UnregisterGraphUpdateListener(uint32_t id);
-
-    private:
-        // todo: signature is weird, data structure might be as well
-        void computeGlobalParameterHash(ModuleNamespace::const_ptr_type path, ParamHashMap_t& map) const;
-        static void compareParameterHash(ParamHashMap_t& one, ParamHashMap_t& other) const;
-
-        void updateFlushIdxList(size_t const processedCount, std::vector<size_t>& list);
-        bool checkForFlushEvent(size_t const eventIdx, std::vector<size_t>& list) const;
-        void shortenFlushIdxList(size_t const eventCount, std::vector<size_t>& list);
-    */
-
-    //    [[nodiscard]] std::shared_ptr<param::AbstractParam> FindParameter(
-    //        std::string const& name, bool quiet = false) const;
 };
 
 

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -88,23 +88,6 @@ megamol::core::MegaMolGraph::MegaMolGraph(megamol::core::CoreInstance& core,
     dummy_namespace->SetCoreInstance(core);
 }
 
-/**
- * A move of the graph should be OK, even without changing state of Modules in graph.
- */
-megamol::core::MegaMolGraph::MegaMolGraph(MegaMolGraph&& rhs) noexcept {}
-
-/**
- * Same is true for move-assignment.
- */
-megamol::core::MegaMolGraph& megamol::core::MegaMolGraph::operator=(MegaMolGraph&& rhs) noexcept { return *this; }
-
-/**
- * Construction from serialized string.
- */
-// megamol::core::MegaMolGraph::MegaMolGraph(std::string const& descr) {
-//}
-
-/** dtor */
 megamol::core::MegaMolGraph::~MegaMolGraph() {
     moduleProvider_ptr = nullptr;
     callProvider_ptr = nullptr;

--- a/core/src/view/AbstractView_EventConsumption.cpp
+++ b/core/src/view/AbstractView_EventConsumption.cpp
@@ -113,7 +113,7 @@ void view_poke_rendering(AbstractView& view, megamol::frontend_resources::Render
 }
 
 std::vector<std::string> get_view_runtime_resources_requests() {
-    return {"ViewRenderInput", "KeyboardEvents", "MouseEvents", "WindowEvents"};
+    return {"ViewRenderInputs", "KeyboardEvents", "MouseEvents", "WindowEvents"};
 }
 
 bool view_rendering_execution(

--- a/frontend/resources/include/FrontendResource.h
+++ b/frontend/resources/include/FrontendResource.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <string>
 #include <any>
 #include <functional>

--- a/frontend/resources/include/FrontendResource.h
+++ b/frontend/resources/include/FrontendResource.h
@@ -14,15 +14,24 @@
 #include <typeinfo>
 
 namespace megamol {
+namespace frontend_resources {
+
+template<typename T>
+using optional = std::optional<std::reference_wrapper<T>>;
+
+}
 namespace frontend {
 
+using megamol::frontend_resources::optional;
 
 class FrontendResource {
 public:
+
     FrontendResource()
         : identifier{""}
         , resource{}
         , type_hash{0}
+        , optional{false}
     {}
 
     template <typename T>
@@ -30,7 +39,11 @@ public:
 
     template <typename T>
     FrontendResource(const std::string& identifier, const T& resource)
-        : identifier{identifier}, resource{std::reference_wrapper<const T>(resource)}, type_hash{typeid(T).hash_code()} {}
+            : identifier{identifier}
+            , resource{std::reference_wrapper<const T>(resource)}
+            , type_hash{typeid(T).hash_code()}
+            , optional{false}
+    {}
 
     const std::string& getIdentifier() const { return identifier; }
 
@@ -39,8 +52,33 @@ public:
     }
 
     template <typename T> T const& getResource() const {
+        if (optional) {
+            std::cout << "FrontendResource fatal error: resource " + this->identifier + " accessed non-optional but is marked as optional";
+            std::cerr << "FrontendResource fatal error: resource " + this->identifier + " accessed non-optional but is marked as optional";
+            std::exit(1);
+        }
+
         //try {
             return std::any_cast<std::reference_wrapper<const T>>(resource).get();
+        //} catch (const std::bad_any_cast& e) {
+        //    return std::nullopt;
+        //}
+    }
+
+    template<typename T>
+    optional<const T> getOptionalResource() const {
+        if (!optional) {
+            std::cout << "FrontendResource fatal error: resource " + this->identifier + " accessed optional but is marked as non-optional";
+            std::cerr << "FrontendResource fatal error: resource " + this->identifier + " accessed optional but is marked as non-optional";
+            std::exit(1);
+        }
+
+        if (!resource.has_value()) {
+            return std::nullopt;
+        }
+
+        //try {
+            return std::make_optional( std::any_cast<std::reference_wrapper<const T>>(resource) );
         //} catch (const std::bad_any_cast& e) {
         //    return std::nullopt;
         //}
@@ -50,10 +88,18 @@ public:
         return type_hash;
     }
 
+    FrontendResource toOptional() const {
+        FrontendResource r = *this;
+        r.optional = true;
+
+        return r;
+    }
+
 private:
     std::string identifier;
     std::any resource;
     std::size_t type_hash = 0;
+    bool optional = false;
 };
 
 

--- a/frontend/resources/include/FrontendResourcesLookup.h
+++ b/frontend/resources/include/FrontendResourcesLookup.h
@@ -1,0 +1,65 @@
+/*
+ * FrontendResourcesLookup.h
+ *
+ * Copyright (C) 2021 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include "FrontendResource.h"
+#include "mmcore/utility/log/Log.h"
+
+#include <iostream>
+#include <vector>
+#include <algorithm> // std::find_if
+
+namespace megamol {
+namespace frontend_resources {
+
+struct FrontendResourcesLookup {
+
+    FrontendResourcesLookup()
+        : resources{}
+    {}
+
+    FrontendResourcesLookup(std::vector<frontend::FrontendResource> const& resources)
+        : resources{resources}
+    {}
+
+    using ResourceLookupResult = std::tuple<bool, std::vector<megamol::frontend::FrontendResource>>;
+
+    ResourceLookupResult get_requested_resources(std::vector<std::string> resource_requests) const {
+        std::vector<megamol::frontend::FrontendResource> result_resources;
+        result_resources.reserve(resource_requests.size());
+
+        bool success = true;
+
+        for (auto& request : resource_requests) {
+            auto dependency_it = std::find_if(this->resources.begin(), this->resources.end(), [&](megamol::frontend::FrontendResource const& dependency) {
+                return request.find(dependency.getIdentifier()) != std::string::npos;
+            });
+
+            bool resource_found = dependency_it != resources.end();
+
+            success &= resource_found;
+
+            if (resource_found) {
+                auto& resource = *dependency_it;
+                result_resources.push_back(resource);
+            } else {
+                auto msg = std::string("FrontendResourcesLookup: Fatal Error: ")
+                    + "\n\tcould not find requested resource " + request;
+                megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
+            }
+        }
+
+        return {success, result_resources};
+    }
+
+    private:
+    std::vector<frontend::FrontendResource> resources;
+};
+
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/resources/include/FrontendResourcesMap.h
+++ b/frontend/resources/include/FrontendResourcesMap.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "FrontendResource.h"
+#include "mmcore/utility/log/Log.h"
 
 #include <vector>
 #include <map>
@@ -32,8 +33,7 @@ struct FrontendResourcesMap {
                     + "\n\tbecause that would lead to ambiguous map entries for your resources "
                     + "\n\tstopping program execution ";
 
-                std::cout << msg << std::endl;
-                std::cerr << msg << std::endl;
+                megamol::core::utility::log::Log::DefaultLog.WriteError(msg.c_str());
                 std::exit(1);
             } else {
                 this->resources.insert({hash, resource});

--- a/frontend/resources/include/IOpenGL_Context.h
+++ b/frontend/resources/include/IOpenGL_Context.h
@@ -1,5 +1,5 @@
 /*
- * OpenGL_Context.h
+ * IOpenGL_Context.h
  *
  * Copyright (C) 2020 by VISUS (Universitaet Stuttgart).
  * Alle Rechte vorbehalten.
@@ -11,10 +11,6 @@ namespace megamol {
 namespace frontend_resources {
 
 struct IOpenGL_Context {
-    virtual void activate() const = 0;
-    virtual void close() const = 0;
-
-    virtual ~IOpenGL_Context() = default;
 };
 
 } /* end namespace frontend_resources */

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -13,6 +13,8 @@
 #include "ImageWrapper.h"
 #include "ImagePresentationSink.h"
 
+#include "FrontendResourcesLookup.h"
+
 #include <list>
 
 namespace megamol {
@@ -85,6 +87,7 @@ public:
     struct RenderInputsUpdate {
         virtual ~RenderInputsUpdate(){};
         virtual void update() {};
+        virtual FrontendResource get_resource() { return {}; };
     };
 
 private:
@@ -120,11 +123,12 @@ private:
     void present_images_to_glfw_window(std::vector<ImageWrapper> const& images);
 
     std::tuple<
-        std::vector<FrontendResource>,
-        std::unique_ptr<RenderInputsUpdate>
+        bool, // success
+        std::vector<FrontendResource>, // resources
+        std::unique_ptr<ImagePresentation_Service::RenderInputsUpdate> // unique_data for entry point
     >
     map_resources(std::vector<std::string> const& requests);
-    const std::vector<FrontendResource>* m_frontend_resources_ptr = nullptr;
+    megamol::frontend_resources::FrontendResourcesLookup m_frontend_resources_lookup;
 
     // feeds view render inputs with framebuffer size from FramebufferEvents resource, if not configured otherwise
     UintPair m_window_framebuffer_size = {0, 0};

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -355,18 +355,6 @@ void megamol::frontend_resources::WindowManipulation::set_fullscreen(const Fulls
 namespace megamol {
 namespace frontend {
 
-void OpenGL_GLFW_Service::OpenGL_Context::activate() const {
-    if (!ptr) return;
-
-    glfwMakeContextCurrent(static_cast<GLFWwindow*>(ptr));
-}
-
-void OpenGL_GLFW_Service::OpenGL_Context::close() const {
-    if (!ptr) return;
-
-    glfwMakeContextCurrent(nullptr);
-}
-
 
 struct OpenGL_GLFW_Service::PimplData {
     GLFWwindow* glfwContextWindowPtr{nullptr};
@@ -500,7 +488,6 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
     auto& window_ptr = m_pimpl->glfwContextWindowPtr;
     window_ptr = ::glfwCreateWindow(initial_width, initial_height,
         m_pimpl->config.windowTitlePrefix.c_str(), nullptr, nullptr);
-    m_opengl_context_impl.ptr = window_ptr;
 
     if (!window_ptr) {
         log_error("Could not create GLFW Window. You probably do not have OpenGL support. Your graphics hardware might "
@@ -512,9 +499,7 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
 
     // we publish a fake GL context to have a resource others can ask for
     // however, we set the actual GL context active for the main thread and leave it active until further design requirements arise
-    m_opengl_context = &m_fake_opengl_context;
     ::glfwMakeContextCurrent(window_ptr);
-    //m_opengl_context_impl.activate();
 
     //if(gladLoadGLLoader((GLADloadproc) glfwGetProcAddress) == 0) {
     if(gladLoadGL() == 0) {
@@ -593,7 +578,7 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
         {"MouseEvents", m_mouseEvents},
         {"WindowEvents", m_windowEvents},
         {"FramebufferEvents", m_framebufferEvents},
-        {"IOpenGL_Context", *m_opengl_context},
+        {"IOpenGL_Context", m_opengl_context},
         {"WindowManipulation", m_windowManipulation}
     };
 

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.hpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.hpp
@@ -107,18 +107,6 @@ private:
     void create_glfw_mouse_cursors();
     void update_glfw_mouse_cursors(const int cursor_id);
 
-    struct OpenGL_Context : public megamol::frontend_resources::IOpenGL_Context {
-        void* ptr = nullptr;
-
-        void activate() const override;
-        void close() const override;
-    };
-
-    struct Fake_OpenGL_Context : public megamol::frontend_resources::IOpenGL_Context {
-        void activate() const override {}
-        void close() const override {}
-    };
-
     // abstract away GLFW library details behind pointer-to-implementation. only use GLFW header in .cpp
     struct PimplData;
     std::unique_ptr<PimplData, std::function<void(PimplData*)>> m_pimpl;
@@ -128,9 +116,7 @@ private:
     MouseEvents m_mouseEvents;
     WindowEvents m_windowEvents;
     FramebufferEvents m_framebufferEvents;
-    OpenGL_Context m_opengl_context_impl;
-    Fake_OpenGL_Context m_fake_opengl_context;
-    frontend_resources::IOpenGL_Context* m_opengl_context;
+    frontend_resources::IOpenGL_Context m_opengl_context;
     WindowManipulation m_windowManipulation;
 
     // this holds references to the event structs we fill. the events are passed to the renderers/views using

--- a/frontend/services/service_collection/FrontendServiceCollection.cpp
+++ b/frontend/services/service_collection/FrontendServiceCollection.cpp
@@ -7,8 +7,11 @@
 
 #include "FrontendServiceCollection.hpp"
 
-#include <algorithm>
+#include "FrontendResourcesLookup.h"
+
+#include <numeric>
 #include <iostream>
+#include <algorithm>
 
 #include "mmcore/utility/log/Log.h"
 
@@ -79,22 +82,24 @@ namespace frontend {
                 m_serviceResources.push_back(r);
         }
 
+        megamol::frontend_resources::FrontendResourcesLookup m_resource_lookup{m_serviceResources};
+
         // for each servie, provide him with requested resources
-        std::vector<FrontendResource> resources;
         for_each_service {
-            resources.clear();
             auto request_names = service.get().getRequestedResourceNames();
+            auto [success, resources] = m_resource_lookup.get_requested_resources(request_names);
 
-            for (auto& name : request_names) {
-                auto modulePtr = findResource(name);
-
-                if (modulePtr) {
-                    resources.push_back(*modulePtr);
-                } else {
-                    // if a requested resource can not be found we fail and should stop program execution
-                    log_error("could not find resource: \"" + name + "\" for service: " + service.get().serviceName());
-                    return false;
-                }
+            if (!success) {
+                // if a requested resource can not be found we fail and should stop program execution
+                log_error("could not find all resources: for service: " + service.get().serviceName()
+                    + "\nRequests: " +
+                          std::accumulate(request_names.begin(), request_names.end(), std::string{},
+                              [](std::string const& lhs, std::string const& rhs) { return lhs + ", " + rhs; })
+                    + "\nFound Resources: " +
+                          std::accumulate(resources.begin(), resources.end(), std::string{},
+                              [](std::string const& lhs, megamol::frontend::FrontendResource const& rhs) { return lhs + ", " + rhs.getIdentifier(); })
+                );
+                return false;
             }
 
             service.get().setRequestedResources(resources);
@@ -103,16 +108,6 @@ namespace frontend {
         return true;
     }
 
-    FrontendResource* FrontendServiceCollection::findResource(std::string const& name) {
-        auto module_it = std::find_if(m_serviceResources.begin(), m_serviceResources.end(),
-            [&](FrontendResource const& resource) { return name == resource.getIdentifier(); });
-
-        if (module_it != m_serviceResources.end())
-            return &(*module_it);
-
-        return nullptr;
-    }
-    
     void FrontendServiceCollection::updateProvidedResources() {
         for_each_service {
             service.get().updateProvidedResources();


### PR DESCRIPTION

## Summary of Changes
Centralizes Frontend Resource Matching in a class, uses that class everywhere in frontend, adds requesting optional resources via `optional<Resource>` 

## References and Context
In preparation of total GL separation in MegaMol, we need to be able to handle the `OpenGL_Context` resource beeing available during runtime or not. The new optional resources features allows that.

## Test Instructions
Since only resource matching/lookup in the frontend changed, simply loading a working project and MegaMol successfully starting up and rendering the project proofs successfull resource matching. Requesting a resource with name `"Resource"` as `"optional<Resource>"` should not shut down MegaMol. Actual resource access is done using the function `
FrontendResource::getOptionalResource<Resource>() -> frontend_resources::optional<const Resource>
`