### PR TITLE
GitHub actions for clang-format

### DIFF
--- a/.ci/check_files.sh
+++ b/.ci/check_files.sh
@@ -30,7 +30,33 @@ while read -r file; do
     fi
   fi
 
+  # ignore externals
+  # TODO we probably want to distinguish more granular between 3rd-party and our files here
+  if [[ $file == "./externals/"* ]]; then
+    continue
+  fi
+
+  # is cpp file?
+  is_cpp=false
+  if [[ $file == *.cpp ]] || [[ $file == *.h ]] || [[ $file == *.hpp ]] || [[ $file == *.inl ]]; then
+    is_cpp=true
+  fi
+
   # === File tests ===
+
+  # ClangFormat
+  if [[ "$is_cpp" == true ]]; then
+    if [[ $1 == "fix" ]]; then
+      clang-format-12 -i "$file"
+    else
+      output="$(clang-format-12 --dry-run --Werror "$file" 2>&1)"
+      if [[ $? -ne 0 ]]; then
+        EXIT_CODE=1
+        echo "ERROR: ClangFormat found issues in: $file"
+        #echo "$output"
+      fi
+    fi
+  fi
 
   # Check if file is UTF-8 (or ASCII)
   encoding=$(file -b --mime-encoding "$file")

--- a/.ci/check_format.sh
+++ b/.ci/check_format.sh
@@ -25,6 +25,9 @@ while read -r file; do
     if [[ $file == *"/3rd/"* ]]; then
       continue
     fi
+    if [[ $file == *"/archvis/external/"* ]]; then
+      continue
+    fi
     if [[ $file == *"/protein/msms/"* ]]; then
       continue
     fi

--- a/.ci/run_clang_format.sh
+++ b/.ci/run_clang_format.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-clang-format-12 --version
-find . -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inl" | grep -Ev '^\./(externals|utils)/' | grep -Ev '^\./plugins/.*(3rd|external)/' | xargs clang-format-12 -i

--- a/.ci/run_clang_format.sh
+++ b/.ci/run_clang_format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+clang-format-12 --version
+find . -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inl" | grep -Ev '^\./(externals|utils)/' | grep -Ev '^\./plugins/.*(3rd|external)/' | xargs clang-format-12 -i

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -12,11 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Run clang-format
-        run: .ci/run_clang_format.sh
-      - name: Check diff
-        run: |
-          git diff --exit-code --color
+      - name: Run format check
+        run: .ci/check_format.sh
       - name: Comment
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v5
@@ -26,7 +23,14 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'ClangFormat found [formatting issues](https://github.com/'
+              body: 'Style check found [formatting issues](https://github.com/'
                     + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId + ')! '
                     + 'Comment `/format`, to automatically commit the suggested changes.'
             })
+  plugin_check:
+    name: Plugin-Check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run plugin check
+        run: .ci/check_plugins.sh

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -1,0 +1,32 @@
+name: Style-Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  style_check:
+    name: Style-Check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run clang-format
+        run: .ci/run_clang_format.sh
+      - name: Check diff
+        run: |
+          git diff --exit-code --color
+      - name: Comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'ClangFormat found [formatting issues](https://github.com/'
+                    + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId + ')! '
+                    + 'Comment `/format`, to automatically commit the suggested changes.'
+            })

--- a/.github/workflows/style_fix.yml
+++ b/.github/workflows/style_fix.yml
@@ -1,0 +1,30 @@
+name: Style-Fix
+
+on: issue_comment
+
+jobs:
+  style_fix:
+    name: Style-Fix
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/format' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Checkout PR
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clang-format
+        run: .ci/run_clang_format.sh
+      - name: Commit
+        run: |
+          if ! git diff --quiet --exit-code; then
+            git config user.email "actions@megamol.org"
+            git config user.name "MegaMol-Bot"
+            git commit -am "Run ClangFormat."
+            git push
+          else
+            echo "Nothing to do!"
+          fi

--- a/.github/workflows/style_fix.yml
+++ b/.github/workflows/style_fix.yml
@@ -16,14 +16,14 @@ jobs:
           gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run clang-format
-        run: .ci/run_clang_format.sh
+      - name: Run style fix
+        run: .ci/check_format.sh fix
       - name: Commit
         run: |
           if ! git diff --quiet --exit-code; then
             git config user.email "actions@megamol.org"
             git config user.name "MegaMol-Bot"
-            git commit -am "Run ClangFormat."
+            git commit -am "Format fix."
             git push
           else
             echo "Nothing to do!"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,15 @@ jobs:
       'VS2019 Release':
         configuration: Release
         generator: 'Visual Studio 16 2019'
