### PR TITLE
Customizable step size and fix for min-max reset problem

### DIFF
--- a/core/include/mmcore/param/FloatParam.h
+++ b/core/include/mmcore/param/FloatParam.h
@@ -23,6 +23,8 @@ public:
 
     FloatParam(float initVal, float minVal, float maxVal) : Super(initVal, minVal, maxVal) {}
 
+    FloatParam(float initVal, float minVal, float maxVal, float stepSize) : Super(initVal, minVal, maxVal, stepSize) {}
+
     virtual ~FloatParam() = default;
 
     std::string Definition() const override {
@@ -30,6 +32,7 @@ public:
         outDef << "MMFLOT";
         outDef.write(reinterpret_cast<char const*>(&MinValue()), sizeof(MinValue()));
         outDef.write(reinterpret_cast<char const*>(&MaxValue()), sizeof(MaxValue()));
+        outDef.write(reinterpret_cast<char const*>(&StepSize()), sizeof(StepSize()));
 
         return outDef.str();
     }

--- a/core/include/mmcore/param/GenericParam.h
+++ b/core/include/mmcore/param/GenericParam.h
@@ -76,6 +76,16 @@ public:
     }
 
     /**
+     * Sets the step size of the parameter.
+     *
+     * @param s the new step size for the parameter
+     */
+    template<typename U = T>
+    std::enable_if_t<std::is_arithmetic_v<U>, void> SetStepSize(T s) {
+        this->stepSize = s;
+    }
+
+    /**
      * Gets the value of the parameter
      *
      * @return The value of the parameter
@@ -107,7 +117,6 @@ public:
     }
 
     /**
-     * Needed for RemoteControl
      * Gets the step size of the parameter
      *
      * @return The step size of the parameter

--- a/core/include/mmcore/param/GenericParam.h
+++ b/core/include/mmcore/param/GenericParam.h
@@ -42,14 +42,13 @@ public:
 
     // stepSize has no effect on Slider
     template<typename U = T>
-    GenericParam(
-        T const& initVal, T const& minVal, T const& maxVal, T const& stepSize, std::enable_if_t<enable_cond_v<U>, void>* = nullptr)
-    {
+    GenericParam(T const& initVal, T const& minVal, T const& maxVal, T const& stepSize,
+        std::enable_if_t<enable_cond_v<U>, void>* = nullptr) {
         initParam(initVal);
         this->minVal = minVal;
         this->maxVal = maxVal;
         this->stepSize = stepSize;
-    }    
+    }
 
     virtual ~GenericParam() = default;
 

--- a/core/include/mmcore/param/GenericParam.h
+++ b/core/include/mmcore/param/GenericParam.h
@@ -38,10 +38,18 @@ public:
     template<typename U = T>
     GenericParam(
         T const& initVal, T const& minVal, T const& maxVal, std::enable_if_t<enable_cond_v<U>, void>* = nullptr)
-            : minVal(minVal)
-            , maxVal(maxVal) {
+            : GenericParam(initVal, minVal, maxVal, std::numeric_limits<T>::max()) {}
+
+    // stepSize has no effect on Slider
+    template<typename U = T>
+    GenericParam(
+        T const& initVal, T const& minVal, T const& maxVal, T const& stepSize, std::enable_if_t<enable_cond_v<U>, void>* = nullptr)
+    {
         initParam(initVal);
-    }
+        this->minVal = minVal;
+        this->maxVal = maxVal;
+        this->stepSize = stepSize;
+    }    
 
     virtual ~GenericParam() = default;
 
@@ -99,17 +107,29 @@ public:
         return maxVal;
     }
 
+    /**
+     * Needed for RemoteControl
+     * Gets the step size of the parameter
+     *
+     * @return The step size of the parameter
+     */
+    template<typename U = T>
+    std::enable_if_t<enable_cond_v<U>, T const&> StepSize() const {
+        return stepSize;
+    }
+
 private:
     void initParam(T const& v) {
-        initMinMax();
+        initMinMaxStep();
         InitPresentation(TYPE);
         SetValue(v);
     }
 
-    void initMinMax() {
+    void initMinMaxStep() {
         if constexpr (std::is_arithmetic_v<T>) {
             minVal = std::numeric_limits<T>::lowest();
             maxVal = std::numeric_limits<T>::max();
+            stepSize = std::numeric_limits<T>::max();
         } else if constexpr (is_vislib_vector_f_v<T>) {
             minVal = T(std::numeric_limits<typename T::ValueT>::lowest());
             maxVal = T(std::numeric_limits<typename T::ValueT>::max());
@@ -121,5 +141,7 @@ private:
     T minVal;
 
     T maxVal;
+
+    T stepSize;
 };
 } // namespace megamol::core::param

--- a/core/include/mmcore/param/IntParam.h
+++ b/core/include/mmcore/param/IntParam.h
@@ -22,6 +22,8 @@ public:
 
     IntParam(int initVal, int minVal, int maxVal) : Super(initVal, minVal, maxVal) {}
 
+    IntParam(int initVal, int minVal, int maxVal, int stepSize) : Super(initVal, minVal, maxVal, stepSize) {}
+
     virtual ~IntParam() = default;
 
     std::string Definition() const override {
@@ -29,6 +31,7 @@ public:
         outDef << "MMINTR";
         outDef.write(reinterpret_cast<char const*>(&MinValue()), sizeof(MinValue()));
         outDef.write(reinterpret_cast<char const*>(&MaxValue()), sizeof(MaxValue()));
+        outDef.write(reinterpret_cast<char const*>(&StepSize()), sizeof(StepSize()));
 
         return outDef.str();
     }

--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -167,7 +167,7 @@ ModulePtr_t megamol::gui::Graph::AddModule(const ModuleStockVector_t& stock_modu
 
                 for (auto& p : mod.parameters) {
                     Parameter parameter(megamol::gui::GenerateUniqueID(), p.type, p.storage, p.minval, p.maxval,
-                        p.param_name, p.description);
+                        p.stepsize, p.param_name, p.description);
                     parameter.SetParentModuleName(mod_ptr->FullName());
                     parameter.SetValueString(p.default_value, true, true);
                     parameter.SetGUIVisible(p.gui_visibility);

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -33,8 +33,8 @@ using namespace megamol;
 using namespace megamol::gui;
 
 
-megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minv, Max_t maxv,
-    Step_t step, const std::string& param_name, const std::string& description)
+megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minv, Max_t maxv, Step_t step,
+    const std::string& param_name, const std::string& description)
         : megamol::core::param::AbstractParamPresentation()
         , uid(uid)
         , type(type)
@@ -1750,8 +1750,8 @@ bool megamol::gui::Parameter::widget_int(
 }
 
 
-bool megamol::gui::Parameter::widget_float(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step) {
+bool megamol::gui::Parameter::widget_float(megamol::gui::Parameter::WidgetScope scope, const std::string& label,
+    float& val, float minv, float maxv, float step) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
@@ -1769,7 +1769,8 @@ bool megamol::gui::Parameter::widget_float(
 
         // Min Max Step Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (ImGui::ArrowButton("###_min_max_step", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+            if (ImGui::ArrowButton(
+                    "###_min_max_step", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
                 this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
             }
             this->gui_tooltip.ToolTip("Min/Max/Step Values");
@@ -2253,8 +2254,8 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
 }
 
 
