### PR TITLE
Frontend: Handle Optional OpenGL Context

### DIFF
--- a/frontend/resources/include/Framebuffer_Events.h
+++ b/frontend/resources/include/Framebuffer_Events.h
@@ -38,6 +38,10 @@ struct FramebufferEvents {
         apply_state();
         size_events.clear();
     }
+
+    void append(FramebufferEvents const& other) {
+        size_events.insert(size_events.end(), other.size_events.begin(), other.size_events.end());
+    }
 };
 
 namespace input = frontend_resources;

--- a/frontend/services/command/Command_Service.cpp
+++ b/frontend/services/command/Command_Service.cpp
@@ -19,7 +19,7 @@ static void log_error(std::string const& text) {
 
 bool megamol::frontend::Command_Service::init(void* configPtr) {
 
-    requestedResourceNames = {"KeyboardEvents"};
+    requestedResourceNames = {"optional<KeyboardEvents>"};
     providedResourceReferences = {{frontend_resources::CommandRegistry_Req_Name, commands}};
 
     log("initialized successfully");
@@ -33,9 +33,16 @@ void megamol::frontend::Command_Service::close() {
 }
 
 void megamol::frontend::Command_Service::digestChangedRequestedResources() {
-        auto keyboard_events =
-            &this->requestedResourceReferences[0].getResource<megamol::frontend_resources::KeyboardEvents>();
-        for (auto& key_event : keyboard_events->key_events) {
+        auto maybe_keyboard_events =
+            this->requestedResourceReferences[0].getOptionalResource<megamol::frontend_resources::KeyboardEvents>();
+
+        if (!maybe_keyboard_events.has_value()) {
+            return;
+        }
+
+        megamol::frontend_resources::KeyboardEvents const& keyboard_events = maybe_keyboard_events.value().get();
+
+        for (auto& key_event : keyboard_events.key_events) {
             auto key = std::get<0>(key_event);
             auto action = std::get<1>(key_event);
             auto modifiers = std::get<2>(key_event);

--- a/frontend/services/gui/src/GUI_Service.cpp
+++ b/frontend/services/gui/src/GUI_Service.cpp
@@ -14,10 +14,10 @@
 #include "GUIManager.h"
 #include "ImagePresentationEntryPoints.h"
 #include "KeyboardMouse_Events.h"
+#include "OpenGL_Context.h"
 #include "ProjectLoader.h"
 #include "RuntimeConfig.h"
 #include "ScriptPaths.h"
-#include "OpenGL_Context.h"
 #include "WindowManipulation.h"
 #include "Window_Events.h"
 
@@ -79,9 +79,7 @@ namespace frontend {
         this->m_providedStateResource.provide_gui_visibility = [&](bool show) -> void {
             return this->resource_provide_gui_visibility(show);
         };
-        this->m_providedStateResource.request_gui_scale = [&]() -> float {
-            return this->resource_request_gui_scale();
-        };
+        this->m_providedStateResource.request_gui_scale = [&]() -> float { return this->resource_request_gui_scale(); };
         this->m_providedStateResource.provide_gui_scale = [&](float scale) -> void {
             return this->resource_provide_gui_scale(scale);
         };
@@ -89,13 +87,11 @@ namespace frontend {
         this->resource_provide_gui_scale(m_config.gui_scale);
 
         this->m_providedRegisterWindowResource.register_window =
-            [&](const std::string& name,
-                std::function<void(megamol::gui::AbstractWindow::BasicConfig&)> func) -> void {
+            [&](const std::string& name, std::function<void(megamol::gui::AbstractWindow::BasicConfig&)> func) -> void {
             this->resource_register_window(name, func);
         };
-        this->m_providedRegisterWindowResource.register_popup =
-            [&](const std::string& name, std::weak_ptr<bool> open,
-                std::function<void(void)> func) -> void {
+        this->m_providedRegisterWindowResource.register_popup = [&](const std::string& name, std::weak_ptr<bool> open,
+                                                                    std::function<void(void)> func) -> void {
             this->resource_register_popup(name, open, func);
         };
         this->m_providedRegisterWindowResource.register_notification =
@@ -106,8 +102,7 @@ namespace frontend {
         this->m_gui->SetVisibility(m_config.gui_show);
         this->m_gui->SetScale(m_config.gui_scale);
 
-        megamol::core::utility::log::Log::DefaultLog.WriteInfo(
-            "GUI_Service: initialized successfully");
+        megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: initialized successfully");
 
         return true;
     }
@@ -141,8 +136,8 @@ namespace frontend {
                 this->m_window_size.x = static_cast<float>(std::get<0>(size_event));
                 this->m_window_size.y = static_cast<float>(std::get<1>(size_event));
             }
-            this->m_gui->SetClipboardFunc(window_events._getClipboardString_Func, window_events._setClipboardString_Func,
-                window_events._clipboard_user_data);
+            this->m_gui->SetClipboardFunc(window_events._getClipboardString_Func,
+                window_events._setClipboardString_Func, window_events._clipboard_user_data);
         }
 
         /// KeyboardEvents = resource index 2
@@ -164,7 +159,7 @@ namespace frontend {
             }
             /// WARNING: Changing a constant type will lead to an undefined behavior!
             const_cast<megamol::frontend_resources::KeyboardEvents&>(keyboard_events).key_events = pass_key_events;
-    
+
             std::vector<unsigned int> pass_codepoint_events;
             for (auto& codepoint_event : keyboard_events.codepoint_events) {
                 if (!this->m_gui->OnChar(codepoint_event)) {
@@ -202,10 +197,11 @@ namespace frontend {
                 }
             }
             /// WARNING: Changing a constant type will lead to an undefined behavior!
-            const_cast<megamol::frontend_resources::MouseEvents&>(mouse_events).scroll_events = pass_mouse_scroll_events;
+            const_cast<megamol::frontend_resources::MouseEvents&>(mouse_events).scroll_events =
+                pass_mouse_scroll_events;
 
-            std::vector<std::tuple<megamol::frontend_resources::MouseButton, megamol::frontend_resources::MouseButtonAction,
-                megamol::frontend_resources::Modifiers>>
+            std::vector<std::tuple<megamol::frontend_resources::MouseButton,
+                megamol::frontend_resources::MouseButtonAction, megamol::frontend_resources::Modifiers>>
                 pass_mouse_btn_events;
             for (auto& button_event : mouse_events.buttons_events) {
                 auto button = std::get<0>(button_event);
@@ -254,12 +250,14 @@ namespace frontend {
             frame_statistics.rendered_frames_count);
 
         /// Get window manipulation resource = resource index 11
-        auto maybe_window_manipulation =
-            this->m_requestedResourceReferences[11].getOptionalResource<megamol::frontend_resources::WindowManipulation>();
+        auto maybe_window_manipulation = this->m_requestedResourceReferences[11]
+                                             .getOptionalResource<megamol::frontend_resources::WindowManipulation>();
         if (maybe_window_manipulation.has_value()) {
-            megamol::frontend_resources::WindowManipulation const& window_manipulation = maybe_window_manipulation.value().get();
+            megamol::frontend_resources::WindowManipulation const& window_manipulation =
+                maybe_window_manipulation.value().get();
 
-            const_cast<megamol::frontend_resources::WindowManipulation&>(window_manipulation).set_mouse_cursor(this->m_gui->GetMouseCursor());
+            const_cast<megamol::frontend_resources::WindowManipulation&>(window_manipulation)
+                .set_mouse_cursor(this->m_gui->GetMouseCursor());
         }
     }
 
@@ -321,7 +319,8 @@ namespace frontend {
             frontend_resources::OpenGL_Context const& opengl_context = maybe_opengl_context.value().get();
 
             if (this->m_gui->CreateContext(megamol::gui::ImGuiRenderBackend::OPEN_GL)) {
-                megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: initialized OpenGL backend successfully");
+                megamol::core::utility::log::Log::DefaultLog.WriteInfo(
+                    "GUI_Service: initialized OpenGL backend successfully");
             } else {
                 megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: error creating OpenGL backend");
                 this->setShutdown();

--- a/frontend/services/gui/src/GUI_Service.cpp
+++ b/frontend/services/gui/src/GUI_Service.cpp
@@ -17,6 +17,7 @@
 #include "ProjectLoader.h"
 #include "RuntimeConfig.h"
 #include "ScriptPaths.h"
+#include "OpenGL_Context.h"
 #include "WindowManipulation.h"
 #include "Window_Events.h"
 
@@ -41,7 +42,6 @@ namespace frontend {
         this->m_framebuffer_size = glm::vec2(1.0f, 1.0f);
         this->m_window_size = glm::vec2(1.0f, 1.0f);
         this->m_megamol_graph = nullptr;
-        this->m_gui = nullptr;
         this->m_config = config;
 
         this->m_queuedProjectFiles.clear();
@@ -49,9 +49,9 @@ namespace frontend {
         this->m_providedResourceReferences.clear();
         this->m_requestedResourcesNames = {
             "MegaMolGraph",                               // 0 - sync graph
-            "WindowEvents",                               // 1 - time, size, clipboard
-            "KeyboardEvents",                             // 2 - key press
-            "MouseEvents",                                // 3 - mouse click
+            "optional<WindowEvents>",                     // 1 - time, size, clipboard
+            "optional<KeyboardEvents>",                   // 2 - key press
+            "optional<MouseEvents>",                      // 3 - mouse click
             "optional<OpenGL_Context>",                   // 4 - graphics api for imgui context
             "FramebufferEvents",                          // 5 - viewport size
             "GLFrontbufferToPNG_ScreenshotTrigger",       // 6 - trigger screenshot
@@ -59,70 +59,57 @@ namespace frontend {
             "ProjectLoader",                              // 8 - trigger loading of new running project
             "FrameStatistics",                            // 9 - current fps and ms value
             "RuntimeConfig",                              // 10 - resource paths
-            "WindowManipulation",                         // 11 - GLFW window pointer
+            "optional<WindowManipulation>",               // 11 - GLFW window pointer
             frontend_resources::CommandRegistry_Req_Name, // 12 - Command registry
             "ImagePresentationEntryPoints"                // 13 - Entry point
         };
 
-        // init gui
-        if (config.imgui_rbnd == GUI_Service::ImGuiRenderBackend::OPEN_GL) {
-            if (this->m_gui == nullptr) {
-                this->m_gui = std::make_shared<megamol::gui::GUIManager>();
-                if (this->m_gui != nullptr) {
+        this->m_gui = std::make_shared<megamol::gui::GUIManager>();
 
-                    // Create context
-                    if (this->m_gui->CreateContext(megamol::gui::ImGuiRenderBackend::OPEN_GL)) {
+        // Set function pointer in state resource once
+        this->m_providedStateResource.request_gui_state = [&](bool as_lua) -> std::string {
+            return this->resource_request_gui_state(as_lua);
+        };
+        this->m_providedStateResource.provide_gui_state = [&](const std::string& json_state) -> void {
+            return this->resource_provide_gui_state(json_state);
+        };
+        this->m_providedStateResource.request_gui_visibility = [&]() -> bool {
+            return this->resource_request_gui_visibility();
+        };
+        this->m_providedStateResource.provide_gui_visibility = [&](bool show) -> void {
+            return this->resource_provide_gui_visibility(show);
+        };
+        this->m_providedStateResource.request_gui_scale = [&]() -> float {
+            return this->resource_request_gui_scale();
+        };
+        this->m_providedStateResource.provide_gui_scale = [&](float scale) -> void {
+            return this->resource_provide_gui_scale(scale);
+        };
+        this->resource_provide_gui_visibility(m_config.gui_show);
+        this->resource_provide_gui_scale(m_config.gui_scale);
 
-                        // Set function pointer in state resource once
-                        this->m_providedStateResource.request_gui_state = [&](bool as_lua) -> std::string {
-                            return this->resource_request_gui_state(as_lua);
-                        };
-                        this->m_providedStateResource.provide_gui_state = [&](const std::string& json_state) -> void {
-                            return this->resource_provide_gui_state(json_state);
-                        };
-                        this->m_providedStateResource.request_gui_visibility = [&]() -> bool {
-                            return this->resource_request_gui_visibility();
-                        };
-                        this->m_providedStateResource.provide_gui_visibility = [&](bool show) -> void {
-                            return this->resource_provide_gui_visibility(show);
-                        };
-                        this->m_providedStateResource.request_gui_scale = [&]() -> float {
-                            return this->resource_request_gui_scale();
-                        };
-                        this->m_providedStateResource.provide_gui_scale = [&](float scale) -> void {
-                            return this->resource_provide_gui_scale(scale);
-                        };
-                        this->resource_provide_gui_visibility(config.gui_show);
-                        this->resource_provide_gui_scale(config.gui_scale);
+        this->m_providedRegisterWindowResource.register_window =
+            [&](const std::string& name,
+                std::function<void(megamol::gui::AbstractWindow::BasicConfig&)> func) -> void {
+            this->resource_register_window(name, func);
+        };
+        this->m_providedRegisterWindowResource.register_popup =
+            [&](const std::string& name, std::weak_ptr<bool> open,
+                std::function<void(void)> func) -> void {
+            this->resource_register_popup(name, open, func);
+        };
+        this->m_providedRegisterWindowResource.register_notification =
+            [&](const std::string& name, std::weak_ptr<bool> open, const std::string& message) -> void {
+            this->resource_register_notification(name, open, message);
+        };
 
-                        this->m_providedRegisterWindowResource.register_window =
-                            [&](const std::string& name,
-                                std::function<void(megamol::gui::AbstractWindow::BasicConfig&)> func) -> void {
-                            this->resource_register_window(name, func);
-                        };
-                        this->m_providedRegisterWindowResource.register_popup =
-                            [&](const std::string& name, std::weak_ptr<bool> open,
-                                std::function<void(void)> func) -> void {
-                            this->resource_register_popup(name, open, func);
-                        };
-                        this->m_providedRegisterWindowResource.register_notification =
-                            [&](const std::string& name, std::weak_ptr<bool> open, const std::string& message) -> void {
-                            this->resource_register_notification(name, open, message);
-                        };
+        this->m_gui->SetVisibility(m_config.gui_show);
+        this->m_gui->SetScale(m_config.gui_scale);
 
-                        this->m_gui->SetVisibility(config.gui_show);
-                        this->m_gui->SetScale(config.gui_scale);
+        megamol::core::utility::log::Log::DefaultLog.WriteInfo(
+            "GUI_Service: initialized successfully");
 
-                        megamol::core::utility::log::Log::DefaultLog.WriteInfo(
-                            "GUI_Service: initialized successfully.");
-                        return true;
-                    }
-                }
-            }
-        }
-
-
-        return false;
+        return true;
     }
 
 
@@ -144,81 +131,93 @@ namespace frontend {
         // Check for updates in requested resources --------------------------------
 
         /// WindowEvents = resource index 1
-        auto window_events =
-            &this->m_requestedResourceReferences[1].getResource<megamol::frontend_resources::WindowEvents>();
-        this->m_time = window_events->time;
-        for (auto& size_event : window_events->size_events) {
-            this->m_window_size.x = static_cast<float>(std::get<0>(size_event));
-            this->m_window_size.y = static_cast<float>(std::get<1>(size_event));
+        auto maybe_window_events =
+            this->m_requestedResourceReferences[1].getOptionalResource<megamol::frontend_resources::WindowEvents>();
+        if (maybe_window_events.has_value()) {
+            megamol::frontend_resources::WindowEvents const& window_events = maybe_window_events.value().get();
+
+            this->m_time = window_events.time;
+            for (auto& size_event : window_events.size_events) {
+                this->m_window_size.x = static_cast<float>(std::get<0>(size_event));
+                this->m_window_size.y = static_cast<float>(std::get<1>(size_event));
+            }
+            this->m_gui->SetClipboardFunc(window_events._getClipboardString_Func, window_events._setClipboardString_Func,
+                window_events._clipboard_user_data);
         }
-        this->m_gui->SetClipboardFunc(window_events->_getClipboardString_Func, window_events->_setClipboardString_Func,
-            window_events->_clipboard_user_data);
 
         /// KeyboardEvents = resource index 2
-        auto keyboard_events =
-            &this->m_requestedResourceReferences[2].getResource<megamol::frontend_resources::KeyboardEvents>();
-        std::vector<std::tuple<megamol::frontend_resources::Key, megamol::frontend_resources::KeyAction,
-            megamol::frontend_resources::Modifiers>>
-            pass_key_events;
-        for (auto& key_event : keyboard_events->key_events) {
-            auto key = std::get<0>(key_event);
-            auto action = std::get<1>(key_event);
-            auto modifiers = std::get<2>(key_event);
-            if (!this->m_gui->OnKey(key, action, modifiers)) {
-                pass_key_events.emplace_back(key_event);
-            }
-        }
-        /// WARNING: Changing a constant type will lead to an undefined behavior!
-        const_cast<megamol::frontend_resources::KeyboardEvents*>(keyboard_events)->key_events = pass_key_events;
+        auto maybe_keyboard_events =
+            this->m_requestedResourceReferences[2].getOptionalResource<megamol::frontend_resources::KeyboardEvents>();
+        if (maybe_keyboard_events.has_value()) {
+            megamol::frontend_resources::KeyboardEvents const& keyboard_events = maybe_keyboard_events.value().get();
 
-        std::vector<unsigned int> pass_codepoint_events;
-        for (auto& codepoint_event : keyboard_events->codepoint_events) {
-            if (!this->m_gui->OnChar(codepoint_event)) {
-                pass_codepoint_events.emplace_back(codepoint_event);
+            std::vector<std::tuple<megamol::frontend_resources::Key, megamol::frontend_resources::KeyAction,
+                megamol::frontend_resources::Modifiers>>
+                pass_key_events;
+            for (auto& key_event : keyboard_events.key_events) {
+                auto key = std::get<0>(key_event);
+                auto action = std::get<1>(key_event);
+                auto modifiers = std::get<2>(key_event);
+                if (!this->m_gui->OnKey(key, action, modifiers)) {
+                    pass_key_events.emplace_back(key_event);
+                }
             }
+            /// WARNING: Changing a constant type will lead to an undefined behavior!
+            const_cast<megamol::frontend_resources::KeyboardEvents&>(keyboard_events).key_events = pass_key_events;
+    
+            std::vector<unsigned int> pass_codepoint_events;
+            for (auto& codepoint_event : keyboard_events.codepoint_events) {
+                if (!this->m_gui->OnChar(codepoint_event)) {
+                    pass_codepoint_events.emplace_back(codepoint_event);
+                }
+            }
+            /// WARNING: Changing a constant type will lead to an undefined behavior!
+            const_cast<megamol::frontend_resources::KeyboardEvents&>(keyboard_events).codepoint_events =
+                pass_codepoint_events;
         }
-        /// WARNING: Changing a constant type will lead to an undefined behavior!
-        const_cast<megamol::frontend_resources::KeyboardEvents*>(keyboard_events)->codepoint_events =
-            pass_codepoint_events;
 
         /// MouseEvents = resource index 3
-        auto mouse_events =
-            &this->m_requestedResourceReferences[3].getResource<megamol::frontend_resources::MouseEvents>();
-        std::vector<std::tuple<double, double>> pass_mouse_pos_events;
-        for (auto& position_event : mouse_events->position_events) {
-            auto x_pos = std::get<0>(position_event);
-            auto y_pos = std::get<1>(position_event);
-            if (!this->m_gui->OnMouseMove(x_pos, y_pos)) {
-                pass_mouse_pos_events.emplace_back(position_event);
-            }
-        }
-        /// WARNING: Changing a constant type will lead to an undefined behavior!
-        const_cast<megamol::frontend_resources::MouseEvents*>(mouse_events)->position_events = pass_mouse_pos_events;
+        auto maybe_mouse_events =
+            this->m_requestedResourceReferences[3].getOptionalResource<megamol::frontend_resources::MouseEvents>();
+        if (maybe_mouse_events.has_value()) {
+            megamol::frontend_resources::MouseEvents const& mouse_events = maybe_mouse_events.value().get();
 
-        std::vector<std::tuple<double, double>> pass_mouse_scroll_events;
-        for (auto& scroll_event : mouse_events->scroll_events) {
-            auto x_scroll = std::get<0>(scroll_event);
-            auto y_scroll = std::get<1>(scroll_event);
-            if (!this->m_gui->OnMouseScroll(x_scroll, y_scroll)) {
-                pass_mouse_scroll_events.emplace_back(scroll_event);
+            std::vector<std::tuple<double, double>> pass_mouse_pos_events;
+            for (auto& position_event : mouse_events.position_events) {
+                auto x_pos = std::get<0>(position_event);
+                auto y_pos = std::get<1>(position_event);
+                if (!this->m_gui->OnMouseMove(x_pos, y_pos)) {
+                    pass_mouse_pos_events.emplace_back(position_event);
+                }
             }
-        }
-        /// WARNING: Changing a constant type will lead to an undefined behavior!
-        const_cast<megamol::frontend_resources::MouseEvents*>(mouse_events)->scroll_events = pass_mouse_scroll_events;
+            /// WARNING: Changing a constant type will lead to an undefined behavior!
+            const_cast<megamol::frontend_resources::MouseEvents&>(mouse_events).position_events = pass_mouse_pos_events;
 
-        std::vector<std::tuple<megamol::frontend_resources::MouseButton, megamol::frontend_resources::MouseButtonAction,
-            megamol::frontend_resources::Modifiers>>
-            pass_mouse_btn_events;
-        for (auto& button_event : mouse_events->buttons_events) {
-            auto button = std::get<0>(button_event);
-            auto action = std::get<1>(button_event);
-            auto modifiers = std::get<2>(button_event);
-            if (!this->m_gui->OnMouseButton(button, action, modifiers)) {
-                pass_mouse_btn_events.emplace_back(button_event);
+            std::vector<std::tuple<double, double>> pass_mouse_scroll_events;
+            for (auto& scroll_event : mouse_events.scroll_events) {
+                auto x_scroll = std::get<0>(scroll_event);
+                auto y_scroll = std::get<1>(scroll_event);
+                if (!this->m_gui->OnMouseScroll(x_scroll, y_scroll)) {
+                    pass_mouse_scroll_events.emplace_back(scroll_event);
+                }
             }
+            /// WARNING: Changing a constant type will lead to an undefined behavior!
+            const_cast<megamol::frontend_resources::MouseEvents&>(mouse_events).scroll_events = pass_mouse_scroll_events;
+
+            std::vector<std::tuple<megamol::frontend_resources::MouseButton, megamol::frontend_resources::MouseButtonAction,
+                megamol::frontend_resources::Modifiers>>
+                pass_mouse_btn_events;
+            for (auto& button_event : mouse_events.buttons_events) {
+                auto button = std::get<0>(button_event);
+                auto action = std::get<1>(button_event);
+                auto modifiers = std::get<2>(button_event);
+                if (!this->m_gui->OnMouseButton(button, action, modifiers)) {
+                    pass_mouse_btn_events.emplace_back(button_event);
+                }
+            }
+            /// WARNING: Changing a constant type will lead to an undefined behavior!
+            const_cast<megamol::frontend_resources::MouseEvents&>(mouse_events).buttons_events = pass_mouse_btn_events;
         }
-        /// WARNING: Changing a constant type will lead to an undefined behavior!
-        const_cast<megamol::frontend_resources::MouseEvents*>(mouse_events)->buttons_events = pass_mouse_btn_events;
 
         /// FramebufferEvents = resource index 5
         auto framebuffer_events =
@@ -255,9 +254,13 @@ namespace frontend {
             frame_statistics.rendered_frames_count);
 
         /// Get window manipulation resource = resource index 11
-        auto& window_manipulation =
-            this->m_requestedResourceReferences[11].getResource<megamol::frontend_resources::WindowManipulation>();
-        window_manipulation.set_mouse_cursor(this->m_gui->GetMouseCursor());
+        auto maybe_window_manipulation =
+            this->m_requestedResourceReferences[11].getOptionalResource<megamol::frontend_resources::WindowManipulation>();
+        if (maybe_window_manipulation.has_value()) {
+            megamol::frontend_resources::WindowManipulation const& window_manipulation = maybe_window_manipulation.value().get();
+
+            const_cast<megamol::frontend_resources::WindowManipulation&>(window_manipulation).set_mouse_cursor(this->m_gui->GetMouseCursor());
+        }
     }
 
 
@@ -308,6 +311,27 @@ namespace frontend {
         this->m_requestedResourceReferences = resources;
         if (this->m_gui == nullptr) {
             return;
+        }
+
+        auto maybe_opengl_context =
+            m_requestedResourceReferences[4].getOptionalResource<frontend_resources::OpenGL_Context>();
+
+        if (maybe_opengl_context.has_value() && m_config.imgui_rbnd == GUI_Service::ImGuiRenderBackend::OPEN_GL) {
+            // GL context is active and we need to use it
+            frontend_resources::OpenGL_Context const& opengl_context = maybe_opengl_context.value().get();
+
+            if (this->m_gui->CreateContext(megamol::gui::ImGuiRenderBackend::OPEN_GL)) {
+                megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: initialized OpenGL backend successfully");
+            } else {
+                megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: error creating OpenGL backend");
+                this->setShutdown();
+            }
+        } else {
+            // no GL available
+            if (m_config.imgui_rbnd == GUI_Service::ImGuiRenderBackend::OPEN_GL) {
+                megamol::core::utility::log::Log::DefaultLog.WriteInfo("GUI_Service: no OpenGL_Context available");
+                this->setShutdown();
+            }
         }
 
         /// MegaMolGraph = resource index 0

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -8,7 +8,6 @@
 #include "ImagePresentation_Service.hpp"
 
 #include "WindowManipulation.h"
-#include "Framebuffer_Events.h"
 #include "GUIState.h"
 
 #include "ImageWrapper_to_GLTexture.hpp"
@@ -72,6 +71,7 @@ bool ImagePresentation_Service::init(const Config& config) {
     {
           {"ImagePresentationEntryPoints", m_entry_points_registry_resource} // used by MegaMolGraph to set entry points
         , {"EntryPointToPNG_ScreenshotTrigger", m_entrypointToPNG_trigger}
+        , {"FramebufferEvents", m_global_framebuffer_events}
     };
 
     this->m_requestedResourcesNames =

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -77,7 +77,7 @@ bool ImagePresentation_Service::init(const Config& config) {
           "FrontendResources" // std::vector<FrontendResource>
         , "optional<WindowManipulation>"
         , "FramebufferEvents"
-        , "GUIState"
+        , "optional<GUIState>" // TODO: unused?
         , "RegisterLuaCallbacks"
         , "optional<OpenGL_Context>"
         , "ImageWrapperToPNG_ScreenshotTrigger"

--- a/frontend/services/image_presentation/ImagePresentation_Service.cpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.cpp
@@ -10,6 +10,7 @@
 #include "WindowManipulation.h"
 #include "GUIState.h"
 
+#include "OpenGL_Context.h"
 #include "ImageWrapper_to_GLTexture.hpp"
 #include "ImagePresentation_Sinks.hpp"
 
@@ -63,9 +64,6 @@ bool ImagePresentation_Service::init(const Config& config) {
     m_entry_points_registry_resource.remove_entry_point = [&](std::string name)                         -> bool { return remove_entry_point(name); };
     m_entry_points_registry_resource.rename_entry_point = [&](std::string oldName, std::string newName) -> bool { return rename_entry_point(oldName, newName); };
     m_entry_points_registry_resource.clear_entry_points = [&]() { clear_entry_points(); };
-
-    m_presentation_sinks.push_back(
-        {"GLFW Window Presentation Sink", [&](auto const& images) { this->present_images_to_glfw_window(images); }});
 
     this->m_providedResourceReferences =
     {
@@ -153,9 +151,10 @@ void ImagePresentation_Service::setRequestedResources(std::vector<FrontendResour
     auto& framebuffer_events = m_requestedResourceReferences[2].getResource<megamol::frontend_resources::FramebufferEvents>();
     m_window_framebuffer_size = {framebuffer_events.previous_state.width, framebuffer_events.previous_state.height};
 
+    add_glfw_sink();
+
     fill_lua_callbacks();
 }
-#define m_frontend_resources (*m_frontend_resources_ptr)
 
 void ImagePresentation_Service::updateProvidedResources() {
 }
@@ -187,6 +186,10 @@ void ImagePresentation_Service::RenderNextFrame() {
 }
 
 void ImagePresentation_Service::PresentRenderedImages() {
+    // before presenting to the sinks, we need to apply the latest global fbo size changes
+    // this way sinks can access the current fbo size as previous_state
+    m_global_framebuffer_events.clear();
+
     // pull result images into separate list
     static std::vector<ImageWrapper> wrapped_images;
     wrapped_images.clear();
@@ -364,6 +367,18 @@ bool ImagePresentation_Service::clear_entry_points() {
     m_entry_points.clear();
 
     return true;
+}
+
+void ImagePresentation_Service::add_glfw_sink() {
+    auto maybe_gl_context = m_requestedResourceReferences[5].getOptionalResource<megamol::frontend_resources::OpenGL_Context>();
+
+    if (maybe_gl_context == std::nullopt) {
+        log_warning("no GLFW OpenGL_Context resource available");
+        return;
+    }
+
+    m_presentation_sinks.push_back(
+        {"GLFW Window Presentation Sink", [&](auto const& images) { this->present_images_to_glfw_window(images); }});
 }
 
 void ImagePresentation_Service::present_images_to_glfw_window(std::vector<ImageWrapper> const& images) {

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -119,6 +119,8 @@ private:
     bool clear_entry_points();
 
     std::list<ImagePresentationSink> m_presentation_sinks;
+
+    void add_glfw_sink();
     void present_images_to_glfw_window(std::vector<ImageWrapper> const& images);
 
     std::tuple<

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -15,6 +15,8 @@
 
 #include "FrontendResourcesLookup.h"
 
+#include "Framebuffer_Events.h"
+
 #include <list>
 
 namespace megamol {
@@ -90,6 +92,8 @@ private:
     std::vector<FrontendResource> m_providedResourceReferences;
     std::vector<std::string> m_requestedResourcesNames;
     std::vector<FrontendResource> m_requestedResourceReferences;
+
+    frontend_resources::FramebufferEvents m_global_framebuffer_events;
 
     // for each View in the MegaMol graph we create a GraphEntryPoint with corresponding callback for resource/input consumption
     // the ImagePresentation Service makes sure that the (lifetime and rendering) resources/dependencies requested by the module

--- a/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/OpenGL_GLFW_Service.cpp
@@ -577,13 +577,14 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
         {"KeyboardEvents", m_keyboardEvents},
         {"MouseEvents", m_mouseEvents},
         {"WindowEvents", m_windowEvents},
-        {"FramebufferEvents", m_framebufferEvents},
+        //{"FramebufferEvents", m_framebufferEvents}, // pushes own events into global FramebufferEvents
         {"OpenGL_Context", m_opengl_context},
         {"WindowManipulation", m_windowManipulation}
     };
 
     m_requestedResourcesNames = {
-          "FrameStatistics"
+          "FrameStatistics",
+          "FramebufferEvents"
     };
 
     m_pimpl->last_time = std::chrono::system_clock::now();
@@ -756,10 +757,12 @@ void OpenGL_GLFW_Service::updateProvidedResources() {
     auto& should_close_events = this->m_windowEvents.should_close_events;
     if (should_close_events.size() && std::count(should_close_events.begin(), should_close_events.end(), true))
         this->setShutdown(true); // cleanup of this service and dependent GL stuff is triggered via this shutdown hint
+
+    auto& global_framebuffer_events = const_cast<FramebufferEvents&>(m_requestedResourceReferences[1].getResource<FramebufferEvents>());
+    global_framebuffer_events.append(m_framebufferEvents);
 }
 
 void OpenGL_GLFW_Service::digestChangedRequestedResources() {
-    // we dont depend on outside resources
 }
 
 void OpenGL_GLFW_Service::resetProvidedResources() {

--- a/frontend/services/project_loader/ProjectLoader_Service.cpp
+++ b/frontend/services/project_loader/ProjectLoader_Service.cpp
@@ -58,7 +58,7 @@ bool ProjectLoader_Service::init(const Config& config) {
     {
         "ExecuteLuaScript",
         "SetScriptPath",
-        "WindowEvents"
+        "optional<WindowEvents>"
     };
 
     log("initialized successfully");
@@ -163,12 +163,16 @@ void ProjectLoader_Service::digestChangedRequestedResources() {
     // break this recursion
     if (m_digestion_recursion)
         return;
-    m_digestion_recursion = true;
 
     // execute lua files dropped into megamol window
-    using WindowEventsType = megamol::frontend_resources::WindowEvents;
-    WindowEventsType& window_events =
-        const_cast<WindowEventsType&>(this->m_requestedResourceReferences[2].getResource<WindowEventsType>());
+    auto maybe_window_events = this->m_requestedResourceReferences[2].getOptionalResource<frontend_resources::WindowEvents>();
+    if (!maybe_window_events.has_value()) {
+        return;
+    }
+
+    m_digestion_recursion = true;
+
+    auto& window_events = const_cast<frontend_resources::WindowEvents&>(maybe_window_events.value().get());
 
     // in mmRenderNextFrame recursion the dropped paths get cleared. remember them.
     auto possible_files = window_events.dropped_path_events;

--- a/frontend/services/remote_service/Remote_Service.cpp
+++ b/frontend/services/remote_service/Remote_Service.cpp
@@ -129,7 +129,7 @@ bool Remote_Service::init(const Config& config) {
     {
           "MegaMolGraph"
         , "ExecuteLuaScript" // std::function<std::tuple<bool,std::string>(std::string const&)>
-        , "GUIRegisterWindow"
+        , "optional<GUIRegisterWindow>"
     };
 
     m_do_remote_things = std::function{[&]() {}};
@@ -326,7 +326,14 @@ void Remote_Service::add_headnode_remote_command(HeadNodeRemoteControl::Command 
 }
 
 void Remote_Service::remote_control_window() {
-    auto &gui_window_request_resource = m_requestedResourceReferences[2].getResource<megamol::frontend_resources::GUIRegisterWindow>();
+    auto maybe_gui_window_request_resource = m_requestedResourceReferences[2].getOptionalResource<megamol::frontend_resources::GUIRegisterWindow>();
+
+    if (!maybe_gui_window_request_resource.has_value()) {
+        return;
+    }
+
+    auto& gui_window_request_resource = maybe_gui_window_request_resource.value().get();
+
     gui_window_request_resource.register_window("Head Node Remote Control", [&](megamol::gui::AbstractWindow::BasicConfig& window_config) {
         window_config.flags = ImGuiWindowFlags_AlwaysAutoResize;
 

--- a/frontend/services/screenshot_service/Screenshot_Service.cpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.cpp
@@ -204,9 +204,6 @@ bool Screenshot_Service::init(const Config& config) {
 }
 
 void Screenshot_Service::close() {
-    // close libraries or APIs you manage
-    // wrap up resources your service provides, but don not depend on outside resources to be available here
-    // after this, at some point only the destructor of your service gets called
 }
 
 std::vector<FrontendResource>& Screenshot_Service::getProvidedResources() {
@@ -217,6 +214,7 @@ std::vector<FrontendResource>& Screenshot_Service::getProvidedResources() {
         {"GLFrontbufferToPNG_ScreenshotTrigger", m_frontbufferToPNG_trigger},
         {"ImageWrapperToPNG_ScreenshotTrigger", m_imagewrapperToPNG_trigger}
     };
+
 
     return m_providedResourceReferences;
 }
@@ -246,27 +244,12 @@ void Screenshot_Service::digestChangedRequestedResources() {
 }
 
 void Screenshot_Service::resetProvidedResources() {
-    // this gets called at the end of the main loop iteration
-    // since the current resources state should have been handled in this frame already
-    // you may clean up resources whose state is not needed for the next iteration
-    // e.g. m_keyboardEvents.clear();
-    // network_traffic_buffer.reset_to_empty();
 }
 
 void Screenshot_Service::preGraphRender() {
-    // this gets called right before the graph is told to render something
-    // e.g. you can start a start frame timer here
-
-    // rendering via MegaMol View is called after this function finishes
-    // in the end this calls the equivalent of ::mmcRenderView(hView, &renderContext)
-    // which leads to view.Render()
 }
 
 void Screenshot_Service::postGraphRender() {
-    // the graph finished rendering and you may more stuff here
-    // e.g. end frame timer
-    // update window name
-    // swap buffers, glClear
 }
 
 

--- a/frontend/services/screenshot_service/Screenshot_Service.hpp
+++ b/frontend/services/screenshot_service/Screenshot_Service.hpp
@@ -54,6 +54,8 @@ public:
     // bool shouldShutdown() const; // shutdown initially false
     // void setShutdown(const bool s = true);
 
+    static unsigned char default_alpha_value;
+
 private:
     megamol::frontend_resources::GLScreenshotSource m_frontbufferSource_resource;
     megamol::frontend_resources::ScreenshotImageDataToPNGWriter m_toFileWriter_resource;

--- a/frontend/services/screenshot_service/gl/GLScreenshotSource.cpp
+++ b/frontend/services/screenshot_service/gl/GLScreenshotSource.cpp
@@ -1,0 +1,61 @@
+/*
+ * GLScreenshotSource.cpp
+ *
+ * Copyright (C) 2021 by MegaMol Team
+ * Alle Rechte vorbehalten.
+ */
+
+#include "Screenshot_Service.hpp"
+
+// to grab GL front buffer
+#include <glad/glad.h>
+
+void megamol::frontend_resources::GLScreenshotSource::set_read_buffer(ReadBuffer buffer) {
+    m_read_buffer = buffer;
+    GLenum read_buffer;
+
+    switch (buffer) {
+    default:
+        [[fallthrough]];
+    case ReadBuffer::FRONT:
+            read_buffer = GL_FRONT;
+        break;
+    case ReadBuffer::BACK:
+            read_buffer = GL_BACK;
+        break;
+    case ReadBuffer::COLOR_ATT0:
+            read_buffer = GL_COLOR_ATTACHMENT0;
+        break;
+    case ReadBuffer::COLOR_ATT1:
+            read_buffer = GL_COLOR_ATTACHMENT0+1;
+        break;
+    case ReadBuffer::COLOR_ATT2:
+            read_buffer = GL_COLOR_ATTACHMENT0+2;
+        break;
+    case ReadBuffer::COLOR_ATT3:
+            read_buffer = GL_COLOR_ATTACHMENT0+3;
+        break;
+    }
+}
+
+megamol::frontend_resources::ScreenshotImageData const& megamol::frontend_resources::GLScreenshotSource::take_screenshot() const {
+    // TODO: in FBO-based rendering the FBO object carries its size and we dont need to look it up
+    // simpler and more correct approach would be to observe Framebuffer_Events resource
+    // but this is our naive implementation for now
+    GLint viewport_dims[4] = {0};
+    glGetIntegerv(GL_VIEWPORT, viewport_dims);
+    GLint fbWidth = viewport_dims[2];
+    GLint fbHeight = viewport_dims[3];
+
+    static ScreenshotImageData result;
+    result.resize(static_cast<size_t>(fbWidth), static_cast<size_t>(fbHeight));
+
+    glReadBuffer(m_read_buffer);
+    glReadPixels(0, 0, fbWidth, fbHeight, GL_RGBA, GL_UNSIGNED_BYTE, result.image.data());
+
+    for (auto& pixel : result.image)
+        pixel.a = megamol::frontend::Screenshot_Service::default_alpha_value;
+
+    return result;
+}
+


### PR DESCRIPTION
Changes resource usage of resources provdided by the OpenGL_GLFW_Service to `optional<>` such that the frontend can run without OpenGL.

## Bugs
* GUI Service internals are hard to separate
* `TrackingShotRenderer` / `~CinematicUtils()` / `~SDFFont()` use GL calls in destructor during GUI module stock loading

## CPU-only TODOs
* global format for CPU FBOs (CPU Views, Imgui CPU Backend, frontend_resources::ImageWrapper)
* CPU image sink (Image Presentation): screenshots, websocket, send via remote service? image compression?
* how to close CPU megamol? CTRL+C handler? easier remote console access? command prompt?
* Imgui CPU backend