### PR TITLE
Added missing STL header includes

### DIFF
--- a/core/include/mmcore/MultiPerformanceHistory.h
+++ b/core/include/mmcore/MultiPerformanceHistory.h
@@ -3,10 +3,10 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <list>
 #include <string>
 #include <vector>
-#include <limits>
 
 namespace megamol {
 namespace core {

--- a/core/include/mmcore/MultiPerformanceHistory.h
+++ b/core/include/mmcore/MultiPerformanceHistory.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <string>
 #include <vector>
+#include <limits>
 
 namespace megamol {
 namespace core {

--- a/core/include/mmcore/utility/log/Log.h
+++ b/core/include/mmcore/utility/log/Log.h
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <memory>
 
 // Enclose title of log message between start and and tag to get it pushed in GUI popup
 #define LOGMESSAGE_GUI_POPUP_START_TAG "<<<<<"

--- a/core/include/mmcore/utility/log/Log.h
+++ b/core/include/mmcore/utility/log/Log.h
@@ -13,9 +13,9 @@
 #include <cstdio>
 #include <ctime>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <thread>
-#include <memory>
 
 // Enclose title of log message between start and and tag to get it pushed in GUI popup
 #define LOGMESSAGE_GUI_POPUP_START_TAG "<<<<<"


### PR DESCRIPTION
Without these includes, megamol failes to compile with GCC 11.2.0 (tested on Arch Linux 5.16.4-arch1-1).

## Summary of Changes
`#include <limits>` for std::numeric_limits in MultiPerformanceHistory.h
`#include <memory>` for std::shared_ptr in Log.h