+        cmakeExtraArgs: '$(enablePlugins)'
       'VS2019 Debug':
         configuration: Debug
         generator: 'Visual Studio 16 2019'
+        cmakeExtraArgs: '$(enablePlugins)'
+      'VS2019 Release (nonGL)':
+        configuration: Release
+        generator: 'Visual Studio 16 2019'
+        cmakeExtraArgs: '-DENABLE_GL=OFF'
 
   pool:
     name: 'hardware'
@@ -43,7 +49,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake Configure'
     inputs:
-      cmakeArgs: '.. -G"$(generator)" -A"x64" $(enablePlugins)'
+      cmakeArgs: '.. -G"$(generator)" -A"x64" $(cmakeExtraArgs)'
   - task: CMake@1
     displayName: 'CMake Build'
     inputs:
@@ -58,21 +64,32 @@ jobs:
       #  cxxCompiler: g++-9
       #  configuration: Release
       #  generator: 'Unix Makefiles'
+      #  cmakeExtraArgs: '$(enablePlugins)'
       'GCC9 / Make / Debug':
         cCompiler: gcc-9
         cxxCompiler: g++-9
         configuration: Debug
         generator: 'Unix Makefiles'
+        cmakeExtraArgs: '$(enablePlugins)'
       'GCC9 / Ninja / Release':
         cCompiler: gcc-9
         cxxCompiler: g++-9
         configuration: Release
         generator: 'Ninja'
+        cmakeExtraArgs: '$(enablePlugins)'
       'Clang10 / Make / Release':
         cCompiler: clang-10
         cxxCompiler: clang++-10
         configuration: Release
         generator: 'Unix Makefiles'
+        cmakeExtraArgs: '$(enablePlugins)'
+      ## Temporarily disabled until more CI machines are available!
+      #'GCC9 / Make / Debug (nonGL)':
+      #  cCompiler: gcc-9
+      #  cxxCompiler: g++-9
+      #  configuration: Debug
+      #  generator: 'Unix Makefiles'
+      #  cmakeExtraArgs: '-DENABLE_GL=OFF'
 
   pool:
     name: 'default'
@@ -87,62 +104,11 @@ jobs:
   - task: CMake@1
     displayName: 'CMake Configure'
     inputs:
-      cmakeArgs: '.. -G"$(generator)" -DCMAKE_C_COMPILER=$(cCompiler) -DCMAKE_CXX_COMPILER=$(cxxCompiler) -DCMAKE_BUILD_TYPE=$(configuration) $(enablePlugins)'
+      cmakeArgs: '.. -G"$(generator)" -DCMAKE_C_COMPILER=$(cCompiler) -DCMAKE_CXX_COMPILER=$(cxxCompiler) -DCMAKE_BUILD_TYPE=$(configuration) $(cmakeExtraArgs)'
   - task: CMake@1
     displayName: 'CMake Build'
     inputs:
       cmakeArgs: '--build . --parallel $(numberOfCpuCores)'
-
-- job: nonGL_Linux
-  strategy:
-    matrix:
-      'GCC9 / Make / Debug':
-        cCompiler: gcc-9
-        cxxCompiler: g++-9
-        configuration: Debug
-        generator: 'Unix Makefiles'
-  pool:
-    name: 'default'
-    demands:
-    - Agent.OS -equals Linux
-    - cmake
-    - megamol_build_enabled
-
-  steps:
-  - bash: echo "##vso[task.setvariable variable=numberOfCpuCores]$(nproc)"
-    displayName: 'Bash get number of CPU cores'
-  - task: CMake@1
-    displayName: 'CMake Configure'
-    inputs:
-      cmakeArgs: '.. -G"$(generator)" -DCMAKE_C_COMPILER=$(cCompiler) -DCMAKE_CXX_COMPILER=$(cxxCompiler) -DCMAKE_BUILD_TYPE=$(configuration) -DENABLE_GL=OFF'
-  - task: CMake@1
-    displayName: 'CMake Build'
-    inputs:
-      cmakeArgs: '--build . --parallel $(numberOfCpuCores)'
-
-- job: nonGL_Windows
-  strategy:
-    matrix:
-      'VS2019 Release':
-        configuration: Release
-        generator: 'Visual Studio 16 2019'
-
-  pool:
-    name: 'hardware'
-    demands:
-    - Agent.OS -equals Windows_NT
-    - cmake
-    - VisualStudio_16.0
-
-  steps:
-  - task: CMake@1
-    displayName: 'CMake Configure'
-    inputs:
-      cmakeArgs: '.. -G"$(generator)" -A"x64" -DENABLE_GL=OFF'
-  - task: CMake@1
-    displayName: 'CMake Build'
-    inputs:
-      cmakeArgs: '--build . --config $(configuration)'
 
 # The file check runs on Linux. Windows clients probably uses git autocrlf, making it hard to detect wrong line endings in the repo.
 - job: StyleChecks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,17 @@ pr:
 - master
 
 variables:
