### PR TITLE
PCP continuous draw mode

### DIFF
--- a/plugins/infovis_gl/shaders/infovis_gl/pc_common/pc_fragment_count_uniforms.inc.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_common/pc_fragment_count_uniforms.inc.glsl
@@ -1,4 +1,4 @@
-layout(binding = 0) uniform sampler1D transferFunction;
+layout(binding = 0) uniform sampler1D tfTexture;
 layout(binding = 1) uniform sampler2D fragmentCount;
 
 uniform vec2 scaling = vec2(1.0);

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_common/pc_fragment_count_uniforms.inc.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_common/pc_fragment_count_uniforms.inc.glsl
@@ -1,4 +1,3 @@
-layout(binding = 0) uniform sampler1D tfTexture;
 layout(binding = 1) uniform sampler2D fragmentCount;
 
 uniform vec2 scaling = vec2(1.0);

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.comp.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.comp.glsl
@@ -18,7 +18,7 @@ void main()
 
     uint invocationID = getInvocationID();
     fragmentMinMax[invocationID] = uvec2(4294967295u, 0u);
-
+    
     memoryBarrierBuffer();
     uvec2 texCoord = gl_GlobalInvocationID.xy;
 
@@ -42,28 +42,12 @@ void main()
         texCoord.y += fragmentCountStepSize.y;
     }
 
+    // Technically, it is no longer need to store the value for each innvocation
+    // as the min/max is currently gather from local variable using atomic operations
+    // (see below)
+    // I will keep this for now in case we want to go back to a different gathering method
     fragmentMinMax[invocationID] = uvec2(thisMin, thisMax);
 
-    //  barrier();
-    memoryBarrierBuffer();
-
-    if (invocationID == 0)
-    {
-        for (uint index = 1; index < invocationCount; ++index)
-        {
-            uvec2 thatMinMax = fragmentMinMax[index];
-
-            if (thatMinMax.x < thisMin)
-            {
-                thisMin = thatMinMax.x;
-            }
-
-            if (thatMinMax.y > thisMax)
-            {
-                thisMax = thatMinMax.y;
-            }
-        }
-
-        fragmentMinMax[0] = uvec2(thisMin, thisMax);
-    }
+    atomicMin(fragmentMinMax[0].x,thisMin);
+    atomicMax(fragmentMinMax[0].y,thisMax);
 }

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.comp.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.comp.glsl
@@ -17,8 +17,7 @@ void main()
     }
 
     uint invocationID = getInvocationID();
-    fragmentMinMax[invocationID] = uvec2(4294967295u, 0u);
-    
+
     memoryBarrierBuffer();
     uvec2 texCoord = gl_GlobalInvocationID.xy;
 
@@ -41,12 +40,6 @@ void main()
         }
         texCoord.y += fragmentCountStepSize.y;
     }
-
-    // Technically, it is no longer need to store the value for each innvocation
-    // as the min/max is currently gather from local variable using atomic operations
-    // (see below)
-    // I will keep this for now in case we want to go back to a different gathering method
-    fragmentMinMax[invocationID] = uvec2(thisMin, thisMax);
 
     atomicMin(fragmentMinMax[0].x,thisMin);
     atomicMax(fragmentMinMax[0].y,thisMax);

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
@@ -1,5 +1,8 @@
 #version 430
 
+#include "core/tflookup.inc.glsl"
+#include "core/tfconvenience.inc.glsl"
+
 #include "pc_common/pc_fragment_count_buffers.inc.glsl"
 #include "pc_common/pc_fragment_count_uniforms.inc.glsl"
 
@@ -19,7 +22,7 @@ void main()
             value = sqrt(value);
         }
         value = clamp(value, 0.0, 1.0);
-        fragColor = texture(tfTexture, value);
+        fragColor = tflookup(value);
     } else {
         discard;
     }

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
@@ -13,14 +13,14 @@ void main()
 
     uvec2 globalMinMax = fragmentMinMax[0].xy;
 
-    if (frags.r >= 0) {
+    if (frags.r > 0) {
         float value = (frags.r - globalMinMax[0]) / (globalMinMax[1] - globalMinMax[0]);
         if (sqrtDensity == 1) {
             value = sqrt(value);
         }
         value = clamp(value, 0.0, 1.0);
-        fragColor = texture(transferFunction, value);
+        fragColor = texture(tfTexture, value);
     } else {
-        fragColor = clearColor;
+        discard;
     }
 }

--- a/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/pc_fragment_count.frag.glsl
@@ -16,7 +16,10 @@ void main()
 
     uvec2 globalMinMax = fragmentMinMax[0].xy;
 
