### PR TITLE
Transparent UI

### DIFF
--- a/frontend/resources/include/EntryPoint.h
+++ b/frontend/resources/include/EntryPoint.h
@@ -38,6 +38,7 @@ struct EntryPoint {
 
     EntryPointExecutionCallback execute;
     ImageWrapper execution_result_image;
+    int priority = 0; // entry points with smaller priority get presented first
 };
 
 } /* end namespace frontend_resources */

--- a/frontend/resources/include/ImagePresentationEntryPoints.h
+++ b/frontend/resources/include/ImagePresentationEntryPoints.h
@@ -29,6 +29,7 @@ using EntryPointRenderFunctions = std::tuple<
 // using the ImagePresentationEntryPoints resource participants (services) may add/remove entry points to the image presentation
 struct ImagePresentationEntryPoints {
     std::function<bool(std::string const&, EntryPointRenderFunctions const&)> add_entry_point;
+    std::function<bool(std::string const&, const int)> set_entry_point_priority;
     std::function<bool(std::string const&)> remove_entry_point;
     std::function<bool(std::string const&, std::string const&)> rename_entry_point;
     std::function<void()> clear_entry_points;

--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -97,6 +97,7 @@ void megamol::gui::GUIManager::init_state() {
     this->gui_state.stat_averaged_ms = 0.0f;
     this->gui_state.stat_frame_count = 0;
     this->gui_state.load_docking_preset = true;
+    this->gui_state.window_alpha = 1.0f;
 }
 
 
@@ -206,6 +207,9 @@ bool GUIManager::PreDraw(glm::vec2 framebuffer_size, glm::vec2 window_size, doub
         default:
             break;
         }
+        style.Colors[ImGuiCol_WindowBg].w = this->gui_state.window_alpha;
+        style.Colors[ImGuiCol_ChildBg].w = this->gui_state.window_alpha;
+
         // Set tesselation error: Smaller value => better tesselation of circles and round corners.
         style.CircleTessellationMaxError = 0.3f;
         // Scale all ImGui style options with current scaling factor
@@ -961,6 +965,20 @@ void GUIManager::draw_menu() {
             this->gui_state.load_docking_preset = true;
         }
 #endif
+
+        ImGui::Separator();
+
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Transparency");
+        this->tooltip.Marker("Alpha value of window background");
+        ImGui::SameLine();
+        if (ImGui::SliderFloat("###window_transparency", &this->gui_state.window_alpha, 0.0f, 1.0f, "%.2f")) {
+            ImGuiStyle& style = ImGui::GetStyle();
+            style.Colors[ImGuiCol_WindowBg].w = this->gui_state.window_alpha;
+            style.Colors[ImGuiCol_ChildBg].w = this->gui_state.window_alpha;
+            ;
+        }
+
         ImGui::EndMenu();
     }
     ImGui::Separator();

--- a/frontend/services/gui/src/GUIManager.h
+++ b/frontend/services/gui/src/GUIManager.h
@@ -317,6 +317,7 @@ private:
         float stat_averaged_ms;               // current average fps value
         size_t stat_frame_count;              // current fame count
         bool load_docking_preset;             // Flag indicating docking preset loading
+        float window_alpha;                   // Global transparency value for window background
     };
 
     // VARIABLES --------------------------------------------------------------

--- a/frontend/services/gui/src/GUI_Service.cpp
+++ b/frontend/services/gui/src/GUI_Service.cpp
@@ -353,9 +353,12 @@ void GUI_Service::setRequestedResources(std::vector<FrontendResource> resources)
     auto& image_presentation = const_cast<megamol::frontend_resources::ImagePresentationEntryPoints&>(
         this->m_requestedResourceReferences[13]
             .getResource<megamol::frontend_resources::ImagePresentationEntryPoints>());
+    const std::string gui_entry_point_name = "GUI_Service";
     bool view_presentation_ok = image_presentation.add_entry_point(
-        "GUI_Service", {static_cast<void*>(this->m_gui.get()), std::function{gui_rendering_execution},
-                           std::function{get_gui_runtime_resources_requests}});
+        gui_entry_point_name, {static_cast<void*>(this->m_gui.get()), std::function{gui_rendering_execution},
+                                  std::function{get_gui_runtime_resources_requests}});
+    view_presentation_ok &= image_presentation.set_entry_point_priority(
+        gui_entry_point_name, 100); // render after views (default priority is 0)
     if (!view_presentation_ok) {
         megamol::core::utility::log::Log::DefaultLog.WriteInfo(
             "GUI_Service: error adding graph entry point ... image presentation service rejected GUI Service.");

--- a/frontend/services/gui/src/windows/WindowCollection.cpp
+++ b/frontend/services/gui/src/windows/WindowCollection.cpp
@@ -78,7 +78,6 @@ void WindowCollection::Draw(bool menu_visible) {
         if (wc.Config().show) {
 
             // Draw Window ----------------------------------------------------
-            ImGui::SetNextWindowBgAlpha(1.0f);
             ImGui::SetNextWindowCollapsed(wc.Config().collapsed, ImGuiCond_Always);
 
             // Begin Window

--- a/frontend/services/image_presentation/ImagePresentation_Service.hpp
+++ b/frontend/services/image_presentation/ImagePresentation_Service.hpp
@@ -102,6 +102,7 @@ private:
     std::list<EntryPoint> m_entry_points;
 
     bool add_entry_point(std::string const& name, EntryPointRenderFunctions const& entry_point);
+    bool set_entry_point_priority(std::string const& name, const int priority);
     bool remove_entry_point(std::string const& name);
     bool rename_entry_point(std::string const& oldName, std::string const& newName);
     bool clear_entry_points();

--- a/frontend/services/image_presentation/gl/ImagePresentation_Sinks.cpp
+++ b/frontend/services/image_presentation/gl/ImagePresentation_Sinks.cpp
@@ -86,7 +86,6 @@ void glfw_window_blit::blit_texture(
                                    "layout(location = 0) out vec4 outFragColor; \n "
                                    "void main() { \n "
                                    "    vec4 color = texture(col_tex, uv_coord).rgba; \n "
-                                   "    if (color.a == 0.0) discard; \n "
                                    "    outFragColor = color; \n "
                                    "} ";
 
@@ -112,6 +111,7 @@ void glfw_window_blit::blit_texture(
 
     glViewport(0, 0, fbo_width, fbo_height);
     glEnable(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     blit_shader->use();
     glActiveTexture(GL_TEXTURE0);
@@ -120,6 +120,7 @@ void glfw_window_blit::blit_texture(
     glDrawArrays(GL_TRIANGLES, 0, 6);
     glUseProgram(0);
     glDisable(GL_BLEND);
+    glEnable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, 0);
     /**/


### PR DESCRIPTION
Makes ImGUI windows transparent so that you can see the view output, e.g. when you change something in the configurator.

![grafik](https://user-images.githubusercontent.com/44215465/155572448-719b8dbd-c6d7-4735-aec9-bb97afcaaa05.png)
