### PR TITLE
Fix compilation of 'imageviewer2' plug-in

### DIFF
--- a/plugins/image/CMakeLists.txt
+++ b/plugins/image/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 megamol_plugin(image
   BUILD_DEFAULT OFF
+  DEPENDS_GL
   DEPENDS_PLUGINS
     image_calls)
 

--- a/plugins/image/include/image/ImageRenderer.h
+++ b/plugins/image/include/image/ImageRenderer.h
@@ -12,12 +12,12 @@
 #endif /* (defined(_MSC_VER) && (_MSC_VER > 1000)) */
 
 #include "mmcore/param/ParamSlot.h"
-#include "mmcore/view/Renderer3DModuleGL.h"
+#include "mmcore_gl/view/Renderer3DModuleGL.h"
 #include "vislib/Pair.h"
 #include "vislib/SmartPtr.h"
-#include "vislib/graphics/gl/GLSLShader.h"
-#include "vislib/graphics/gl/OpenGLTexture2D.h"
 #include "vislib/math/Rectangle.h"
+#include "vislib_gl/graphics/gl/GLSLShader.h"
+#include "vislib_gl/graphics/gl/OpenGLTexture2D.h"
 #include <memory>
 
 #ifdef WITH_MPI
@@ -32,6 +32,7 @@
 #include "vislib/RawStorage.h"
 
 using namespace megamol::core;
+namespace view_gl = megamol::core_gl::view;
 
 namespace megamol {
 namespace imageviewer2 {
@@ -39,7 +40,7 @@ namespace imageviewer2 {
 /**
  * Mesh-based renderer for bézier curve tubes
  */
-class ImageRenderer : public view::Renderer3DModuleGL {
+class ImageRenderer : public view_gl::Renderer3DModuleGL {
 public:
     /**
      * Answer the name of this module.
@@ -91,7 +92,7 @@ protected:
      *
      * @return The return value of the function.
      */
-    virtual bool GetExtents(view::CallRender3DGL& call);
+    virtual bool GetExtents(view_gl::CallRender3DGL& call);
 
     /**
      * Implementation of 'Release'.
@@ -105,9 +106,15 @@ protected:
      *
      * @return The return value of the function.
      */
-    virtual bool Render(view::CallRender3DGL& call);
+    virtual bool Render(view_gl::CallRender3DGL& call);
 
 private:
+    /**
+     * Utility function to convert a 'std::string' instance into 'TString',
+     * while preserving '\0' bytes.
+     */
+    static vislib::TString stdToTString(const std::string& str);
+
     /**
      * Splits a line at the semicolon into a left and right part. If there
      * is no semicolon, defaultEye governs which one of the strings is set,
@@ -225,13 +232,14 @@ private:
     /** The height of the image */
     unsigned int height;
 
-    vislib::graphics::gl::GLSLShader theShader;
+    vislib_gl::graphics::gl::GLSLShader theShader;
     GLuint theVertBuffer;
     GLuint theTexCoordBuffer;
     GLuint theVAO;
 
     /** The image tiles */
-    vislib::Array<vislib::Pair<vislib::math::Rectangle<float>, vislib::SmartPtr<vislib::graphics::gl::OpenGLTexture2D>>>
+    vislib::Array<
+        vislib::Pair<vislib::math::Rectangle<float>, vislib::SmartPtr<vislib_gl::graphics::gl::OpenGLTexture2D>>>
         tiles;
 
     /** the slide show files for the left eye */

--- a/plugins/image/src/JpegBitmapCodec.cpp
+++ b/plugins/image/src/JpegBitmapCodec.cpp
@@ -5,7 +5,7 @@
  * (Copyright (C) 2010 by VISUS (Universitaet Stuttgart))
  * Alle Rechte vorbehalten.
  */
-#include "imageviewer2/JpegBitmapCodec.h"
+#include "image/JpegBitmapCodec.h"
 #include "stdafx.h"
 #ifndef _WIN32
 #include "jpeglib.h"

--- a/plugins/image/src/image.cpp
+++ b/plugins/image/src/image.cpp
@@ -7,7 +7,7 @@
 #include "mmcore/utility/plugins/AbstractPluginInstance.h"
 #include "mmcore/utility/plugins/PluginRegister.h"
 
-#include "imageviewer2/ImageRenderer.h"
+#include "image/ImageRenderer.h"
 
 namespace megamol::imageviewer2 {
 class Imaggeviewer2PluginInstance : public megamol::core::utility::plugins::AbstractPluginInstance {


### PR DESCRIPTION
This pull request fixes compilation issues in the 'image'/'imageviewer2' plug-in related to renamed headers and namespaces, allowing the plug-in to be included in the MegaMol build process again.

## Summary of Changes
* Fixed compilation of 'imageviewer2' plug-in

## References and Context

N/A

## Test Instructions

* MegaMol should compile successfully with the CMake option `BUILD_PLUGIN_IMAGE` enabled.
* The example project `examples/imageviewer/picviewer.lua` should load without errors after these changes.
  * Note that on Linux, the example image does not load immediately due to backslashes in the path name within the example project. This can be fixed by manually replacing the backslashes with forward slashes in the image renderer's parameters.