### PR TITLE
Remote Service/MPI: dont assume MPI_Comm type

### DIFF
--- a/frontend/resources/include/MPI_Context.h
+++ b/frontend/resources/include/MPI_Context.h
@@ -7,11 +7,18 @@
 
 #pragma once
 
+#ifdef WITH_MPI
+#include <mpi.h>
+#else
+using MPI_Comm = int;
+#define MPI_COMM_NULL 0x04000000
+#endif
+
 namespace megamol {
 namespace frontend_resources {
 
 struct MPI_Context {
-    int mpi_comm = 0; // MPI_Comm
+    MPI_Comm mpi_comm = MPI_COMM_NULL;
     int mpi_comm_size = -1;
     int rank = 0;            // rank of this process
     int broadcast_rank = -1; // rank of process that is supposed to do MPI broadcasts

--- a/frontend/services/remote_service/MpiNode.hpp
+++ b/frontend/services/remote_service/MpiNode.hpp
@@ -11,12 +11,7 @@
 
 #include "comm/DistributedProto.h"
 
-#ifdef WITH_MPI
-#include <mpi.h>
-#else
-using MPI_Comm = int;
-#define MPI_COMM_NULL 0x04000000
-#endif
+#include "MPI_Context.h"
 
 struct megamol::frontend::Remote_Service::MpiNode {
     ~MpiNode();
@@ -24,19 +19,15 @@ struct megamol::frontend::Remote_Service::MpiNode {
     bool init(int broadcast_rank);
     bool close();
 
-    bool i_do_broadcast() const {
-        return rank_ == broadcast_rank_;
-    }
-
     // if broadcast rank: broadcast message to all others
     // if other rank: receive message from broadcast
     bool get_broadcast_message(megamol::remote::Message_t& message);
 
+    bool i_do_broadcast() {
+        return mpi_comm.do_i_broadcast();
+    }
+
     void sync_barrier();
 
-    // Remote Service may acess these fields read only
-    MPI_Comm comm_ = MPI_COMM_NULL;
-    int rank_ = -1;
-    int comm_size_ = 0;
-    int broadcast_rank_ = -2;
+    frontend_resources::MPI_Context mpi_comm;
 };

--- a/frontend/services/remote_service/Remote_Service.cpp
+++ b/frontend/services/remote_service/Remote_Service.cpp
@@ -152,17 +152,16 @@ bool Remote_Service::init(const Config& config) {
             return false;
         }
 
-        if (m_mpi.i_do_broadcast()) {
+        if (m_mpi.mpi_comm.do_i_broadcast()) {
             if (!m_render.start_receiver(config.rendernode_zmq_source_address)) {
                 log_error("could not start RenderNode receiver");
                 return false;
             }
         }
 
-        m_mpi_context.mpi_comm = m_mpi.comm_;
-        m_mpi_context.mpi_comm_size = m_mpi.comm_size_;
-        m_mpi_context.rank = m_mpi.rank_;
-        m_mpi_context.broadcast_rank = m_mpi.broadcast_rank_;
+        // copy MPI context/comm info to global resource
+        // here we hope the MPI_Comm struct defined in mpi.h is ok with beeing copied
+        m_mpi_context = m_mpi.mpi_comm;
 
         this->m_providedResourceReferences.push_back({"MPI_Context", m_mpi_context});
     }


### PR DESCRIPTION
Uses `MPI_Comm` type shipped with `mpi.h` instead of assuming it to be `int`.
