### PR TITLE
Fix cam right vector in manipulators

### DIFF
--- a/core/include/mmcore/thecam/arcball_manipulator.inl
+++ b/core/include/mmcore/thecam/arcball_manipulator.inl
@@ -53,7 +53,6 @@ void megamol::core::thecam::arcball_manipulator<T>::on_drag(
 
             // get camera pose
             auto cam_pose = cam->template get<view::Camera::Pose>();
-            auto cam_right = glm::cross(cam_pose.direction, cam_pose.up);
 
             // split movement into horizontal and vertical (in camera space)
             quaternion_type rot_pitch;
@@ -61,11 +60,11 @@ void megamol::core::thecam::arcball_manipulator<T>::on_drag(
 
             // rotate horizontally
             rot_pitch = glm::angleAxis(dx * (3.14159265f / 180.0f), cam_pose.up);
-            cam_right = glm::rotate(rot_pitch, cam_right);
+            cam_pose.right = glm::rotate(rot_pitch, cam_pose.right);
             cam_pose.direction = glm::rotate(rot_pitch, cam_pose.direction);
 
             // rotate vertically
-            rot_yaw = glm::angleAxis(dy * (3.14159265f / 180.0f), -cam_right);
+            rot_yaw = glm::angleAxis(dy * (3.14159265f / 180.0f), -cam_pose.right);
             cam_pose.direction = glm::rotate(rot_yaw, cam_pose.direction);
             cam_pose.up = glm::rotate(rot_yaw, cam_pose.up);
 

--- a/core/include/mmcore/thecam/rotate_manipulator.inl
+++ b/core/include/mmcore/thecam/rotate_manipulator.inl
@@ -34,7 +34,7 @@ void megamol::core::thecam::rotate_manipulator<T>::yaw(const world_type angle, b
         auto cam_pose = this->camera()->template get<core::view::Camera::Pose>();
         auto up = fixToWorldUp ? vector_type(0.0f, 1.0f, 0.0f, 0.0f) : cam_pose.up;
         cam_pose.direction = glm::rotate(cam_pose.direction, glm::radians(angle), up);
-        cam_pose.up = glm::rotate(cam_pose.up, glm::radians(angle), up);
+        cam_pose.right = glm::rotate(cam_pose.right, glm::radians(angle), up);
         this->camera()->setPose(cam_pose);
     }
 }
@@ -47,6 +47,7 @@ void megamol::core::thecam::rotate_manipulator<T>::roll(const world_type angle) 
     if (this->enabled()) {
         auto cam_pose = this->camera()->template get<core::view::Camera::Pose>();
         cam_pose.up = glm::rotate(cam_pose.up, glm::radians(angle), cam_pose.direction);
+        cam_pose.right = glm::rotate(cam_pose.right, glm::radians(angle), cam_pose.direction);
         this->camera()->setPose(cam_pose);
     }
 }

--- a/core/include/mmcore/thecam/turntable_manipulator.h
+++ b/core/include/mmcore/thecam/turntable_manipulator.h
@@ -64,7 +64,6 @@ public:
 
                 // get camera pose
                 auto cam_pose = cam->template get<view::Camera::Pose>();
-                auto cam_right = glm::cross(cam_pose.direction, cam_pose.up);
 
                 // split movement into horizontal and vertical (in camera space)
                 quaternion_type rot_lat;
@@ -72,12 +71,12 @@ public:
 
                 // rotate horizontally
                 rot_lon = glm::angleAxis(factor_x * dx * (3.14159265f / 180.0f), glm::vec3(0.0, 1.0, 0.0));
-                cam_right = glm::rotate(rot_lon, cam_right);
+                cam_pose.right = glm::rotate(rot_lon, cam_pose.right);
                 cam_pose.direction = glm::rotate(rot_lon, cam_pose.direction);
                 cam_pose.up = glm::rotate(rot_lon, cam_pose.up);
 
                 // rotate vertically
-                rot_lat = glm::angleAxis(factor_y * dy * (3.14159265f / 180.0f), -cam_right);
+                rot_lat = glm::angleAxis(factor_y * dy * (3.14159265f / 180.0f), -cam_pose.right);
                 cam_pose.direction = glm::rotate(rot_lat, cam_pose.direction);
                 cam_pose.up = glm::rotate(rot_lat, cam_pose.up);
 


### PR DESCRIPTION
## Summary of Changes
- uses and sets right vector in camera pose

## Test Instructions
- use right vector stored in camera pose and see whether it is equal to a manually computed right vector from direction and up vectors
