### PR TITLE
Load Resources Relative To Executable Path

### DIFF
--- a/core/include/mmcore/LuaInterpreter.h
+++ b/core/include/mmcore/LuaInterpreter.h
@@ -553,7 +553,9 @@ template <class T> int megamol::core::LuaInterpreter<T>::help(lua_State *L) {
     std::stringstream out;
     out << "MegaMol Lua Help:" << std::endl;
     std::string helpString;
-    for (const auto &s : theHelp)
+    auto copy = theHelp;
+    std::sort(copy.begin(), copy.end());
+    for (const auto &s : copy)
         helpString += s.first + s.second + "\n";
     out << helpString;
     lua_pushstring(L, out.str().c_str());

--- a/frontend/main/extra/install_megamol_config_lua.cmake.in
+++ b/frontend/main/extra/install_megamol_config_lua.cmake.in
@@ -11,6 +11,7 @@ set(SUPER_SOURCE_FILE "@CMAKE_CURRENT_SOURCE_DIR@/extra/megamol_config.lua.in")
 
 if(${SUPER_SOURCE_FILE} IS_NEWER_THAN ${TARGET_FILE})
     message(STATUS "Install: ${TARGET_FILE}")
+    file(RENAME "${TARGET_FILE}" "${TARGET_FILE}.safety_backup")
     file(INSTALL ${SOURCE_FILE} DESTINATION ${TARGET_DIR})
 else()
     message(STATUS "Skipped: ${TARGET_FILE} (existing file is newer)")

--- a/frontend/main/extra/megamol_config.lua.in
+++ b/frontend/main/extra/megamol_config.lua.in
@@ -32,7 +32,8 @@ print("Default MegaMol Frontend 3000 Configuration:")
 -- The key and value strings must not contain space, = or : characters
 mmSetGlobalValue("MegaMol", "Frontend3000") -- CLI: --global=MegaMol:Frontend3000
  
-basePath = "${CMAKE_INSTALL_PREFIX}/"
+exeutableDirPath = mmGetMegaMolExecutableDirectory()
+basePath = exeutableDirPath .. "../"
 
 -- Log Levels: 0=None, 1=Error, 100=Warn, 200=INFO, *=ALL
 -- You can provide an integer (as string) 

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -612,6 +612,7 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_config(
     using megamol::frontend_resources::LuaCallbacksCollection;
     using Error = megamol::frontend_resources::LuaCallbacksCollection::LuaError;
     using VoidResult = megamol::frontend_resources::LuaCallbacksCollection::VoidResult;
+    using StringResult = megamol::frontend_resources::LuaCallbacksCollection::StringResult;
 
 #define sane(s)                                                  \
     if (s.empty() || s.find_first_of(" =") != std::string::npos) \
@@ -701,6 +702,10 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_config(
 #undef sane
 #undef file_exists
 #undef add_cli
+
+    lua_config_callbacks.add<StringResult>("mmGetMegaMolExecutableDirectory",
+        "()\n\tReturns the directory of the running MegaMol executable.",
+        {[&]() { return StringResult{config.megamol_executable_directory}; }});
 
     lua_config_callbacks.add<VoidResult, std::string>("mmSetAppDir",
         "(string dir)\n\tSets the path where the mmconsole.exe is located.",

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -47,6 +47,8 @@ std::pair<RuntimeConfig, GlobalValueStore> megamol::frontend::handle_cli_and_con
     const int argc, const char** argv, megamol::core::LuaAPI& lua) {
     RuntimeConfig config;
 
+    config.megamol_executable_directory = getExecutableDirectory().u8string();
+
     // config files are already checked to exist in file system
     config.configuration_files = extract_config_file_paths(argc, argv);
 

--- a/frontend/resources/include/RuntimeConfig.h
+++ b/frontend/resources/include/RuntimeConfig.h
@@ -31,6 +31,7 @@ struct RuntimeConfig {
     std::vector<std::string> configuration_file_contents = {};
     std::vector<StringPair> cli_options_from_configs = {}; // mmSetCliOption - set config/option values accepted in CLI
     std::vector<std::string> configuration_file_contents_as_cli = {};
+    Path megamol_executable_directory = "";      // mmGetMegaMolExecutableDirectory
     Path application_directory = "";             // mmSetAppDir
     std::vector<Path> resource_directories = {}; // mmAddResourceDir
     std::vector<Path> shader_directories = {};   // mmAddShaderDir
@@ -103,6 +104,7 @@ struct RuntimeConfig {
 
         // clang-format off
         return std::string("RuntimeConfig values: "  ) +
+            std::string("\n\tExecutable directory: "   ) + "\n\t\t" + megamol_executable_directory +
             std::string("\n\tProgram invocation: "   ) + "\n\t\t" + program_invocation_string +
             std::string("\n\tVersion: "              ) + MEGAMOL_CORE_COMP_REV + 
             std::string("\n\tConfiguration files: "  ) + summarize(configuration_files) +


### PR DESCRIPTION
Adds `mmGetMegaMolExecutableDirectory()`. Changes default `megamol_config.lua` Config to use directory of the running megamol.exe to load resources relative to that path.

Allows to move built `install` directory anywhere.