### PR TITLE
MegaMol Project Concept

### DIFF
--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -14,7 +14,9 @@
 #include "FrontendResource.h"
 #include "FrontendResourcesLookup.h"
 #include "ImagePresentationEntryPoints.h"
+#include "MegaMolProject.h"
 #include "ModuleGraphSubscription.h"
+
 #include "mmcore/MegaMolGraphTypes.h"
 #include "mmcore/MegaMolGraph_Convenience.h"
 #include "mmcore/RootModuleNamespace.h"
@@ -135,6 +137,8 @@ private:
     // poke the rendering, collect the resulting View renderings and present them to the user appropriately
     std::list<Module::ptr_type> graph_entry_points;
     megamol::frontend_resources::ImagePresentationEntryPoints* m_image_presentation = nullptr;
+
+    megamol::frontend_resources::MegaMolProject* m_current_project_path = nullptr;
 
     MegaMolGraph_Convenience convenience_functions;
 

--- a/core/include/mmcore/param/FilePathParam.h
+++ b/core/include/mmcore/param/FilePathParam.h
@@ -118,7 +118,8 @@ public:
      *
      * @return Return 0 for success, flags with failed check otherwise.
      */
-    static Flags_t ValidatePath(const std::filesystem::path& p, const Extensions_t&, Flags_t f);
+    static Flags_t ValidatePath(
+        const std::filesystem::path& p, const Extensions_t&, Flags_t f, const std::filesystem::path& project_dir = "");
 
 
     /**

--- a/core/include/mmcore/param/FilePathParam.h
+++ b/core/include/mmcore/param/FilePathParam.h
@@ -83,7 +83,7 @@ public:
      * @return The value of the parameter
      */
     std::filesystem::path Value() const {
-        return this->value;
+        return this->GetAbsolutePathValue(this->value);
     }
 
     /**
@@ -92,7 +92,7 @@ public:
      * @return The value of the parameter as string.
      */
     std::string ValueString() const override {
-        return this->value.generic_u8string();
+        return this->Value().generic_u8string();
     }
 
     /**
@@ -120,6 +120,19 @@ public:
      */
     static Flags_t ValidatePath(const std::filesystem::path& p, const Extensions_t&, Flags_t f);
 
+
+    /**
+     * Adds absolute path to current project directory to the file path parameter.
+     * This way file paths relative to the project directory can be resolved.
+     */
+    void SetProjectDirectory(const std::filesystem::path& p);
+
+    /**
+     * Returns either the current path value if it is an absolute path,
+     * or concatinates project directory path and current path value if it is a relative path.
+     */
+    std::filesystem::path GetAbsolutePathValue(const std::filesystem::path& p) const;
+
 private:
     /** The flags of the parameter */
     Flags_t flags;
@@ -132,6 +145,12 @@ private:
 
     /** The file or directory path */
     std::filesystem::path value;
+
+    /**
+     * Absolute path to project directory. If empty, no project path available.
+     * This path is relative per guarantee of the frontend
+     */
+    std::filesystem::path project_directory;
 };
 
 

--- a/core/include/mmcore/param/FilePathParam.h
+++ b/core/include/mmcore/param/FilePathParam.h
@@ -122,13 +122,13 @@ public:
 
 private:
     /** The flags of the parameter */
-    const Flags_t flags;
+    Flags_t flags;
 
     /** The accepted file extension(s).
      * Leave empty to allow all extensions.
      * Only considered when Flag_RestrictExtension is set.
      */
-    const Extensions_t extensions;
+    Extensions_t extensions;
 
     /** The file or directory path */
     std::filesystem::path value;

--- a/core/include/mmcore/param/FilePathParam.h
+++ b/core/include/mmcore/param/FilePathParam.h
@@ -45,6 +45,8 @@ public:
      * @param flags The flags for the parameter
      * @param exts The required file extensions for the parameter
      */