-    if (frags.r > 0) {
+    if (frags.g > 0) {
+        fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+    else if (frags.r > 0) {
         float value = (frags.r - globalMinMax[0]) / (globalMinMax[1] - globalMinMax[0]);
         if (sqrtDensity == 1) {
             value = sqrt(value);

--- a/plugins/infovis_gl/shaders/infovis_gl/splom_point.frag.glsl
+++ b/plugins/infovis_gl/shaders/infovis_gl/splom_point.frag.glsl
@@ -24,7 +24,7 @@ float gauss2(vec2 p) {
     const vec2 x = p * 6.0;
     const float g = exp(-dot(x, x) * 0.5);
     const float gAtPlusMinus3 = exp(-4.5);
-    return (g - gAtPlusMinus3) / (1.0 - gAtPlusMinus3);
+    return max((g - gAtPlusMinus3) / (1.0 - gAtPlusMinus3), 0.0f);
 }
 
 void main(void) {
@@ -39,6 +39,10 @@ void main(void) {
         break;
     default:
         density = 0.0;
+    }
+
+    if (density <= 0.0f) {
+        discard;
     }
 
     const float attenuation = vsPixelKernelSize - vsKernelSize;

--- a/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
@@ -920,7 +920,17 @@ void ParallelCoordinatesRenderer2D::doFragmentCount(void) {
 
     glUseProgram(0);
 
-    // todo read back minmax and check for plausibility!
+    // read back minmax and check for plausibility!
+    // I will keep this around for future debugging/updates to min/max computation
+    //std::vector<uint32_t> storage(2 * invocationCount); // n is the size
+    //glGetNamedBufferSubData(counterBuffer, 0, 2 * invocationCount * sizeof(uint32_t), storage.data());
+    //for (size_t i = 0; i < storage.size() / 2; ++i) {
+    //    megamol::core::utility::log::Log::DefaultLog.WriteInfo(
+    //        "ParallelCoordinateRenderer2D cell %lu min/max: %u / %u", i, storage[i * 2], storage[i * 2 + 1]);
+    //}
+    
+
+
     debugPop();
 }
 

--- a/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
@@ -928,8 +928,6 @@ void ParallelCoordinatesRenderer2D::doFragmentCount(void) {
     //    megamol::core::utility::log::Log::DefaultLog.WriteInfo(
     //        "ParallelCoordinateRenderer2D cell %lu min/max: %u / %u", i, storage[i * 2], storage[i * 2 + 1]);
     //}
-    
-
 
     debugPop();
 }

--- a/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
@@ -974,7 +974,6 @@ void ParallelCoordinatesRenderer2D::drawParcos(glm::ivec2 const& viewRes) {
     ::glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
     const float red[] = {1.0f, 0.0f, 0.0f, 1.0};
-    const float moreRed[] = {10.0f, 0.0f, 0.0f, 1.0};
 
     auto drawmode = this->drawModeSlot.Param<core::param::EnumParam>()->Value();
 
@@ -1001,7 +1000,7 @@ void ParallelCoordinatesRenderer2D::drawParcos(glm::ivec2 const& viewRes) {
             glEnable(GL_BLEND);
             glBlendFunc(GL_ONE, GL_ONE);
             glBlendEquation(GL_FUNC_ADD);
-            this->drawDiscrete(red, moreRed, 0.0f, viewRes);
+            this->drawDiscrete(red, red, 0.0f, viewRes);
             densityFBO.Disable();
 
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ParallelCoordinatesRenderer2D.cpp
@@ -974,6 +974,7 @@ void ParallelCoordinatesRenderer2D::drawParcos(glm::ivec2 const& viewRes) {
     ::glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
     const float red[] = {1.0f, 0.0f, 0.0f, 1.0};
+    const float red_green[] = {1.0f, 1.0f, 0.0f, 1.0};
 
     auto drawmode = this->drawModeSlot.Param<core::param::EnumParam>()->Value();
 
@@ -988,7 +989,7 @@ void ParallelCoordinatesRenderer2D::drawParcos(glm::ivec2 const& viewRes) {
         if (!this->densityFBO.IsValid() || this->densityFBO.GetWidth() != fbo->getWidth() ||
             this->densityFBO.GetHeight() != fbo->getHeight()) {
             densityFBO.Release();
-            ok = densityFBO.Create(fbo->getWidth(), fbo->getHeight(), GL_R32F, GL_RED, GL_FLOAT);
+            ok = densityFBO.Create(fbo->getWidth(), fbo->getHeight(), GL_RG32F, GL_RG, GL_FLOAT);
             makeDebugLabel(GL_TEXTURE, densityFBO.GetColourTextureID(), "densityFBO");
         }
         if (ok) {
@@ -1000,7 +1001,7 @@ void ParallelCoordinatesRenderer2D::drawParcos(glm::ivec2 const& viewRes) {
             glEnable(GL_BLEND);
             glBlendFunc(GL_ONE, GL_ONE);
             glBlendEquation(GL_FUNC_ADD);
-            this->drawDiscrete(red, red, 0.0f, viewRes);
+            this->drawDiscrete(red, red_green, 0.0f, viewRes);
             densityFBO.Disable();
 
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/plugins/infovis_gl/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ScatterplotMatrixRenderer2D.cpp
@@ -1277,7 +1277,7 @@ void ScatterplotMatrixRenderer2D::bindAndClearScreen() {
     glBlendEquation(GL_FUNC_ADD);
     switch (this->valueMappingParam.Param<core::param::EnumParam>()->Value()) {
     case VALUE_MAPPING_KERNEL_BLEND:
-        // Assuming the View's background color is still set as clear color.
+        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
         glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
         break;
     case VALUE_MAPPING_KERNEL_DENSITY:


### PR DESCRIPTION
Fix some of the more obvious issues with PCP's continuous draw mode, including transfer function texture binding and background (color) handling.

Remaining issues:
- [x] PCP flickers in cont. mode (tested with infovis example and Vega8 GPU). Fragment counting in compute shader might not be correct/stable? => Fixed by using atomic operations. Original gathering of min/max value by compute group 0 would sometimes read (invalid?) high value from somewhere unknown