-bool megamol::gui::Parameter::widget_knob(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step) {
+bool megamol::gui::Parameter::widget_knob(megamol::gui::Parameter::WidgetScope scope, const std::string& label,
+    float& val, float minv, float maxv, float step) {
     bool retval = false;
 
     ImGuiStyle& style = ImGui::GetStyle();

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -54,7 +54,8 @@ megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t stor
         , gui_float_format("%.7f")
         , gui_help()
         , gui_tooltip_text()
-        , gui_widget_store()
+        , gui_widget_value()
+        , gui_widget_stepsize()
         , gui_set_focus(0)
         , gui_state_dirty(false)
         , gui_show_minmaxstep(false)
@@ -694,7 +695,7 @@ bool megamol::gui::Parameter::WriteCoreParameterValue(
     if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::ButtonParam>()) {
         if (in_param.type == ParamType_t::BUTTON) {
             p_ptr->setDirty();
-            // KeyCode can not be changed
+            /// XXX KeyCode can not be changed
         } else {
             type_error = true;
         }
@@ -714,35 +715,37 @@ bool megamol::gui::Parameter::WriteCoreParameterValue(
     } else if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::EnumParam>()) {
         if (in_param.type == ParamType_t::ENUM) {
             p_ptr->SetValue(std::get<int>(in_param.GetValue()));
-            // Map can not be changed
+            /// XXX Map can not be changed
         } else {
             type_error = true;
         }
     } else if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::FilePathParam>()) {
         if (in_param.type == ParamType_t::FILEPATH) {
             p_ptr->SetValue(std::get<std::filesystem::path>(in_param.GetValue()));
-            // Storage can not be changed
+            /// XXX Storage can not be changed
         } else {
             type_error = true;
         }
     } else if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::FlexEnumParam>()) {
         if (in_param.type == ParamType_t::FLEXENUM) {
             p_ptr->SetValue(std::get<std::string>(in_param.GetValue()));
-            // Storage can not be changed
+            /// XXX Storage can not be changed
         } else {
             type_error = true;
         }
     } else if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::FloatParam>()) {
         if (in_param.type == ParamType_t::FLOAT) {
             p_ptr->SetValue(std::get<float>(in_param.GetValue()));
-            // Min and Max can not be changed
+            p_ptr->SetStepSize(in_param.GetStepSize<float>());
+            /// XXX Min and Max can not be changed
         } else {
             type_error = true;
         }
     } else if (auto* p_ptr = out_param_ptr.DynamicCast<core::param::IntParam>()) {
         if (in_param.type == ParamType_t::INT) {
             p_ptr->SetValue(std::get<int>(in_param.GetValue()));
-            // Min and Max can not be changed
+            p_ptr->SetStepSize(in_param.GetStepSize<int>());
+            /// XXX Min and Max can not be changed
         } else {
             type_error = true;
         }
@@ -768,7 +771,7 @@ bool megamol::gui::Parameter::WriteCoreParameterValue(
         if (in_param.type == ParamType_t::VECTOR2F) {
             auto value = std::get<glm::vec2>(in_param.GetValue());
             p_ptr->SetValue(vislib::math::Vector<float, 2>(value[0], value[1]));
-            // Min and Max can not be changed
+            /// XXX Min and Max can not be changed
         } else {
             type_error = true;
         }
@@ -776,7 +779,7 @@ bool megamol::gui::Parameter::WriteCoreParameterValue(
         if (in_param.type == ParamType_t::VECTOR3F) {
             auto value = std::get<glm::vec3>(in_param.GetValue());
             p_ptr->SetValue(vislib::math::Vector<float, 3>(value[0], value[1], value[2]));
-            // Min and Max can not be changed
+            /// XXX Min and Max can not be changed
         } else {
             type_error = true;
         }
@@ -784,7 +787,7 @@ bool megamol::gui::Parameter::WriteCoreParameterValue(
         if (in_param.type == ParamType_t::VECTOR4F) {
             auto value = std::get<glm::vec4>(in_param.GetValue());
             p_ptr->SetValue(vislib::math::Vector<float, 4>(value[0], value[1], value[2], value[3]));
-            // Min and Max can not be changed
+            /// XXX Min and Max can not be changed
         } else {
             type_error = true;
         }
@@ -961,9 +964,10 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             else if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
-                        this->GetStepSize<T>())) {
+                float step = this->GetStepSize<T>();
+                if (this->widget_float(scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
                     this->SetValue(val);
+                    this->SetStepSize(step);
                     retval = true;
                 }
                 error = false;
@@ -972,9 +976,11 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
-                            this->GetStepSize<T>())) {
+                    int step = this->GetStepSize<T>();
+                    if (this->widget_int(
+                            scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
                         this->SetValue(val);
+                        this->SetStepSize(step);
                         retval = true;
                     }
                     error = false;
@@ -1228,9 +1234,10 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
-                        this->GetStepSize<T>())) {
+                float step = this->GetStepSize<T>();
+                if (this->widget_float(scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
                     this->SetValue(val);
+                    this->SetStepSize(step);
                     retval = true;
                 }
                 error = false;
@@ -1239,9 +1246,11 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
-                            this->GetStepSize<T>())) {
+                    int step = this->GetStepSize<T>();
+                    if (this->widget_int(
+                            scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
                         this->SetValue(val);
+                        this->SetStepSize(step);
                         retval = true;
                     }
                     error = false;
@@ -1420,24 +1429,24 @@ bool megamol::gui::Parameter::widget_string(
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
         ImGui::BeginGroup();
-        if (!std::holds_alternative<std::string>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
+        if (!std::holds_alternative<std::string>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
         std::string hidden_label = "###" + label;
 
         // Determine multi line count of string
-        int multiline_cnt = static_cast<int>(std::count(std::get<std::string>(this->gui_widget_store).begin(),
-            std::get<std::string>(this->gui_widget_store).end(), '\n'));
+        int multiline_cnt = static_cast<int>(std::count(std::get<std::string>(this->gui_widget_value).begin(),
+            std::get<std::string>(this->gui_widget_value).end(), '\n'));
         multiline_cnt = std::min(static_cast<int>(GUI_MAX_MULITLINE), multiline_cnt);
         ImVec2 multiline_size = ImVec2(ImGui::CalcItemWidth(),
             ImGui::GetFrameHeightWithSpacing() + (ImGui::GetFontSize() * static_cast<float>(multiline_cnt)));
-        ImGui::InputTextMultiline(hidden_label.c_str(), &std::get<std::string>(this->gui_widget_store), multiline_size,
+        ImGui::InputTextMultiline(hidden_label.c_str(), &std::get<std::string>(this->gui_widget_value), multiline_size,
             ImGuiInputTextFlags_CtrlEnterForNewLine);
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            val = std::get<std::string>(this->gui_widget_store);
+            val = std::get<std::string>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
         ImGui::SameLine();
 
@@ -1495,8 +1504,8 @@ bool megamol::gui::Parameter::widget_flexenum(megamol::gui::Parameter::WidgetSco
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<std::string>(this->gui_widget_store)) {
-            this->gui_widget_store = std::string();
+        if (!std::holds_alternative<std::string>(this->gui_widget_value)) {
+            this->gui_widget_value = std::string();
         }
         auto combo_flags = ImGuiComboFlags_HeightRegular;
         if (ImGui::BeginCombo(label.c_str(), val.c_str(), combo_flags)) {
@@ -1524,11 +1533,11 @@ bool megamol::gui::Parameter::widget_flexenum(megamol::gui::Parameter::WidgetSco
                 this->gui_set_focus++;
             }
             ImGui::InputText(
-                "###flex_enum_text_edit", &std::get<std::string>(this->gui_widget_store), ImGuiInputTextFlags_None);
+                "###flex_enum_text_edit", &std::get<std::string>(this->gui_widget_value), ImGuiInputTextFlags_None);
             if (ImGui::IsItemDeactivatedAfterEdit()) {
-                if (!std::get<std::string>(this->gui_widget_store).empty()) {
-                    val = std::get<std::string>(this->gui_widget_store);
-                    std::get<std::string>(this->gui_widget_store).clear();
+                if (!std::get<std::string>(this->gui_widget_value).empty()) {
+                    val = std::get<std::string>(this->gui_widget_value);
+                    std::get<std::string>(this->gui_widget_value).clear();
                     retval = true;
                 }
                 ImGui::CloseCurrentPopup();
@@ -1552,13 +1561,13 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
         ImGui::BeginGroup();
-        if (!std::holds_alternative<std::string>(this->gui_widget_store)) {
-            this->gui_widget_store = val.generic_u8string();
+        if (!std::holds_alternative<std::string>(this->gui_widget_value)) {
+            this->gui_widget_value = val.generic_u8string();
         }
         ImGuiStyle& style = ImGui::GetStyle();
 
         float widget_width = ImGui::CalcItemWidth() - (ImGui::GetFrameHeightWithSpacing() + style.ItemSpacing.x);
-        float text_width = ImGui::CalcTextSize(std::get<std::string>(this->gui_widget_store).c_str()).x +
+        float text_width = ImGui::CalcTextSize(std::get<std::string>(this->gui_widget_value).c_str()).x +
                            (2.0f * style.ItemInnerSpacing.x);
         widget_width = std::max(widget_width, text_width);
 
@@ -1568,11 +1577,11 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
         auto file_flags = store.first;
         auto file_extensions = store.second;
         bool button_edit = this->gui_file_browser.Button_Select(
-            std::get<std::string>(this->gui_widget_store), file_extensions, file_flags);
+            std::get<std::string>(this->gui_widget_value), file_extensions, file_flags);
         ImGui::SameLine();
-        ImGui::InputText(label.c_str(), &std::get<std::string>(this->gui_widget_store), ImGuiInputTextFlags_None);
+        ImGui::InputText(label.c_str(), &std::get<std::string>(this->gui_widget_value), ImGuiInputTextFlags_None);
         if (button_edit || ImGui::IsItemDeactivatedAfterEdit()) {
-            val = std::filesystem::u8path(std::get<std::string>(this->gui_widget_store));
+            val = std::filesystem::u8path(std::get<std::string>(this->gui_widget_value));
             try {
                 if (last_val != val) {
                     auto error_flags = FilePathParam::ValidatePath(val, file_extensions, file_flags);
@@ -1610,12 +1619,12 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
             }
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val.generic_u8string();
+            this->gui_widget_value = val.generic_u8string();
         }
         ImGui::PopItemWidth();
         ImGui::EndGroup();
 
-        this->gui_tooltip_text += "\n" + std::get<std::string>(this->gui_widget_store);
+        this->gui_tooltip_text += "\n" + std::get<std::string>(this->gui_widget_value);
     }
 
     auto popup_flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar;
@@ -1674,18 +1683,34 @@ bool megamol::gui::Parameter::widget_ternary(
 
 
 bool megamol::gui::Parameter::widget_int(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int step) {
+    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int& step, int minv, int maxv) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<int>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
+
+        if (!std::holds_alternative<int>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
-        if (!std::holds_alternative<int>(this->stepsize)) {
-            this->stepsize = step;
+
+        // If no step size is set, set relative default step size depending on given min-max value range
+        if (step == INT_MAX) {
+            step = 1;
+            if ((minv > INT_MIN) && (maxv < INT_MAX)) {
+                step = std::max(1, static_cast<int>(static_cast<float>(maxv - minv) * 0.01f));
+            } else if ((minv == INT_MIN) && (maxv < INT_MAX)) {
+                step = std::max(1, static_cast<int>(std::abs(static_cast<float>(maxv - val)) * 0.01f));
+            } else if ((minv > INT_MIN) && (maxv == INT_MAX)) {
+                step = std::max(1, static_cast<int>(std::abs(static_cast<float>(val - minv)) * 0.01f));
+            }
+            this->gui_widget_stepsize = step;
+            retval = true;
         }
-        auto p = this->GetGUIPresentation();
+        int min_step_size = step;
+        int max_step_size = 10 * step;
+        if (!std::holds_alternative<int>(this->gui_widget_stepsize)) {
+            this->gui_widget_stepsize = step;
+        }
 
         // Min Max Step Values
         ImGui::BeginGroup();
@@ -1695,40 +1720,28 @@ bool megamol::gui::Parameter::widget_int(
         this->gui_tooltip.ToolTip("Min/Max/Step Values");
         ImGui::SameLine();
 
-        int min_step_size = 1;
-        int max_step_size = 10;
-        if (step == INT_MAX) {
-            // Relative step size if step size is not explicitly set
-            if ((minv > INT_MIN) && (maxv < INT_MAX)) {
-                min_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.003f); // 0.3%
-                max_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.03f);  // 3%
-            }
-        } else {
-            min_step_size = step;
-            max_step_size = 10 * step;
-        }
-
         // Value
+        auto p = this->GetGUIPresentation();
         if (p == Present_t::Slider) {
             const int offset = 2;
             auto slider_min = (minv > INT_MIN) ? (minv) : ((val == 0) ? (-offset) : (val - (offset * val)));
             auto slider_max = (maxv < INT_MAX) ? (maxv) : ((val == 0) ? (offset) : (val + (offset * val)));
-            ImGui::SliderInt(label.c_str(), &std::get<int>(this->gui_widget_store), slider_min, slider_max);
+            ImGui::SliderInt(label.c_str(), &std::get<int>(this->gui_widget_value), slider_min, slider_max);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else if (p == Present_t::Drag) {
             ImGui::DragInt(
-                label.c_str(), &std::get<int>(this->gui_widget_store), static_cast<float>(min_step_size), minv, maxv);
+                label.c_str(), &std::get<int>(this->gui_widget_value), static_cast<float>(min_step_size), minv, maxv);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else { // Present_t::Basic
-            ImGui::InputInt(label.c_str(), &std::get<int>(this->gui_widget_store), min_step_size, max_step_size,
+            ImGui::InputInt(label.c_str(), &std::get<int>(this->gui_widget_value), min_step_size, max_step_size,
                 ImGuiInputTextFlags_None);
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            this->gui_widget_store = std::max(minv, std::min(std::get<int>(this->gui_widget_store), maxv));
-            val = std::get<int>(this->gui_widget_store);
+            this->gui_widget_value = std::max(minv, std::min(std::get<int>(this->gui_widget_value), maxv));
+            val = std::get<int>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
         if (this->gui_show_minmaxstep) {
             gui_utils::PushReadOnly();
@@ -1739,9 +1752,19 @@ bool megamol::gui::Parameter::widget_int(
             // step has no effect on slider
             gui_utils::PopReadOnly();
             if (p != Present_t::Slider) {
-                //auto step_size = min_step_size;
-                ImGui::InputInt("Step Size", &std::get<int>(this->stepsize), min_step_size, max_step_size,
-                    ImGuiInputTextFlags_None);
+                auto tmp_stepsize_step = static_cast<float>(std::abs(std::get<int>(this->gui_widget_stepsize)));
+                int stepsize_min_step = std::max(1, static_cast<int>(tmp_stepsize_step * 0.01f));
+                int stepsize_max_step = std::max(10, static_cast<int>(tmp_stepsize_step * 0.1f));
+                ImGui::InputInt("Step Size", &std::get<int>(this->gui_widget_stepsize), stepsize_min_step,
+                    stepsize_max_step, ImGuiInputTextFlags_None);
+                if (ImGui::IsItemDeactivatedAfterEdit()) {
+                    // Limit stepsize to positive value > 0
+                    this->gui_widget_stepsize = std::max(1, std::get<int>(this->gui_widget_stepsize));
+                    step = std::get<int>(this->gui_widget_stepsize);
+                    retval = true;
+                } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
+                    this->gui_widget_stepsize = step;
+                }
             }
         }
         ImGui::EndGroup();
@@ -1751,21 +1774,37 @@ bool megamol::gui::Parameter::widget_int(
 
 
 bool megamol::gui::Parameter::widget_float(megamol::gui::Parameter::WidgetScope scope, const std::string& label,
-    float& val, float minv, float maxv, float step) {
+    float& val, float& step, float minv, float maxv) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<float>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
-        }
-        if (!std::holds_alternative<float>(this->stepsize)) {
-            this->stepsize = step;
+
+        if (!std::holds_alternative<float>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
 
-        auto p = this->GetGUIPresentation();
+        // If no step size is set, set relative default step size depending on given min-max value range
+        if (step == FLT_MAX) {
+            step = 1.0f;
+            if ((minv > -FLT_MAX) && (maxv < FLT_MAX)) {
+                step = std::max(0.000001f, (maxv - minv) * 0.01f);
+            } else if ((minv == -FLT_MAX) && (maxv < FLT_MAX)) {
+                step = std::max(0.000001f, std::abs(maxv - val) * 0.01f);
+            } else if ((minv > -FLT_MAX) && (maxv == FLT_MAX)) {
+                step = std::max(0.000001f, std::abs(val - minv) * 0.01f);
+            }
+            this->gui_widget_stepsize = step;
+            retval = true;
+        }
+        float min_step_size = step;
+        float max_step_size = 10.f * min_step_size;
+        if (!std::holds_alternative<float>(this->gui_widget_stepsize)) {
+            this->gui_widget_stepsize = step;
+        }
 
         ImGui::BeginGroup();
+        auto p = this->GetGUIPresentation();
 
         // Min Max Step Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
@@ -1777,40 +1816,27 @@ bool megamol::gui::Parameter::widget_float(megamol::gui::Parameter::WidgetScope 
             ImGui::SameLine();
         }
 
-        float min_step_size = 1.0f;
-        float max_step_size = 10.0f;
-        if (step == FLT_MAX) {
-            // Relative step size if step size is not explicitly set
-            if ((minv > -FLT_MAX) && (maxv < FLT_MAX)) {
-                min_step_size = (maxv - minv) * 0.003f; // 0.3%
-                max_step_size = (maxv - minv) * 0.03f;  // 3%
-            }
-        } else {
-            min_step_size = step;
-            max_step_size = 10.f * min_step_size;
-        }
-
         // Value
         if (p == Present_t::Slider) {
             const float offset = 2.0f;
             auto slider_min = (minv > -FLT_MAX) ? (minv) : ((val == 0.0f) ? (-offset) : (val - (offset * val)));
             auto slider_max = (maxv < FLT_MAX) ? (maxv) : ((val == 0.0f) ? (offset) : (val + (offset * val)));
-            ImGui::SliderFloat(label.c_str(), &std::get<float>(this->gui_widget_store), slider_min, slider_max,
+            ImGui::SliderFloat(label.c_str(), &std::get<float>(this->gui_widget_value), slider_min, slider_max,
                 this->gui_float_format.c_str());
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else if (p == Present_t::Drag) {
-            ImGui::DragFloat(label.c_str(), &std::get<float>(this->gui_widget_store), min_step_size, minv, maxv);
+            ImGui::DragFloat(label.c_str(), &std::get<float>(this->gui_widget_value), min_step_size, minv, maxv);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else { // Present_t::Basic
-            ImGui::InputFloat(label.c_str(), &std::get<float>(this->gui_widget_store), min_step_size, max_step_size,
+            ImGui::InputFloat(label.c_str(), &std::get<float>(this->gui_widget_value), min_step_size, max_step_size,
                 this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            this->gui_widget_store = std::max(minv, std::min(std::get<float>(this->gui_widget_store), maxv));
-            val = std::get<float>(this->gui_widget_store);
+            this->gui_widget_value = std::max(minv, std::min(std::get<float>(this->gui_widget_value), maxv));
+            val = std::get<float>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
 
         // Min Max Step Values
@@ -1824,11 +1850,21 @@ bool megamol::gui::Parameter::widget_float(megamol::gui::Parameter::WidgetScope 
                 ImGui::InputFloat("Max Value", &max_value, min_step_size, max_step_size, this->gui_float_format.c_str(),
                     ImGuiInputTextFlags_None);
                 gui_utils::PopReadOnly();
-                // step has no effect on slider
+                // Step has no effect on slider
                 if (p != Present_t::Slider) {
-                    //auto step_size = min_step_size;
-                    ImGui::InputFloat("Step Size", &std::get<float>(this->stepsize), min_step_size, max_step_size,
-                        this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
+                    auto tmp_stepsize_step = std::abs(std::get<float>(this->gui_widget_stepsize));
+                    auto stepsize_min_step = tmp_stepsize_step * 0.01f;
+                    auto stepsize_max_step = tmp_stepsize_step * 0.1f;
+                    ImGui::InputFloat("Step Size", &std::get<float>(this->gui_widget_stepsize), stepsize_min_step,
+                        stepsize_max_step, this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
+                    if (ImGui::IsItemDeactivatedAfterEdit()) {
+                        // Limit stepsize to positive value > 0
+                        this->gui_widget_stepsize = std::max(0.000001f, std::get<float>(this->gui_widget_stepsize));
+                        step = std::get<float>(this->gui_widget_stepsize);
+                        retval = true;
+                    } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
+                        this->gui_widget_stepsize = step;
+                    }
                 }
             }
         }
@@ -1844,8 +1880,8 @@ bool megamol::gui::Parameter::widget_vector2f(megamol::gui::Parameter::WidgetSco
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<glm::vec2>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
+        if (!std::holds_alternative<glm::vec2>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
 
         auto p = this->GetGUIPresentation();
@@ -1871,7 +1907,7 @@ bool megamol::gui::Parameter::widget_vector2f(megamol::gui::Parameter::WidgetSco
                 std::max(vec_min, ((value_min == 0.0f) ? (-offset) : (value_min - (offset * fabsf(value_min)))));
             auto slider_max =
                 std::min(vec_max, ((value_max == 0.0f) ? (offset) : (value_max + (offset * fabsf(value_max)))));
-            ImGui::SliderFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_store)), slider_min,
+            ImGui::SliderFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_value)), slider_min,
                 slider_max, this->gui_float_format.c_str());
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else if (p == Present_t::Drag) {
@@ -1880,21 +1916,21 @@ bool megamol::gui::Parameter::widget_vector2f(megamol::gui::Parameter::WidgetSco
             if ((vec_min > -FLT_MAX) && (vec_max < FLT_MAX)) {
                 min_step_size = (vec_max - vec_min) * 0.003f; // 0.3%
             }
-            ImGui::DragFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_store)), min_step_size,
+            ImGui::DragFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_value)), min_step_size,
                 vec_min, vec_max);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else { // Present_t::Basic
-            ImGui::InputFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_store)),
+            ImGui::InputFloat2(label.c_str(), glm::value_ptr(std::get<glm::vec2>(this->gui_widget_value)),
                 this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            auto x = std::max(minv.x, std::min(std::get<glm::vec2>(this->gui_widget_store).x, maxv.x));
-            auto y = std::max(minv.y, std::min(std::get<glm::vec2>(this->gui_widget_store).y, maxv.y));
-            this->gui_widget_store = glm::vec2(x, y);
-            val = std::get<glm::vec2>(this->gui_widget_store);
+            auto x = std::max(minv.x, std::min(std::get<glm::vec2>(this->gui_widget_value).x, maxv.x));
+            auto y = std::max(minv.y, std::min(std::get<glm::vec2>(this->gui_widget_value).y, maxv.y));
+            this->gui_widget_value = glm::vec2(x, y);
+            val = std::get<glm::vec2>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
 
         // Min Max Values
@@ -1922,8 +1958,8 @@ bool megamol::gui::Parameter::widget_vector3f(megamol::gui::Parameter::WidgetSco
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<glm::vec3>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
+        if (!std::holds_alternative<glm::vec3>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
 
         auto p = this->GetGUIPresentation();
@@ -1950,7 +1986,7 @@ bool megamol::gui::Parameter::widget_vector3f(megamol::gui::Parameter::WidgetSco
                 std::max(vec_min, ((value_min == 0.0f) ? (-offset) : (value_min - (offset * fabsf(value_min)))));
             auto slider_max =
                 std::min(vec_max, ((value_max == 0.0f) ? (offset) : (value_max + (offset * fabsf(value_max)))));
-            ImGui::SliderFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_store)), slider_min,
+            ImGui::SliderFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_value)), slider_min,
                 slider_max, this->gui_float_format.c_str());
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else if (p == Present_t::Drag) {
@@ -1959,22 +1995,22 @@ bool megamol::gui::Parameter::widget_vector3f(megamol::gui::Parameter::WidgetSco
             if ((vec_min > -FLT_MAX) && (vec_max < FLT_MAX)) {
                 min_step_size = (vec_max - vec_min) * 0.003f; // 0.3%
             }
-            ImGui::DragFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_store)), min_step_size,
+            ImGui::DragFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_value)), min_step_size,
                 vec_min, vec_max);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else { // Present_t::Basic
-            ImGui::InputFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_store)),
+            ImGui::InputFloat3(label.c_str(), glm::value_ptr(std::get<glm::vec3>(this->gui_widget_value)),
                 this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            auto x = std::max(minv.x, std::min(std::get<glm::vec3>(this->gui_widget_store).x, maxv.x));
-            auto y = std::max(minv.y, std::min(std::get<glm::vec3>(this->gui_widget_store).y, maxv.y));
-            auto z = std::max(minv.z, std::min(std::get<glm::vec3>(this->gui_widget_store).z, maxv.z));
-            this->gui_widget_store = glm::vec3(x, y, z);
-            val = std::get<glm::vec3>(this->gui_widget_store);
+            auto x = std::max(minv.x, std::min(std::get<glm::vec3>(this->gui_widget_value).x, maxv.x));
+            auto y = std::max(minv.y, std::min(std::get<glm::vec3>(this->gui_widget_value).y, maxv.y));
+            auto z = std::max(minv.z, std::min(std::get<glm::vec3>(this->gui_widget_value).z, maxv.z));
+            this->gui_widget_value = glm::vec3(x, y, z);
+            val = std::get<glm::vec3>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
 
         // Min Max Values
@@ -2002,8 +2038,8 @@ bool megamol::gui::Parameter::widget_vector4f(megamol::gui::Parameter::WidgetSco
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-        if (!std::holds_alternative<glm::vec4>(this->gui_widget_store)) {
-            this->gui_widget_store = val;
+        if (!std::holds_alternative<glm::vec4>(this->gui_widget_value)) {
+            this->gui_widget_value = val;
         }
 
         auto p = this->GetGUIPresentation();
@@ -2029,7 +2065,7 @@ bool megamol::gui::Parameter::widget_vector4f(megamol::gui::Parameter::WidgetSco
                 std::max(vec_min, ((value_min == 0.0f) ? (-offset) : (value_min - (offset * fabsf(value_min)))));
             auto slider_max =
                 std::min(vec_max, ((value_max == 0.0f) ? (offset) : (value_max + (offset * fabsf(value_max)))));
-            ImGui::SliderFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_store)), slider_min,
+            ImGui::SliderFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_value)), slider_min,
                 slider_max, this->gui_float_format.c_str());
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else if (p == Present_t::Drag) {
@@ -2038,23 +2074,23 @@ bool megamol::gui::Parameter::widget_vector4f(megamol::gui::Parameter::WidgetSco
             if ((vec_min > -FLT_MAX) && (vec_max < FLT_MAX)) {
                 min_step_size = (vec_max - vec_min) * 0.003f; // 0.3%
             }
-            ImGui::DragFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_store)), min_step_size,
+            ImGui::DragFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_value)), min_step_size,
                 vec_min, vec_max);
             this->gui_help = "[Ctrl + Click] to turn slider into an input box.";
         } else { // Present_t::Basic
-            ImGui::InputFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_store)),
+            ImGui::InputFloat4(label.c_str(), glm::value_ptr(std::get<glm::vec4>(this->gui_widget_value)),
                 this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
         }
         if (ImGui::IsItemDeactivatedAfterEdit()) {
-            auto x = std::max(minv.x, std::min(std::get<glm::vec4>(this->gui_widget_store).x, maxv.x));
-            auto y = std::max(minv.y, std::min(std::get<glm::vec4>(this->gui_widget_store).y, maxv.y));
-            auto z = std::max(minv.z, std::min(std::get<glm::vec4>(this->gui_widget_store).z, maxv.z));
-            auto w = std::max(minv.w, std::min(std::get<glm::vec4>(this->gui_widget_store).w, maxv.w));
-            this->gui_widget_store = glm::vec4(x, y, z, w);
-            val = std::get<glm::vec4>(this->gui_widget_store);
+            auto x = std::max(minv.x, std::min(std::get<glm::vec4>(this->gui_widget_value).x, maxv.x));
+            auto y = std::max(minv.y, std::min(std::get<glm::vec4>(this->gui_widget_value).y, maxv.y));
+            auto z = std::max(minv.z, std::min(std::get<glm::vec4>(this->gui_widget_value).z, maxv.z));
+            auto w = std::max(minv.w, std::min(std::get<glm::vec4>(this->gui_widget_value).w, maxv.w));
+            this->gui_widget_value = glm::vec4(x, y, z, w);
+            val = std::get<glm::vec4>(this->gui_widget_value);
             retval = true;
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
-            this->gui_widget_store = val;
+            this->gui_widget_value = val;
         }
 
         // Min Max Values
@@ -2256,6 +2292,7 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
 
 bool megamol::gui::Parameter::widget_knob(megamol::gui::Parameter::WidgetScope scope, const std::string& label,
     float& val, float minv, float maxv, float step) {
+
     bool retval = false;
 
     ImGuiStyle& style = ImGui::GetStyle();
@@ -2277,7 +2314,7 @@ bool megamol::gui::Parameter::widget_knob(megamol::gui::Parameter::WidgetScope s
         ImVec2 pos = ImGui::GetCursorPos();
         ImGui::PushItemWidth(ImGui::CalcItemWidth() - left_widget_x_offset);
 
-        if (this->widget_float(scope, label, val, minv, maxv, step)) {
+        if (this->widget_float(scope, label, val, step, minv, maxv)) {
             retval = true;
         }
         ImGui::PopItemWidth();

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -1682,6 +1682,9 @@ bool megamol::gui::Parameter::widget_int(
         if (!std::holds_alternative<int>(this->gui_widget_store)) {
             this->gui_widget_store = val;
         }
+        if (!std::holds_alternative<int>(this->stepsize)) {
+            this->stepsize = step;
+        }
         auto p = this->GetGUIPresentation();
 
         // Min Max Step Values
@@ -1734,11 +1737,12 @@ bool megamol::gui::Parameter::widget_int(
             auto max_value = maxv;
             ImGui::InputInt("Max Value", &max_value, min_step_size, max_step_size, ImGuiInputTextFlags_None);
             // step has no effect on slider
-            if (p != Present_t::Slider) {
-                auto step_size = min_step_size;
-                ImGui::InputInt("Step Size", &step_size, min_step_size, max_step_size, ImGuiInputTextFlags_None);
-            }
             gui_utils::PopReadOnly();
+            if (p != Present_t::Slider) {
+                //auto step_size = min_step_size;
+                ImGui::InputInt("Step Size", &std::get<int>(this->stepsize), min_step_size, max_step_size,
+                    ImGuiInputTextFlags_None);
+            }
         }
         ImGui::EndGroup();
     }
@@ -1755,8 +1759,12 @@ bool megamol::gui::Parameter::widget_float(
         if (!std::holds_alternative<float>(this->gui_widget_store)) {
             this->gui_widget_store = val;
         }
+        if (!std::holds_alternative<float>(this->stepsize)) {
+            this->stepsize = step;
+        }
 
         auto p = this->GetGUIPresentation();
+
         ImGui::BeginGroup();
 
         // Min Max Step Option
@@ -1814,13 +1822,13 @@ bool megamol::gui::Parameter::widget_float(
                 auto max_value = maxv;
                 ImGui::InputFloat("Max Value", &max_value, min_step_size, max_step_size, this->gui_float_format.c_str(),
                     ImGuiInputTextFlags_None);
+                gui_utils::PopReadOnly();
                 // step has no effect on slider
                 if (p != Present_t::Slider) {
-                    auto step_size = min_step_size;
-                    ImGui::InputFloat("Step Size", &step_size, min_step_size, max_step_size,
+                    //auto step_size = min_step_size;
+                    ImGui::InputFloat("Step Size", &std::get<float>(this->stepsize), min_step_size, max_step_size,
                         this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
                 }
-                gui_utils::PopReadOnly();
             }
         }
         ImGui::EndGroup();
@@ -2289,8 +2297,12 @@ bool megamol::gui::Parameter::widget_knob(
             ImGui::TextUnformatted("Max: inf");
         }
         ImGui::SameLine();
-        value_label = "Step: " + this->gui_float_format;
-        ImGui::Text(value_label.c_str(), step);
+        if (step < FLT_MAX) {
+            value_label = "Step: " + this->gui_float_format;
+            ImGui::Text(value_label.c_str(), step);
+        } else {
+            ImGui::TextUnformatted("Step: inf");
+        }
     }
     // GLOBAL -----------------------------------------------------------
     else if (scope == megamol::gui::Parameter::WidgetScope::GLOBAL) {

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -34,7 +34,7 @@ using namespace megamol::gui;
 
 
 megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minv, Max_t maxv,
-    const std::string& param_name, const std::string& description)
+    Step_t step, const std::string& param_name, const std::string& description)
         : megamol::core::param::AbstractParamPresentation()
         , uid(uid)
         , type(type)
@@ -44,6 +44,7 @@ megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t stor
         , core_param_ptr(nullptr)
         , minval(minv)
         , maxval(maxv)
+        , stepsize(step)
         , storage(store)
         , value()
         , default_value()
@@ -56,7 +57,7 @@ megamol::gui::Parameter::Parameter(ImGuiID uid, ParamType_t type, Storage_t stor
         , gui_widget_store()
         , gui_set_focus(0)
         , gui_state_dirty(false)
-        , gui_show_minmax(false)
+        , gui_show_minmaxstep(false)
         , gui_file_browser()
         , gui_tooltip()
         , gui_image_widget()
@@ -350,11 +351,13 @@ bool megamol::gui::Parameter::ReadNewCoreParameterToStockParameter(
         out_param.default_value = p_ptr->ValueString();
         out_param.minval = p_ptr->MinValue();
         out_param.maxval = p_ptr->MaxValue();
+        out_param.stepsize = p_ptr->StepSize();
     } else if (auto* p_ptr = in_param_slot.Param<core::param::IntParam>()) {
         out_param.type = ParamType_t::INT;
         out_param.default_value = p_ptr->ValueString();
         out_param.minval = p_ptr->MinValue();
         out_param.maxval = p_ptr->MaxValue();
+        out_param.stepsize = p_ptr->StepSize();
     } else if (auto* p_ptr = in_param_slot.Param<core::param::StringParam>()) {
         out_param.type = ParamType_t::STRING;
         out_param.default_value = p_ptr->ValueString();
@@ -414,19 +417,19 @@ bool megamol::gui::Parameter::ReadNewCoreParameterToNewParameter(megamol::core::
 
     if (auto* p_ptr = in_param_slot.template Param<core::param::BoolParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::BOOL, std::monostate(),
-            std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::ButtonParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::BUTTON,
-            p_ptr->GetKeyCode(), std::monostate(), std::monostate(), param_name, description);
+            p_ptr->GetKeyCode(), std::monostate(), std::monostate(), std::monostate(), param_name, description);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::ColorParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::COLOR, std::monostate(),
-            std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), param_name, description);
         auto value = p_ptr->Value();
         out_param->SetValue(glm::vec4(value[0], value[1], value[2], value[3]), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::TransferFunctionParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::TRANSFERFUNCTION,
-            std::monostate(), std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::EnumParam>()) {
         EnumStorage_t map;
@@ -437,26 +440,27 @@ bool megamol::gui::Parameter::ReadNewCoreParameterToNewParameter(megamol::core::
             map.emplace(pair.Key(), std::string(pair.Value().PeekBuffer()));
         }
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::ENUM, map,
-            std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::FlexEnumParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::FLEXENUM,
-            p_ptr->getStorage(), std::monostate(), std::monostate(), param_name, description);
+            p_ptr->getStorage(), std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::FloatParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::FLOAT, std::monostate(),
-            p_ptr->MinValue(), p_ptr->MaxValue(), param_name, description);
+            p_ptr->MinValue(), p_ptr->MaxValue(), p_ptr->StepSize(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::IntParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::INT, std::monostate(),
-            p_ptr->MinValue(), p_ptr->MaxValue(), param_name, description);
+            p_ptr->MinValue(), p_ptr->MaxValue(), p_ptr->StepSize(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::Vector2fParam>()) {
         auto minv = p_ptr->MinValue();
         auto maxv = p_ptr->MaxValue();
         auto val = p_ptr->Value();
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::VECTOR2F,
-            std::monostate(), glm::vec2(minv.X(), minv.Y()), glm::vec2(maxv.X(), maxv.Y()), param_name, description);
+            std::monostate(), glm::vec2(minv.X(), minv.Y()), glm::vec2(maxv.X(), maxv.Y()), std::monostate(),
+            param_name, description);
         out_param->SetValue(glm::vec2(val.X(), val.Y()), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::Vector3fParam>()) {
         auto minv = p_ptr->MinValue();
@@ -464,7 +468,7 @@ bool megamol::gui::Parameter::ReadNewCoreParameterToNewParameter(megamol::core::
         auto val = p_ptr->Value();
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::VECTOR3F,
             std::monostate(), glm::vec3(minv.X(), minv.Y(), minv.Z()), glm::vec3(maxv.X(), maxv.Y(), maxv.Z()),
-            param_name, description);
+            std::monostate(), param_name, description);
         out_param->SetValue(glm::vec3(val.X(), val.Y(), val.Z()), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::Vector4fParam>()) {
         auto minv = p_ptr->MinValue();
@@ -472,20 +476,20 @@ bool megamol::gui::Parameter::ReadNewCoreParameterToNewParameter(megamol::core::
         auto val = p_ptr->Value();
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::VECTOR4F,
             std::monostate(), glm::vec4(minv.X(), minv.Y(), minv.Z(), minv.W()),
-            glm::vec4(maxv.X(), maxv.Y(), maxv.Z(), maxv.W()), param_name, description);
+            glm::vec4(maxv.X(), maxv.Y(), maxv.Z(), maxv.W()), std::monostate(), param_name, description);
         out_param->SetValue(glm::vec4(val.X(), val.Y(), val.Z(), val.W()), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.template Param<core::param::TernaryParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::TERNARY,
-            std::monostate(), std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.Param<core::param::StringParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::STRING, std::monostate(),
-            std::monostate(), std::monostate(), param_name, description);
+            std::monostate(), std::monostate(), std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else if (auto* p_ptr = in_param_slot.Param<core::param::FilePathParam>()) {
         out_param = std::make_shared<Parameter>(megamol::gui::GenerateUniqueID(), ParamType_t::FILEPATH,
             FilePathStorage_t({p_ptr->GetFlags(), p_ptr->GetExtensions()}), std::monostate(), std::monostate(),
-            param_name, description);
+            std::monostate(), param_name, description);
         out_param->SetValue(p_ptr->Value(), set_default_val, set_dirty);
     } else {
         megamol::core::utility::log::Log::DefaultLog.WriteError(
@@ -575,6 +579,7 @@ bool megamol::gui::Parameter::ReadCoreParameterToParameter(
             out_param.SetValue(p_ptr->Value(), set_default_val, set_dirty);
             out_param.SetMinValue(p_ptr->MinValue());
             out_param.SetMaxValue(p_ptr->MaxValue());
+            out_param.SetStepSize(p_ptr->StepSize());
         } else {
             type_error = true;
         }
@@ -583,6 +588,7 @@ bool megamol::gui::Parameter::ReadCoreParameterToParameter(
             out_param.SetValue(p_ptr->Value(), set_default_val, set_dirty);
             out_param.SetMinValue(p_ptr->MinValue());
             out_param.SetMaxValue(p_ptr->MaxValue());
+            out_param.SetStepSize(p_ptr->StepSize());
         } else {
             type_error = true;
         }
@@ -955,7 +961,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             else if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
+                        this->GetStepSize<T>())) {
                     this->SetValue(val);
                     retval = true;
                 }
@@ -965,7 +972,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
+                            this->GetStepSize<T>())) {
                         this->SetValue(val);
                         retval = true;
                     }
@@ -1205,7 +1213,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                if (this->widget_knob(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                if (this->widget_knob(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
+                        this->GetStepSize<T>())) {
                     this->SetValue(val);
                     retval = true;
                 }
@@ -1219,7 +1228,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
+                        this->GetStepSize<T>())) {
                     this->SetValue(val);
                     retval = true;
                 }
@@ -1229,7 +1239,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                    if (this->widget_int(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(),
+                            this->GetStepSize<T>())) {
                         this->SetValue(val);
                         retval = true;
                     }
@@ -1663,7 +1674,7 @@ bool megamol::gui::Parameter::widget_ternary(
 
 
 bool megamol::gui::Parameter::widget_int(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int minv, int maxv) {
+    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int step) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
@@ -1673,20 +1684,25 @@ bool megamol::gui::Parameter::widget_int(
         }
         auto p = this->GetGUIPresentation();
 
-        // Min Max Values
+        // Min Max Step Values
         ImGui::BeginGroup();
-        if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmax) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
-            this->gui_show_minmax = !this->gui_show_minmax;
+        if (ImGui::ArrowButton("###_min_max_step", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+            this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
         }
-        this->gui_tooltip.ToolTip("Min/Max Values");
+        this->gui_tooltip.ToolTip("Min/Max/Step Values");
         ImGui::SameLine();
 
-        // Relative step size
         int min_step_size = 1;
         int max_step_size = 10;
-        if ((minv > INT_MIN) && (maxv < INT_MAX)) {
-            min_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.003f); // 0.3%
-            max_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.03f);  // 3%
+        if (step == INT_MAX) {
+            // Relative step size if step size is not explicitly set
+            if ((minv > INT_MIN) && (maxv < INT_MAX)) {
+                min_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.003f); // 0.3%
+                max_step_size = static_cast<int>(static_cast<float>(maxv - minv) * 0.03f);  // 3%
+            }
+        } else {
+            min_step_size = step;
+            max_step_size = 10 * step;
         }
 
         // Value
@@ -1711,12 +1727,17 @@ bool megamol::gui::Parameter::widget_int(
         } else if (!ImGui::IsItemActive() && !ImGui::IsItemEdited()) {
             this->gui_widget_store = val;
         }
-        if (this->gui_show_minmax) {
+        if (this->gui_show_minmaxstep) {
             gui_utils::PushReadOnly();
             auto min_value = minv;
             ImGui::InputInt("Min Value", &min_value, min_step_size, max_step_size, ImGuiInputTextFlags_None);
             auto max_value = maxv;
             ImGui::InputInt("Max Value", &max_value, min_step_size, max_step_size, ImGuiInputTextFlags_None);
+            // step has no effect on slider
+            if (p != Present_t::Slider) {
+                auto step_size = min_step_size;
+                ImGui::InputInt("Step Size", &step_size, min_step_size, max_step_size, ImGuiInputTextFlags_None);
+            }
             gui_utils::PopReadOnly();
         }
         ImGui::EndGroup();
@@ -1726,7 +1747,7 @@ bool megamol::gui::Parameter::widget_int(
 
 
 bool megamol::gui::Parameter::widget_float(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv) {
+    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
@@ -1738,21 +1759,26 @@ bool megamol::gui::Parameter::widget_float(
         auto p = this->GetGUIPresentation();
         ImGui::BeginGroup();
 
-        // Min Max Option
+        // Min Max Step Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmax) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
-                this->gui_show_minmax = !this->gui_show_minmax;
+            if (ImGui::ArrowButton("###_min_max_step", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+                this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
             }
-            this->gui_tooltip.ToolTip("Min/Max Values");
+            this->gui_tooltip.ToolTip("Min/Max/Step Values");
             ImGui::SameLine();
         }
 
-        // Relative step size
         float min_step_size = 1.0f;
         float max_step_size = 10.0f;
-        if ((minv > -FLT_MAX) && (maxv < FLT_MAX)) {
-            min_step_size = (maxv - minv) * 0.003f; // 0.3%
-            max_step_size = (maxv - minv) * 0.03f;  // 3%
+        if (step == FLT_MAX) {
+            // Relative step size if step size is not explicitly set
+            if ((minv > -FLT_MAX) && (maxv < FLT_MAX)) {
+                min_step_size = (maxv - minv) * 0.003f; // 0.3%
+                max_step_size = (maxv - minv) * 0.03f;  // 3%
+            }
+        } else {
+            min_step_size = step;
+            max_step_size = 10.f * min_step_size;
         }
 
         // Value
@@ -1778,9 +1804,9 @@ bool megamol::gui::Parameter::widget_float(
             this->gui_widget_store = val;
         }
 
-        // Min Max Values
+        // Min Max Step Values
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (this->gui_show_minmax) {
+            if (this->gui_show_minmaxstep) {
                 gui_utils::PushReadOnly();
                 auto min_value = minv;
                 ImGui::InputFloat("Min Value", &min_value, min_step_size, max_step_size, this->gui_float_format.c_str(),
@@ -1788,6 +1814,12 @@ bool megamol::gui::Parameter::widget_float(
                 auto max_value = maxv;
                 ImGui::InputFloat("Max Value", &max_value, min_step_size, max_step_size, this->gui_float_format.c_str(),
                     ImGuiInputTextFlags_None);
+                // step has no effect on slider
+                if (p != Present_t::Slider) {
+                    auto step_size = min_step_size;
+                    ImGui::InputFloat("Step Size", &step_size, min_step_size, max_step_size,
+                        this->gui_float_format.c_str(), ImGuiInputTextFlags_None);
+                }
                 gui_utils::PopReadOnly();
             }
         }
@@ -1812,8 +1844,8 @@ bool megamol::gui::Parameter::widget_vector2f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmax) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
-                this->gui_show_minmax = !this->gui_show_minmax;
+            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+                this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
             }
             this->gui_tooltip.ToolTip("Min/Max Values");
             ImGui::SameLine();
@@ -1858,7 +1890,7 @@ bool megamol::gui::Parameter::widget_vector2f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Values
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (this->gui_show_minmax) {
+            if (this->gui_show_minmaxstep) {
                 gui_utils::PushReadOnly();
                 auto min_value = minv;
                 ImGui::InputFloat2(
@@ -1890,8 +1922,8 @@ bool megamol::gui::Parameter::widget_vector3f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmax) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
-                this->gui_show_minmax = !this->gui_show_minmax;
+            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+                this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
             }
             this->gui_tooltip.ToolTip("Min/Max Values");
             ImGui::SameLine();
@@ -1938,7 +1970,7 @@ bool megamol::gui::Parameter::widget_vector3f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Values
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (this->gui_show_minmax) {
+            if (this->gui_show_minmaxstep) {
                 gui_utils::PushReadOnly();
                 auto min_value = minv;
                 ImGui::InputFloat3(
@@ -1970,8 +2002,8 @@ bool megamol::gui::Parameter::widget_vector4f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Option
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmax) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
-                this->gui_show_minmax = !this->gui_show_minmax;
+            if (ImGui::ArrowButton("###_min_max", ((this->gui_show_minmaxstep) ? (ImGuiDir_Down) : (ImGuiDir_Up)))) {
+                this->gui_show_minmaxstep = !this->gui_show_minmaxstep;
             }
             this->gui_tooltip.ToolTip("Min/Max Values");
             ImGui::SameLine();
@@ -2018,7 +2050,7 @@ bool megamol::gui::Parameter::widget_vector4f(megamol::gui::Parameter::WidgetSco
 
         // Min Max Values
         if ((p == Present_t::Basic) || (p == Present_t::Slider) || (p == Present_t::Drag)) {
-            if (this->gui_show_minmax) {
+            if (this->gui_show_minmaxstep) {
                 gui_utils::PushReadOnly();
                 auto min_value = minv;
                 ImGui::InputFloat4(
@@ -2214,7 +2246,7 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
 
 
 bool megamol::gui::Parameter::widget_knob(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv) {
+    megamol::gui::Parameter::WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step) {
     bool retval = false;
 
     ImGuiStyle& style = ImGui::GetStyle();
@@ -2224,7 +2256,7 @@ bool megamol::gui::Parameter::widget_knob(
 
         // Draw knob
         const float knob_size = ImGui::GetTextLineHeightWithSpacing() + ImGui::GetFrameHeightWithSpacing();
-        if (ButtonWidgets::KnobButton("param_knob", knob_size, val, minv, maxv)) {
+        if (ButtonWidgets::KnobButton("param_knob", knob_size, val, minv, maxv, step)) {
             retval = true;
         }
 
@@ -2236,12 +2268,12 @@ bool megamol::gui::Parameter::widget_knob(
         ImVec2 pos = ImGui::GetCursorPos();
         ImGui::PushItemWidth(ImGui::CalcItemWidth() - left_widget_x_offset);
 
-        if (this->widget_float(scope, label, val, minv, maxv)) {
+        if (this->widget_float(scope, label, val, minv, maxv, step)) {
             retval = true;
         }
         ImGui::PopItemWidth();
 
-        // Draw min max
+        // Draw min max step
         ImGui::SetCursorPos(pos + ImVec2(0.0f, ImGui::GetFrameHeightWithSpacing()));
         if (minv > -FLT_MAX) {
             value_label = "Min: " + this->gui_float_format;
@@ -2256,6 +2288,9 @@ bool megamol::gui::Parameter::widget_knob(
         } else {
             ImGui::TextUnformatted("Max: inf");
         }
+        ImGui::SameLine();
+        value_label = "Step: " + this->gui_float_format;
+        ImGui::Text(value_label.c_str(), step);
     }
     // GLOBAL -----------------------------------------------------------
     else if (scope == megamol::gui::Parameter::WidgetScope::GLOBAL) {

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -964,8 +964,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             else if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                float step = this->GetStepSize<T>();
-                if (this->widget_float(scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                auto step = this->GetStepSize<T>();
+                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(), step)) {
                     this->SetValue(val);
                     this->SetStepSize(step);
                     retval = true;
@@ -976,9 +976,9 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    int step = this->GetStepSize<T>();
+                    auto step = this->GetStepSize<T>();
                     if (this->widget_int(
-                            scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                            scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(), step)) {
                         this->SetValue(val);
                         this->SetStepSize(step);
                         retval = true;
@@ -1234,8 +1234,8 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
             // FLOAT -----------------------------------------------
             if constexpr (std::is_same_v<T, float>) {
                 auto val = arg;
-                float step = this->GetStepSize<T>();
-                if (this->widget_float(scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                auto step = this->GetStepSize<T>();
+                if (this->widget_float(scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(), step)) {
                     this->SetValue(val);
                     this->SetStepSize(step);
                     retval = true;
@@ -1246,9 +1246,9 @@ bool megamol::gui::Parameter::draw_parameter(megamol::gui::Parameter::WidgetScop
                     // INT ---------------------------------------------
                 case (ParamType_t::INT): {
                     auto val = arg;
-                    int step = this->GetStepSize<T>();
+                    auto step = this->GetStepSize<T>();
                     if (this->widget_int(
-                            scope, param_label, val, step, this->GetMinValue<T>(), this->GetMaxValue<T>())) {
+                            scope, param_label, val, this->GetMinValue<T>(), this->GetMaxValue<T>(), step)) {
                         this->SetValue(val);
                         this->SetStepSize(step);
                         retval = true;
@@ -1683,12 +1683,11 @@ bool megamol::gui::Parameter::widget_ternary(
 
 
 bool megamol::gui::Parameter::widget_int(
-    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int& step, int minv, int maxv) {
+    megamol::gui::Parameter::WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int& step) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-
         if (!std::holds_alternative<int>(this->gui_widget_value)) {
             this->gui_widget_value = val;
         }
@@ -1774,12 +1773,11 @@ bool megamol::gui::Parameter::widget_int(
 
 
 bool megamol::gui::Parameter::widget_float(megamol::gui::Parameter::WidgetScope scope, const std::string& label,
-    float& val, float& step, float minv, float maxv) {
+    float& val, float minv, float maxv, float& step) {
     bool retval = false;
 
     // LOCAL -----------------------------------------------------------
     if (scope == megamol::gui::Parameter::WidgetScope::LOCAL) {
-
         if (!std::holds_alternative<float>(this->gui_widget_value)) {
             this->gui_widget_value = val;
         }
@@ -2314,7 +2312,7 @@ bool megamol::gui::Parameter::widget_knob(megamol::gui::Parameter::WidgetScope s
         ImVec2 pos = ImGui::GetCursorPos();
         ImGui::PushItemWidth(ImGui::CalcItemWidth() - left_widget_x_offset);
 
-        if (this->widget_float(scope, label, val, step, minv, maxv)) {
+        if (this->widget_float(scope, label, val, minv, maxv, step)) {
             retval = true;
         }
         ImGui::PopItemWidth();

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -212,22 +212,22 @@ public:
     }
 
     template<typename T>
-    const T& GetMinValue() const {
+    T const& GetMinValue() const {
         return std::get<T>(this->minval);
     }
 
     template<typename T>
-    const T& GetMaxValue() const {
+    T const& GetMaxValue() const {
         return std::get<T>(this->maxval);
     }
 
     template<typename T>
-    const T& GetStepSize() const {
+    T const& GetStepSize() const {
         return std::get<T>(this->stepsize);
     }
 
     template<typename T>
-    const T& GetStorage() const {
+    T const& GetStorage() const {
         return std::get<T>(this->storage);
     }
 
@@ -308,7 +308,8 @@ private:
     const std::string gui_float_format;
     std::string gui_help;
     std::string gui_tooltip_text;
-    std::variant<std::monostate, std::string, int, float, glm::vec2, glm::vec3, glm::vec4> gui_widget_store;
+    std::variant<std::monostate, std::string, int, float, glm::vec2, glm::vec3, glm::vec4> gui_widget_value;
+    Step_t gui_widget_stepsize;
     unsigned int gui_set_focus;
     bool gui_state_dirty;
     bool gui_show_minmaxstep;
@@ -340,8 +341,8 @@ private:
     bool widget_filepath(
         WidgetScope scope, const std::string& label, std::filesystem::path& val, const FilePathStorage_t& store);
     bool widget_ternary(WidgetScope scope, const std::string& label, vislib::math::Ternary& val);
-    bool widget_int(WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int step);
-    bool widget_float(WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step);
+    bool widget_int(WidgetScope scope, const std::string& label, int& val, int& step, int minv, int maxv);
+    bool widget_float(WidgetScope scope, const std::string& label, float& val, float& step, float minv, float maxv);
     bool widget_vector2f(WidgetScope scope, const std::string& label, glm::vec2& val, glm::vec2 minv, glm::vec2 maxv);
     bool widget_vector3f(WidgetScope scope, const std::string& label, glm::vec3& val, glm::vec3 minv, glm::vec3 maxv);
     bool widget_vector4f(WidgetScope scope, const std::string& label, glm::vec4& val, glm::vec4 minv, glm::vec4 maxv);
@@ -427,7 +428,10 @@ template<typename T>
 void Parameter::SetStepSize(T step) {
 
     if (std::holds_alternative<T>(this->stepsize)) {
-        this->stepsize = step;
+        if (std::get<T>(this->stepsize) != step) {
+            this->stepsize = step;
+            this->value_dirty = true;
+        }
     } else {
         megamol::core::utility::log::Log::DefaultLog.WriteError(
             "[GUI] Bad variant access. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -133,8 +133,8 @@ public:
 
     // ----------------------------
 
-    Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minval, Max_t maxval,
-        Step_t step, const std::string& param_name, const std::string& description);
+    Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minval, Max_t maxval, Step_t step,
+        const std::string& param_name, const std::string& description);
 
     ~Parameter() override;
 

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -82,6 +82,12 @@ public:
         >
         Max_t;
 
+    typedef std::variant<std::monostate, // default (unused/unavailable)
+        float,                           // FLOAT
+        int                              // INT
+        >
+        Step_t;
+
     typedef std::variant<std::monostate,               // default (unused/unavailable)
         megamol::core::view::KeyCode,                  // BUTTON
         EnumStorage_t,                                 // ENUM
@@ -97,6 +103,7 @@ public:
         std::string default_value;
         Min_t minval;
         Max_t maxval;
+        Step_t stepsize;
         Storage_t storage;
         bool gui_visibility;
         bool gui_read_only;
@@ -126,8 +133,8 @@ public:
 
     // ----------------------------
 
-    Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minval, Max_t maxval, const std::string& param_name,
-        const std::string& description);
+    Parameter(ImGuiID uid, ParamType_t type, Storage_t store, Min_t minval, Max_t maxval,
+        Step_t step, const std::string& param_name, const std::string& description);
 
     ~Parameter() override;
 
@@ -215,6 +222,11 @@ public:
     }
 
     template<typename T>
+    const T& GetStepSize() const {
+        return std::get<T>(this->stepsize);
+    }
+
+    template<typename T>
     const T& GetStorage() const {
         return std::get<T>(this->storage);
     }
@@ -262,6 +274,9 @@ public:
     void SetMaxValue(T maxv);
 
     template<typename T>
+    void SetStepSize(T step);
+
+    template<typename T>
     void SetStorage(T store);
 
     inline void SetExtended(bool extended) {
@@ -281,6 +296,7 @@ private:
 
     Min_t minval;
     Max_t maxval;
+    Step_t stepsize;
     Storage_t storage;
     Value_t value;
 
@@ -295,7 +311,7 @@ private:
     std::variant<std::monostate, std::string, int, float, glm::vec2, glm::vec3, glm::vec4> gui_widget_store;
     unsigned int gui_set_focus;
     bool gui_state_dirty;
-    bool gui_show_minmax;
+    bool gui_show_minmaxstep;
     FileBrowserWidget gui_file_browser;
     HoverToolTip gui_tooltip;
     ImageWidget gui_image_widget;
@@ -324,14 +340,14 @@ private:
     bool widget_filepath(
         WidgetScope scope, const std::string& label, std::filesystem::path& val, const FilePathStorage_t& store);
     bool widget_ternary(WidgetScope scope, const std::string& label, vislib::math::Ternary& val);
-    bool widget_int(WidgetScope scope, const std::string& label, int& val, int minv, int maxv);
-    bool widget_float(WidgetScope scope, const std::string& label, float& val, float minv, float maxv);
+    bool widget_int(WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int step);
+    bool widget_float(WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step);
     bool widget_vector2f(WidgetScope scope, const std::string& label, glm::vec2& val, glm::vec2 minv, glm::vec2 maxv);
     bool widget_vector3f(WidgetScope scope, const std::string& label, glm::vec3& val, glm::vec3 minv, glm::vec3 maxv);
     bool widget_vector4f(WidgetScope scope, const std::string& label, glm::vec4& val, glm::vec4 minv, glm::vec4 maxv);
     bool widget_pinvaluetomouse(WidgetScope scope, const std::string& label, const std::string& val);
     bool widget_transfer_function_editor(WidgetScope scope);
-    bool widget_knob(WidgetScope scope, const std::string& label, float& val, float minv, float maxv);
+    bool widget_knob(WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float step);
     bool widget_rotation_axes(
         WidgetScope scope, const std::string& label, glm::vec4& val, glm::vec4 minv, glm::vec4 maxv);
     bool widget_rotation_direction(
@@ -401,6 +417,17 @@ void Parameter::SetMaxValue(T maxv) {
 
     if (std::holds_alternative<T>(this->maxval)) {
         this->maxval = maxv;
+    } else {
+        megamol::core::utility::log::Log::DefaultLog.WriteError(
+            "[GUI] Bad variant access. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);
+    }
+}
+
+template<typename T>
+void Parameter::SetStepSize(T step) {
+
+    if (std::holds_alternative<T>(this->stepsize)) {
+        this->stepsize = step;
     } else {
         megamol::core::utility::log::Log::DefaultLog.WriteError(
             "[GUI] Bad variant access. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -341,8 +341,8 @@ private:
     bool widget_filepath(
         WidgetScope scope, const std::string& label, std::filesystem::path& val, const FilePathStorage_t& store);
     bool widget_ternary(WidgetScope scope, const std::string& label, vislib::math::Ternary& val);
-    bool widget_int(WidgetScope scope, const std::string& label, int& val, int& step, int minv, int maxv);
-    bool widget_float(WidgetScope scope, const std::string& label, float& val, float& step, float minv, float maxv);
+    bool widget_int(WidgetScope scope, const std::string& label, int& val, int minv, int maxv, int& step);
+    bool widget_float(WidgetScope scope, const std::string& label, float& val, float minv, float maxv, float& step);
     bool widget_vector2f(WidgetScope scope, const std::string& label, glm::vec2& val, glm::vec2 minv, glm::vec2 maxv);
     bool widget_vector3f(WidgetScope scope, const std::string& label, glm::vec3& val, glm::vec3 minv, glm::vec3 maxv);
     bool widget_vector4f(WidgetScope scope, const std::string& label, glm::vec4& val, glm::vec4 minv, glm::vec4 maxv);

--- a/frontend/services/gui/src/widgets/ButtonWidgets.cpp
+++ b/frontend/services/gui/src/widgets/ButtonWidgets.cpp
@@ -84,7 +84,7 @@ bool megamol::gui::ButtonWidgets::OptionButton(
 
 
 bool megamol::gui::ButtonWidgets::KnobButton(
-    const std::string& id, float size, float& inout_value, float minval, float maxval) {
+    const std::string& id, float size, float& inout_value, float minval, float maxval, float step) {
 
     assert(ImGui::GetCurrentContext() != nullptr);
     ImGuiStyle& style = ImGui::GetStyle();
@@ -131,9 +131,13 @@ bool megamol::gui::ButtonWidgets::KnobButton(
 
     // Adapt scaling of one round depending on min max delta
     float scaling = 1.0f;
-    if ((minval > -FLT_MAX) && (maxval < FLT_MAX) && (maxval > minval)) {
-        float delta = maxval - minval;
-        scaling = delta / 100.0f; // 360 degree = 1%
+    if (step == FLT_MAX) {
+        if ((minval > -FLT_MAX) && (maxval < FLT_MAX) && (maxval > minval)) {
+            float delta = maxval - minval;
+            scaling = delta / 100.0f; // 360 degree = 1%
+        }
+    } else {
+        scaling = step;
     }
 
     // Calculate knob position

--- a/frontend/services/gui/src/widgets/ButtonWidgets.h
+++ b/frontend/services/gui/src/widgets/ButtonWidgets.h
@@ -30,7 +30,7 @@ public:
     static bool OptionButton(const std::string& id, const std::string& label, bool dirty, bool read_only);
 
     /** Knob button for 'circular' float value manipulation. */
-    static bool KnobButton(const std::string& id, float size, float& inout_value, float minval, float maxval);
+    static bool KnobButton(const std::string& id, float size, float& inout_value, float minval, float maxval, float step);
 
     /** Extended mode button. */
     // OptionButton with menu for 'Basic' and 'Expert' option

--- a/frontend/services/gui/src/widgets/ButtonWidgets.h
+++ b/frontend/services/gui/src/widgets/ButtonWidgets.h
@@ -30,7 +30,8 @@ public:
     static bool OptionButton(const std::string& id, const std::string& label, bool dirty, bool read_only);
 
     /** Knob button for 'circular' float value manipulation. */
-    static bool KnobButton(const std::string& id, float size, float& inout_value, float minval, float maxval, float step);
+    static bool KnobButton(
+        const std::string& id, float size, float& inout_value, float minval, float maxval, float step);
 
     /** Extended mode button. */
     // OptionButton with menu for 'Basic' and 'Expert' option

--- a/frontend/services/gui/src/widgets/ParameterGroupAnimationWidget.cpp
+++ b/frontend/services/gui/src/widgets/ParameterGroupAnimationWidget.cpp
@@ -186,8 +186,7 @@ bool megamol::gui::ParameterGroupAnimationWidget::Draw(ParamPtrVector_t params, 
         float font_size = ImGui::CalcTextSize(label.c_str()).x;
         ImGui::SetCursorPosX(cursor_pos.x + (knob_size - font_size) / 2.0f);
         ImGui::TextUnformatted(label.c_str());
-        ButtonWidgets::KnobButton(
-            label, knob_size, time, param_time->GetMinValue<float>(),
+        ButtonWidgets::KnobButton(label, knob_size, time, param_time->GetMinValue<float>(),
             param_time->GetMaxValue<float>(), param_time->GetStepSize<float>());
         ImGui::Text(param_time->FloatFormat().c_str(), time);
         ImGui::EndGroup();
@@ -199,8 +198,7 @@ bool megamol::gui::ParameterGroupAnimationWidget::Draw(ParamPtrVector_t params, 
         font_size = ImGui::CalcTextSize(label.c_str()).x;
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (knob_size - font_size) / 2.0f);
         ImGui::TextUnformatted(label.c_str());
-        ButtonWidgets::KnobButton(
-            label, knob_size, speed, param_speed->GetMinValue<float>(),
+        ButtonWidgets::KnobButton(label, knob_size, speed, param_speed->GetMinValue<float>(),
             param_speed->GetMaxValue<float>(), param_speed->GetStepSize<float>());
         ImGui::Text(param_speed->FloatFormat().c_str(), speed);
         ImGui::EndGroup();

--- a/frontend/services/gui/src/widgets/ParameterGroupAnimationWidget.cpp
+++ b/frontend/services/gui/src/widgets/ParameterGroupAnimationWidget.cpp
@@ -187,7 +187,8 @@ bool megamol::gui::ParameterGroupAnimationWidget::Draw(ParamPtrVector_t params, 
         ImGui::SetCursorPosX(cursor_pos.x + (knob_size - font_size) / 2.0f);
         ImGui::TextUnformatted(label.c_str());
         ButtonWidgets::KnobButton(
-            label, knob_size, time, param_time->GetMinValue<float>(), param_time->GetMaxValue<float>());
+            label, knob_size, time, param_time->GetMinValue<float>(),
+            param_time->GetMaxValue<float>(), param_time->GetStepSize<float>());
         ImGui::Text(param_time->FloatFormat().c_str(), time);
         ImGui::EndGroup();
         ImGui::SameLine();
@@ -199,7 +200,8 @@ bool megamol::gui::ParameterGroupAnimationWidget::Draw(ParamPtrVector_t params, 
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (knob_size - font_size) / 2.0f);
         ImGui::TextUnformatted(label.c_str());
         ButtonWidgets::KnobButton(
-            label, knob_size, speed, param_speed->GetMinValue<float>(), param_speed->GetMaxValue<float>());
+            label, knob_size, speed, param_speed->GetMinValue<float>(),
+            param_speed->GetMaxValue<float>(), param_speed->GetStepSize<float>());
         ImGui::Text(param_speed->FloatFormat().c_str(), speed);
         ImGui::EndGroup();
 


### PR DESCRIPTION
Added a feature to set a customizable step size for float and int param widgets (see #539 under Features). The PR also includes a possible fix for the reset problem of the min- and max values (see #969).

Customizing the step size during runtime is currently not working, see Issue #969.

## Summary of Changes
The customizable step size is done for the basic, knob, and drag presentation modes. The main changes are basically just an extension of the min- and max value params, i.e. according members are added, constructors and functions singatures are adapted, and various functions are extended to add a step size Input[Int|Float] in the same way it is done for the min- and max values.

The step size can currently only be set when creating the paramslot. Changes during runtime are not working at the moment.

## References and Context
Regarding the customizable step size, see Issue #539 under Features and #969.
Regarding the min-max-value reset problem, see Issue #969.

## Test Instructions
You can now add a forth parameter (being the step size) in the paramslot constructor:
```
this->test << new param::FloatParam(1.0f, 0.f, 10.f, 0.2f);
```