+    FilePathParam(const std::filesystem::path& initVal, Flags_t flags, const Extensions_t& exts,
+        const std::filesystem::path& project_directory);
     FilePathParam(const std::filesystem::path& initVal, Flags_t flags = Flag_File, const Extensions_t& exts = {});
     FilePathParam(const std::string& initVal, Flags_t flags = Flag_File, const Extensions_t& exts = {});
     FilePathParam(const char* initVal, Flags_t flags = Flag_File, const Extensions_t& exts = {});
@@ -111,6 +113,10 @@ public:
      */
     inline const Extensions_t& GetExtensions() const {
         return this->extensions;
+    }
+
+    inline std::filesystem::path GetProjectDirectory() const {
+        return this->project_directory;
     }
 
     /**

--- a/core/include/mmcore/param/FilePathParam.h
+++ b/core/include/mmcore/param/FilePathParam.h
@@ -92,7 +92,7 @@ public:
      * @return The value of the parameter as string.
      */
     std::string ValueString() const override {
-        return this->Value().generic_u8string();
+        return this->GetRelativePathValueString();
     }
 
     /**
@@ -133,6 +133,23 @@ public:
      */
     std::filesystem::path GetAbsolutePathValue(const std::filesystem::path& p) const;
 
+    /**
+     * Returns the current raw path value, which might be an absolute path in the file system
+     * or a path relative to some project directory
+     */
+    std::filesystem::path GetRelativePathValue() const {
+        return this->value;
+    }
+
+    /**
+     * Returns string of the current raw path value, which might be an absolute path in the file system
+     * or a path relative to some project directory.
+     * This is used by the serialization function of the MegaMolGraph to preserve relative paths of FilePathParams.
+     */
+    std::string GetRelativePathValueString() const {
+        return GetRelativePathValue().generic_u8string();
+    }
+
 private:
     /** The flags of the parameter */
     Flags_t flags;
@@ -148,7 +165,7 @@ private:
 
     /**
      * Absolute path to project directory. If empty, no project path available.
-     * This path is relative per guarantee of the frontend
+     * This path is absolute per guarantee of the frontend
      */
     std::filesystem::path project_directory;
 };

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -10,6 +10,7 @@
 #include "ResourceRequest.h"
 #include "mmcore/AbstractSlot.h"
 #include "mmcore/param/ButtonParam.h"
+#include "mmcore/param/FilePathParam.h"
 #include "mmcore/utility/String.h"
 #include "mmcore/utility/log/Log.h"
 #include "mmcore/view/AbstractView_EventConsumption.h"