-  enablePlugins: '-DBUILD_PLUGIN_MMADIOS=ON -DBUILD_PLUGIN_ASTRO=OFF -DBUILD_PLUGIN_IMAGE=OFF -DBUILD_PLUGIN_MEGAMOL101=ON -DBUILD_PLUGIN_MMVTKM=ON -DBUILD_PLUGIN_REMOTE=OFF'
+  defaultConfig: >-
+    -DBUILD_PLUGIN_ASTRO=OFF
+    -DBUILD_PLUGIN_ASTRO_GL=OFF
+    -DBUILD_PLUGIN_IMAGE=OFF
+    -DBUILD_PLUGIN_MEGAMOL101_GL=ON
+    -DBUILD_PLUGIN_MMADIOS=ON
+    -DBUILD_PLUGIN_MMVTKM=ON
+    -DBUILD_PLUGIN_MMVTKM_GL=ON
+    -DBUILD_PLUGIN_REMOTE=OFF
+  nonGlConfig: >-
+    -DENABLE_GL=OFF
 
 jobs:
 - job: Windows
@@ -15,15 +25,15 @@ jobs:
       'VS2019 Release':
         configuration: Release
         generator: 'Visual Studio 16 2019'
-        cmakeExtraArgs: '$(enablePlugins)'
+        cmakeExtraArgs: '$(defaultConfig)'
       'VS2019 Debug':
         configuration: Debug
         generator: 'Visual Studio 16 2019'
-        cmakeExtraArgs: '$(enablePlugins)'
+        cmakeExtraArgs: '$(defaultConfig)'
       'VS2019 Release (nonGL)':
         configuration: Release
         generator: 'Visual Studio 16 2019'
-        cmakeExtraArgs: '-DENABLE_GL=OFF'
+        cmakeExtraArgs: '$(nonGlConfig)'
 
   pool:
     name: 'hardware'
@@ -33,19 +43,6 @@ jobs:
     - VisualStudio_16.0
 
   steps:
-  #- task: PowerShell@2
-  #  displayName: 'Install Python'
-  #  inputs:
-  #    targetType: 'inline'
-  #    script: |
-  #      $pythonUrl = "https://www.python.org/ftp/python/3.9.4/python-3.9.4-embed-amd64.zip"
-  #      $python_path = Join-Path (Get-Item .).FullName "python_tmp"
-  #      $tmp = New-TemporaryFile
-  #      $tmp = Rename-Item -Path $tmp -NewName "$tmp.zip" -PassThru
-  #      Invoke-WebRequest -OutFile $tmp $pythonUrl
-  #      Expand-Archive -Path $tmp -DestinationPath python_tmp -Force
-  #      $tmp | Remove-Item
-  #      echo "##vso[task.prependpath]$python_path"
   - task: CMake@1
     displayName: 'CMake Configure'
     inputs:
@@ -64,32 +61,33 @@ jobs:
       #  cxxCompiler: g++-9
       #  configuration: Release
       #  generator: 'Unix Makefiles'
-      #  cmakeExtraArgs: '$(enablePlugins)'
+      #  cmakeExtraArgs: '$(defaultConfig)'
       'GCC9 / Make / Debug':
         cCompiler: gcc-9
         cxxCompiler: g++-9
         configuration: Debug
         generator: 'Unix Makefiles'
-        cmakeExtraArgs: '$(enablePlugins)'
-      'GCC9 / Ninja / Release':
-        cCompiler: gcc-9
-        cxxCompiler: g++-9
-        configuration: Release
-        generator: 'Ninja'
-        cmakeExtraArgs: '$(enablePlugins)'
-      'Clang10 / Make / Release':
+        cmakeExtraArgs: '$(defaultConfig)'
+      ## Temporarily disabled until more CI machines are available!
+      #'GCC9 / Ninja / Release':
+      #  cCompiler: gcc-9
+      #  cxxCompiler: g++-9
+      #  configuration: Release
+      #  generator: 'Ninja'
+      #  cmakeExtraArgs: '$(defaultConfig)'
+      ## Temporarily changed to Ninja instead of Make until more CI machines are available!
+      'Clang10 / Ninja / Release':
         cCompiler: clang-10
         cxxCompiler: clang++-10
         configuration: Release
+        generator: 'Ninja'
+        cmakeExtraArgs: '$(defaultConfig)'
+      'GCC9 / Make / Release (nonGL)':
+        cCompiler: gcc-9
+        cxxCompiler: g++-9
+        configuration: Release
         generator: 'Unix Makefiles'
-        cmakeExtraArgs: '$(enablePlugins)'
-      ## Temporarily disabled until more CI machines are available!
-      #'GCC9 / Make / Debug (nonGL)':
-      #  cCompiler: gcc-9
-      #  cxxCompiler: g++-9
-      #  configuration: Debug
-      #  generator: 'Unix Makefiles'
-      #  cmakeExtraArgs: '-DENABLE_GL=OFF'
+        cmakeExtraArgs: '$(nonGlConfig)'
 
   pool:
     name: 'default'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,34 +163,3 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       filePath: '.ci/check_files.sh'
-  - task: Bash@3
-    displayName: 'Run Clang-Format'
-    condition: succeededOrFailed()
-    inputs:
-      targetType: 'inline'
-      script: |
-        clang-format-12 --version
-        find . -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.inl" | grep -Ev '^\./(externals|utils)/' | grep -Ev '^\./plugins/.*(3rd|external)/' | xargs clang-format-12 -i
-        git diff --exit-code
-
-# Disabled for now, because clang format version is wrong
-#- job: ClangFormatCheckWindows
-#  displayName: 'ClangFormat Check (Windows)'
-#  pool:
-#    name: 'hardware'
-#    demands:
-#      - Agent.OS -equals Windows_NT
-#      - cmake
-#      - VisualStudio_16.0
-#
-#  steps:
-#    - task: PowerShell@2
-#      displayName: 'Run Clang-Format'
-#      inputs:
-#        targetType: 'inline'
-#        script: |
-#          $Env:Path = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer;$Env:Path"
-#          $vspath = vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-#          $vspath = join-path $vspath 'VC\Tools\Llvm\x64\bin'
-#          $Env:Path = "$vspath;$Env:Path"
-#          clang-format.exe --version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,23 +109,3 @@ jobs:
     displayName: 'CMake Build'
     inputs:
       cmakeArgs: '--build . --parallel $(numberOfCpuCores)'
-
-# The file check runs on Linux. Windows clients probably uses git autocrlf, making it hard to detect wrong line endings in the repo.
-- job: StyleChecks
-  displayName: 'Style Checks'
-  pool:
-    name: 'default'
-    demands:
-    - Agent.OS -equals Linux
-    - megamol_build_enabled
-  steps:
-  - task: Bash@3
-    displayName: 'Run Plugin Structure Checks'
-    condition: succeededOrFailed()
-    inputs:
-      filePath: '.ci/check_plugins.sh'
-  - task: Bash@3
-    displayName: 'Run File Checks'
-    condition: succeededOrFailed()
-    inputs:
-      filePath: '.ci/check_files.sh'

--- a/utils/mmftdreader/mmftdreader.cpp
+++ b/utils/mmftdreader/mmftdreader.cpp
@@ -84,21 +84,25 @@ int main(int argc, char* argv[]) {
               << "| Name                 | Type | Min          | Max          |" << std::endl
               << "|----------------------|------|--------------|--------------|" << std::endl;
     for (const auto& i : info) {
+        // clang-format off
         std::cout << "| " << std::left << std::setw(20) << i.name
-                  << " | " << std::right << std::setw(4) << (int) i.type
+                  << " | " << std::right << std::setw(4) << (int)i.type
                   << " | " << std::setw(12) << i.min
                   << " | " << std::setw(12) << i.max
                   << " |" << std::endl;
+        // clang-format on
     }
     std::cout << "|----------------------|------|--------------|--------------|" << std::endl;
 
     std::vector<float> data(rowCount * colCount);
     file.read(reinterpret_cast<char*>(data.data()), rowCount * colCount * sizeof(float));
 
+    // clang-format off
     std::cout << std::endl
               << "# Table Data" << std::endl
               << std::endl
               << "| " << std::left;
+    // clang-format on
 
     for (const auto& i : info) {
         std::cout << std::setw(12) << i.name << " | ";


### PR DESCRIPTION
## Summary of Changes
- Use GitHub actions for running clang-format
- Allow to comment `/format` in a PR to automatically commit clang-format changes