@@ -607,6 +608,16 @@ bool megamol::core::MegaMolGraph::add_module(ModuleInstantiationRequest_t const&
     // the current project directory path
     if (m_current_project_path->attributes.has_value()) {
         auto project_directory_path = m_current_project_path->attributes.value().project_directory;
+
+        for (auto child = module_ptr->ChildList_Begin(); child != module_ptr->ChildList_End(); ++child) {
+            auto ps = dynamic_cast<param::ParamSlot*>((*child).get());
+            if (ps != nullptr) {
+                auto p = ps->Param<param::FilePathParam>();
+                if (p != nullptr) {
+                    p->SetProjectDirectory(project_directory_path);
+                }
+            }
+        }
     }
 
     const auto create_module = [module_description, module_ptr](auto& module_lifetime_dependencies) {

--- a/core/src/MegaMolGraph_Convenience.cpp
+++ b/core/src/MegaMolGraph_Convenience.cpp
@@ -74,16 +74,22 @@ std::string megamol::core::MegaMolGraph_Convenience::SerializeCalls() const {
 std::string megamol::core::MegaMolGraph_Convenience::SerializeModuleParameters(std::string const& module_name) const {
     std::string serParams;
 
+    auto parameter_serialization = [](std::string const& name, std::string const& value) {
+        return "mmSetParamValue(\"" + name + "\",[=[" + value + "]=])\n";
+    };
+
     for (auto& paramSlot : get(m_graph_ptr).EnumerateModuleParameterSlots(module_name)) {
-        // it seems serialiing button params is illegal
+        // it seems serializing button params is illegal
         if (auto* p_ptr = paramSlot->template Param<core::param::ButtonParam>()) {
             continue;
         }
+
         auto name = std::string{paramSlot->FullName()};
         // as FullName() prepends :: to module names, normalize multiple leading :: in parameter name path
         name = "::" + name.substr(name.find_first_not_of(':'));
+
         auto value = paramSlot->Parameter()->ValueString();
-        serParams.append("mmSetParamValue(\"" + name + "\",[=[" + value + "]=])\n");
+        serParams.append(parameter_serialization(name, value));
     }
 
     return serParams + '\n';

--- a/core/src/param/FilePathParam.cpp
+++ b/core/src/param/FilePathParam.cpp
@@ -47,7 +47,8 @@ void FilePathParam::SetValue(const std::filesystem::path& v, bool setDirty) {
         std::replace(tmp_val_str.begin(), tmp_val_str.end(), '\\', '/');
         auto new_value = std::filesystem::path(tmp_val_str);
         if (this->value != new_value) {
-            auto error_flags = FilePathParam::ValidatePath(new_value, this->extensions, this->flags);
+            auto absolute_new_value = GetAbsolutePathValue(new_value);
+            auto error_flags = FilePathParam::ValidatePath(absolute_new_value, this->extensions, this->flags);
 
             if (error_flags & Flag_File) {
                 megamol::core::utility::log::Log::DefaultLog.WriteWarn(
@@ -130,4 +131,19 @@ FilePathParam::Flags_t FilePathParam::ValidatePath(const std::filesystem::path& 
             "Filesystem Error: %s [%s, %s, line %d]\n", e.what(), __FILE__, __FUNCTION__, __LINE__);
         return 0;
     }
+}
+
+void FilePathParam::SetProjectDirectory(const std::filesystem::path& p) {
+    assert(p.is_absolute());
+
+    this->project_directory = p;
+}
+
+std::filesystem::path FilePathParam::GetAbsolutePathValue(const std::filesystem::path& p) const {
+    if (p.empty() || p.is_absolute())
+        return p;
+
+    auto concat = this->project_directory / p;
+
+    return concat;
 }

--- a/core/src/param/FilePathParam.cpp
+++ b/core/src/param/FilePathParam.cpp
@@ -10,6 +10,11 @@
 
 using namespace megamol::core::param;
 
+FilePathParam::FilePathParam(const std::filesystem::path& initVal, Flags_t flags, const Extensions_t& exts,
+    const std::filesystem::path& project_directory)
+        : FilePathParam(initVal, flags, exts) {
+    this->SetProjectDirectory(project_directory);
+}
 
 FilePathParam::FilePathParam(const std::filesystem::path& initVal, Flags_t flags, const Extensions_t& exts)
         : AbstractParam()

--- a/core/src/param/FilePathParam.cpp
+++ b/core/src/param/FilePathParam.cpp
@@ -143,7 +143,5 @@ std::filesystem::path FilePathParam::GetAbsolutePathValue(const std::filesystem:
     if (p.empty() || p.is_absolute())
         return p;
 
-    auto concat = this->project_directory / p;
-
-    return concat;
+    return this->project_directory / p;
 }

--- a/core/src/param/FilePathParam.cpp
+++ b/core/src/param/FilePathParam.cpp
@@ -127,25 +127,31 @@ void megamol::core::param::FilePathParam::SetValue(const char* v, bool setDirty)
 }
 
 
-FilePathParam::Flags_t FilePathParam::ValidatePath(const std::filesystem::path& p, const Extensions_t& e, Flags_t f) {
+FilePathParam::Flags_t FilePathParam::ValidatePath(
+    const std::filesystem::path& p, const Extensions_t& e, Flags_t f, const std::filesystem::path& project_dir) {
+
+    std::filesystem::path path = p;
+    if (!project_dir.empty() && project_dir.is_absolute() && p.is_relative()) {
+        path = project_dir / p;
+    }
 
     try {
         FilePathParam::Flags_t retval = 0;
         if ((f & FilePathParam::Flag_Any) != FilePathParam::Flag_Any) {
-            if ((f & FilePathParam::Flag_File) && std::filesystem::is_directory(p)) {
+            if ((f & FilePathParam::Flag_File) && std::filesystem::is_directory(path)) {
                 retval |= FilePathParam::Flag_File;
             }
-            if ((f & FilePathParam::Flag_Directory) && std::filesystem::is_regular_file(p)) {
+            if ((f & FilePathParam::Flag_Directory) && std::filesystem::is_regular_file(path)) {
                 retval |= FilePathParam::Flag_Directory;
             }
         }
-        if (!(f & Internal_NoExistenceCheck) && !std::filesystem::exists(p)) {
+        if (!(f & Internal_NoExistenceCheck) && !std::filesystem::exists(path)) {
             retval |= FilePathParam::Internal_NoExistenceCheck;
         }
         if (f & FilePathParam::Internal_RestrictExtension) {
             bool valid_ext = false;
             for (auto& ext : e) {
-                if (p.extension().generic_u8string() == std::string("." + ext)) {
+                if (path.extension().generic_u8string() == std::string("." + ext)) {
                     valid_ext = true;
                 }
             }

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -48,6 +48,7 @@ std::pair<RuntimeConfig, GlobalValueStore> megamol::frontend::handle_cli_and_con
     RuntimeConfig config;
 
     config.megamol_executable_directory = getExecutableDirectory().u8string();
+    config.megamol_current_working_directory = std::filesystem::current_path().u8string();
 
     // config files are already checked to exist in file system
     config.configuration_files = extract_config_file_paths(argc, argv);

--- a/frontend/resources/include/MegaMolProject.h
+++ b/frontend/resources/include/MegaMolProject.h
@@ -1,0 +1,39 @@
+/*
+ * MegaMolProject.h
+ *
+ * Copyright (C) 2022 by VISUS (Universitaet Stuttgart).
+ * Alle Rechte vorbehalten.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace megamol {
+namespace frontend_resources {
+
+struct MegaMolProject {
+    using path = std::filesystem::path;
+
+    struct ProjectAttributes {
+        // example: C:/megamol/project.lua
+        std::string project_name = ""; // name of project in some way, either "projcet.lua" or "project" or "something"
+        path project_file;             // project.lua
+        path project_directory;        // C:/megamol/
+    };
+
+    std::optional<ProjectAttributes> attributes = std::nullopt;
+
+    void setProjectFile(path const& file) {
+        ProjectAttributes a;
+        a.project_file = file;
+        a.project_directory = path{file}.remove_filename(); // leaves trailing '/'
+        a.project_name = file.filename().stem().string();
+
+        attributes = a;
+    }
+};
+} /* end namespace frontend_resources */
+} /* end namespace megamol */

--- a/frontend/resources/include/MegaMolProject.h
+++ b/frontend/resources/include/MegaMolProject.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -27,6 +28,7 @@ struct MegaMolProject {
     std::optional<ProjectAttributes> attributes = std::nullopt;
 
     void setProjectFile(path const& file) {
+        assert(file.is_absolute());
         ProjectAttributes a;
         a.project_file = file;
         a.project_directory = path{file}.remove_filename(); // leaves trailing '/'

--- a/frontend/resources/include/MegaMolProject.h
+++ b/frontend/resources/include/MegaMolProject.h
@@ -20,7 +20,7 @@ struct MegaMolProject {
     struct ProjectAttributes {
         // example: C:/megamol/project.lua
         std::string project_name = ""; // name of project in some way, either "projcet.lua" or "project" or "something"
-        path project_file;             // project.lua
+        path project_file;             // C:/megamol/project.lua
         path project_directory;        // C:/megamol/
     };
 

--- a/frontend/resources/include/RuntimeConfig.h
+++ b/frontend/resources/include/RuntimeConfig.h
@@ -31,7 +31,8 @@ struct RuntimeConfig {
     std::vector<std::string> configuration_file_contents = {};
     std::vector<StringPair> cli_options_from_configs = {}; // mmSetCliOption - set config/option values accepted in CLI
     std::vector<std::string> configuration_file_contents_as_cli = {};
-    Path megamol_executable_directory = "";      // mmGetMegaMolExecutableDirectory
+    Path megamol_executable_directory = ""; // mmGetMegaMolExecutableDirectory
+    Path megamol_current_working_directory = "";
     Path application_directory = "";             // mmSetAppDir
     std::vector<Path> resource_directories = {}; // mmAddResourceDir
     std::vector<Path> shader_directories = {};   // mmAddShaderDir

--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -1142,8 +1142,8 @@ void megamol::gui::GUIManager::draw_popups() {
         float widget_width = ImGui::CalcItemWidth() - (ImGui::GetFrameHeightWithSpacing() + style.ItemSpacing.x);
         ImGui::PushItemWidth(widget_width);
 
-        this->file_browser.Button_Select(this->gui_state.font_input_string_buffer, {"ttf"},
-            megamol::core::param::FilePathParam::Flag_File_RestrictExtension);
+        this->file_browser.Button_Select(this->gui_state.font_input_string_buffer,
+            FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_RestrictExtension, {"ttf"}});
         ImGui::SameLine();
         ImGui::InputText("Font Filename (.ttf)", &this->gui_state.font_input_string_buffer, ImGuiInputTextFlags_None);
         ImGui::PopItemWidth();
@@ -1263,9 +1263,9 @@ void megamol::gui::GUIManager::draw_popups() {
         // Default for saving gui state and parameter values
         bool save_all_param_values = true;
         bool save_gui_state = false;
-        if (this->file_browser.PopUp_Save("Save Running Project", filename, this->gui_state.open_popup_save, {"lua"},
-                megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,
-                save_all_param_values)) {
+        if (this->file_browser.PopUp_Save("Save Running Project", filename, this->gui_state.open_popup_save,
+                FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, {"lua"}},
+                save_gui_state, save_all_param_values)) {
             std::string state_str;
             if (save_gui_state) {
                 state_str = this->project_to_lua_string(true);
@@ -1281,8 +1281,8 @@ void megamol::gui::GUIManager::draw_popups() {
     // Load project pop-up
     std::string filename;
     this->gui_state.open_popup_load |= this->gui_hotkeys[HOTKEY_GUI_LOAD_PROJECT].is_pressed;
-    if (this->file_browser.PopUp_Load("Load Project", filename, this->gui_state.open_popup_load, {"lua", "png"},
-            megamol::core::param::FilePathParam::Flag_File_RestrictExtension)) {
+    if (this->file_browser.PopUp_Load("Load Project", filename, this->gui_state.open_popup_load,
+            FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_RestrictExtension, {"lua", "png"}})) {
         // Redirect project loading request to Lua_Wrapper_service and load new project to megamol graph
         /// GUI graph and GUI state are updated at next synchronization
         this->gui_state.request_load_projet_file = filename;
@@ -1292,8 +1292,9 @@ void megamol::gui::GUIManager::draw_popups() {
     // File name for screenshot pop-up
     auto dummy = false;
     if (this->file_browser.PopUp_Save("File Name for Screenshot", this->gui_state.screenshot_filepath,
-            this->gui_state.open_popup_screenshot, {"png"},
-            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, dummy, dummy)) {
+            this->gui_state.open_popup_screenshot,
+            FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, {"png"}}, dummy,
+            dummy)) {
         this->gui_state.screenshot_filepath_id = 0;
     }
 

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -1870,9 +1870,9 @@ bool megamol::gui::GraphCollection::save_graph_dialog(ImGuiID graph_uid, bool& o
     // Default for saving gui state and parameter values
     bool save_all_param_values = true;
     bool save_gui_state = false;
-    if (this->gui_file_browser.PopUp_Save("Save Configurator Project", project_filename, open_dialog, {"lua"},
-            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,
-            save_all_param_values)) {
+    if (this->gui_file_browser.PopUp_Save("Save Configurator Project", project_filename, open_dialog,
+            FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, {"lua"}},
+            save_gui_state, save_all_param_values)) {
 
         std::string gui_state;
         if (save_gui_state) {

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -1448,10 +1448,7 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
         ImGuiStyle& style = ImGui::GetStyle();
 
         auto last_val = val;
-        auto file_flags = store.first;
-        auto file_extensions = store.second;
-        bool button_edit = this->gui_file_browser.Button_Select(
-            std::get<std::string>(this->gui_widget_value), file_extensions, file_flags);
+        bool button_edit = this->gui_file_browser.Button_Select(std::get<std::string>(this->gui_widget_value), store);
         ImGui::SameLine();
 
         auto item_width = ImGui::CalcItemWidth();

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -37,6 +37,7 @@ typedef std::map<int, std::string> EnumStorage_t;
 struct FilePathStorage_t {
     megamol::core::param::FilePathParam::Flags_t flags = 0;
     megamol::core::param::FilePathParam::Extensions_t extensions = {};
+    std::filesystem::path project_directory = "";
 };
 
 

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -33,8 +33,11 @@ typedef std::shared_ptr<Module> ModulePtr_t;
 // Types
 typedef std::vector<Parameter> ParamVector_t;
 typedef std::map<int, std::string> EnumStorage_t;
-typedef std::pair<megamol::core::param::FilePathParam::Flags_t, megamol::core::param::FilePathParam::Extensions_t>
-    FilePathStorage_t;
+
+struct FilePathStorage_t {
+    megamol::core::param::FilePathParam::Flags_t flags = 0;
+    megamol::core::param::FilePathParam::Extensions_t extensions = {};
+};
 
 
 /** ************************************************************************

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
@@ -461,6 +461,7 @@ void megamol::gui::FileBrowserWidget::validate_file(FileBrowserWidget::DialogMod
 
     auto const& flags = store.flags;
     auto const& extensions = store.extensions;
+    auto const& project_dir = store.project_directory;
 
     try {
         this->file_errors.clear();
@@ -476,7 +477,7 @@ void megamol::gui::FileBrowserWidget::validate_file(FileBrowserWidget::DialogMod
                 tmp_filepath = dir;
             }
         }
-        auto error_flags = FilePathParam::ValidatePath(tmp_filepath, extensions, flags);
+        auto error_flags = FilePathParam::ValidatePath(tmp_filepath, extensions, flags, project_dir);
         if (error_flags != 0) {
             this->valid_file = false;
         }

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.h
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.h
@@ -10,7 +10,6 @@
 
 #include "HoverToolTip.h"
 #include "StringSearchWidget.h"
-#include "mmcore/param/FilePathParam.h"
 
 
 using namespace megamol::core::param;
@@ -18,6 +17,12 @@ using namespace megamol::core::param;
 
 namespace megamol::gui {
 
+// forward declare the FilePathStorage_t type here
+// we cant include gui/src/grpah/Parameter.h because
+// it includes this header file itself, leading to endless recursive problems
+// instead we include the Parameter.h in the FileBrowserWidget.cpp file
+// since we actuall yuse the FilePathStorage_t implementation there
+struct FilePathStorage_t;
 
 /** ************************************************************************
  * File browser widget
@@ -40,20 +45,19 @@ public:
      * @return True on success, false otherwise.
      */
     bool PopUp_Save(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags, bool& inout_save_gui_state,
-        bool& inout_save_all_param_values) {
-        return this->popup(DIALOGMODE_SAVE, label, inout_filename, inout_open_popup, extensions, flags,
-            inout_save_gui_state, inout_save_all_param_values);
+        const FilePathStorage_t& store, bool& inout_save_gui_state, bool& inout_save_all_param_values) {
+        return this->popup(DIALOGMODE_SAVE, label, inout_filename, inout_open_popup, store, inout_save_gui_state,
+            inout_save_all_param_values);
     }
-    bool PopUp_Load(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags) {
+    bool PopUp_Load(
+        const std::string& label, std::string& inout_filename, bool& inout_open_popup, const FilePathStorage_t& store) {
         bool dummy = false;
-        return this->popup(DIALOGMODE_LOAD, label, inout_filename, inout_open_popup, extensions, flags, dummy, dummy);
+        return this->popup(DIALOGMODE_LOAD, label, inout_filename, inout_open_popup, store, dummy, dummy);
     }
-    bool PopUp_Select(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags) {
+    bool PopUp_Select(
+        const std::string& label, std::string& inout_filename, bool& inout_open_popup, const FilePathStorage_t& store) {
         bool dummy = false;
-        return this->popup(DIALOGMODE_SELECT, label, inout_filename, inout_open_popup, extensions, flags, dummy, dummy);
+        return this->popup(DIALOGMODE_SELECT, label, inout_filename, inout_open_popup, store, dummy, dummy);
     }
 
     /**
@@ -67,8 +71,7 @@ public:
      *
      * @return True on success, false otherwise.
      */
-    bool Button_Select(
-        std::string& inout_filename, const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags);
+    bool Button_Select(std::string& inout_filename, const FilePathStorage_t& store);
 
 private:
     typedef std::pair<std::filesystem::path, bool> ChildData_t;
@@ -100,14 +103,13 @@ private:
     // FUNCTIONS --------------------------------------------------------------
 
     bool popup(DialogMode mode, const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags, bool& inout_save_gui_state,
-        bool& inout_save_all_param_values);
+        const FilePathStorage_t& store, bool& inout_save_gui_state, bool& inout_save_all_param_values);
 
     bool validate_split_path(
-        const std::string& in_path, FilePathParam::Flags_t flags, std::string& out_dir, std::string& out_file) const;
-    void validate_directory(FilePathParam::Flags_t flags, const std::string& directory_str);
-    void validate_file(DialogMode mode, const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags,
-        const std::string& directory_str, const std::string& file_str);
+        const std::string& in_path, const FilePathStorage_t& store, std::string& out_dir, std::string& out_file) const;
+    void validate_directory(const FilePathStorage_t& store, const std::string& directory_str);
+    void validate_file(
+        DialogMode mode, const FilePathStorage_t& store, const std::string& directory_str, const std::string& file_str);
 
     std::string get_parent_path(const std::string& dir) const;
     std::string get_absolute_path(const std::string& dir) const;

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -175,8 +175,8 @@ void megamol::gui::Configurator::PopUps() {
     if (auto graph_ptr = this->graph_collection.GetGraph(this->graph_state.graph_selected_uid)) {
         project_filename = graph_ptr->GetFilename();
     }
-    if (this->file_browser.PopUp_Load("Load Project", project_filename, this->open_popup_load, {"lua"},
-            megamol::core::param::FilePathParam::Flag_File_RestrictExtension)) {
+    if (this->file_browser.PopUp_Load("Load Project", project_filename, this->open_popup_load,
+            FilePathStorage_t{megamol::core::param::FilePathParam::Flag_File_RestrictExtension, {"lua"}})) {
 
         popup_failed = !this->graph_collection.LoadOrAddProjectFromFile(this->add_project_graph_uid, project_filename);
         this->add_project_graph_uid = GUI_INVALID_ID;

--- a/frontend/services/project_loader/ProjectLoader_Service.cpp
+++ b/frontend/services/project_loader/ProjectLoader_Service.cpp
@@ -49,7 +49,10 @@ bool ProjectLoader_Service::init(const Config& config) {
 
     m_loader.load_filename = [&](std::filesystem::path const& filename) { return this->load_file(filename); };
 
-    this->m_providedResourceReferences = {{"ProjectLoader", m_loader}};
+    this->m_providedResourceReferences = {
+        {"ProjectLoader", m_loader},
+        {"MegaMolProject", m_current_project},
+    };
 
     this->m_requestedResourcesNames = {"ExecuteLuaScript", "SetScriptPath", "optional<WindowEvents>"};
 

--- a/frontend/services/project_loader/ProjectLoader_Service.cpp
+++ b/frontend/services/project_loader/ProjectLoader_Service.cpp
@@ -116,6 +116,13 @@ bool ProjectLoader_Service::load_file(std::filesystem::path const& filename) con
     const SetScriptPath& set_script_path = m_requestedResourceReferences[1].getResource<SetScriptPath>();
 
     set_script_path(filename.generic_u8string());
+    // TODO: we have a timing issue with the script path / project path here
+    // the lua script path resource gets updated by the lua service at the beginning of each frame
+    // but here the project service needs to set the project file/directory right before the lua code gets executed,
+    // such that the project path is known to the megamol graph when constructing modules with file path parameters
+    // thus we sed the current project path resource, which the megamol graph can look into
+    // somewhat of a very thight coupling here to pass information into the lua interpreter but currently no other solution...
+    const_cast<ProjectLoader_Service*>(this)->m_current_project.setProjectFile(filename);
 
     auto result = execute_lua(script);
     bool script_ok = std::get<0>(result);

--- a/frontend/services/project_loader/ProjectLoader_Service.hpp
+++ b/frontend/services/project_loader/ProjectLoader_Service.hpp
@@ -9,6 +9,7 @@
 
 #include "AbstractFrontendService.hpp"
 
+#include "MegaMolProject.h"
 #include "ProjectLoader.h"
 
 namespace megamol::frontend {
@@ -51,6 +52,8 @@ private:
     std::vector<FrontendResource> m_providedResourceReferences;
     std::vector<std::string> m_requestedResourcesNames;
     std::vector<FrontendResource> m_requestedResourceReferences;
+
+    megamol::frontend_resources::MegaMolProject m_current_project;
 
     bool m_digestion_recursion = false;
 };


### PR DESCRIPTION
Uses current lua script file path to determine a project directory, allowing FilePath Parameters to load files relative to that directory. The project directory is injected into file parameters of newly created graph modules.

## TODO
- [X] Should File Path Parameters automatically check for files beeing inside the project dir, and use relative paths for those?
* What happens when saving and loading the project again?
   - [X] MegaMolGraph Serialization preserves relative file path (uses `param->ValueString()`)
   - [x] GUI Serialization preserves relative file path 
* ~~What happens when stacking project files?~~ FilePathParams remember their respective project file
* ~~Optional Lua Callback Arguments (optional project name argument)~~
* ~~Do we really want to clear() the graph?~~
- ~~`vislib::sys::File` and `vislib::sys::File::Exists()` must die~~ Only FilePathParam knows about project, re-routing all file loading through project dir too intrusive
- ~~Screenshots and other outputs go to project dir automatically?~~ User configures screenshot output 
- [ ] Unify UX: Configurator project open, project add, file load, file drop
- [ ] Adjust example projects for new file path structure

## Test Instructions
The implementation works for all code paths going though the Project Loader Service, e.g. Drag & Drop of files into the window and "Load Project" in the GUI.
For example, modify the `infovis.lua` example to access the example data set relative to the examples directory.
```lua
-- snip --

-- old: mmSetParamValue("::CSVDataSource_1::filename",[=[../examples/sampledata/iris.csv]=])
mmSetParamValue("::CSVDataSource_1::filename",[=[sampledata/iris.csv]=])
```

![grafik](https://user-images.githubusercontent.com/44215465/188674081-edb842fb-28a7-4a52-9dae-c153a5829c01.png)
