### PR TITLE
Make SplitView based on integer values

### DIFF
--- a/core_gl/include/mmcore_gl/view/SplitViewGL.h
+++ b/core_gl/include/mmcore_gl/view/SplitViewGL.h
@@ -152,7 +152,7 @@ private:
      * @return The renderer 1 call
      */
     inline CallRenderViewGL* render1() const {
-        return this->_render1Slot.CallAs<CallRenderViewGL>();
+        return _render1Slot.CallAs<CallRenderViewGL>();
     }
 
     /**
@@ -161,17 +161,17 @@ private:
      * @return The renderer 2 call
      */
     inline CallRenderViewGL* render2() const {
-        return this->_render2Slot.CallAs<CallRenderViewGL>();
+        return _render2Slot.CallAs<CallRenderViewGL>();
     }
 
     /**
      * Returns the focused (keyboard input) renderer.
      */
     inline CallRenderViewGL* renderFocused() const {
-        if (this->_focus == 1) {
-            return this->render1();
-        } else if (this->_focus == 2) {
-            return this->render2();
+        if (_focus == 1) {
+            return render1();
+        } else if (_focus == 2) {
+            return render2();
         } else {
             return nullptr;
         }
@@ -181,11 +181,11 @@ private:
      * Returns the hovered (mouse input) renderer.
      */
     inline CallRenderViewGL* renderHovered() const {
-        auto mousePos = vislib::math::Point<int, 2>(static_cast<int>(this->_mouseX), static_cast<int>(this->_mouseY));
-        if (this->_clientArea1.Contains(mousePos)) {
-            return this->render1();
-        } else if (this->_clientArea2.Contains(mousePos)) {
-            return this->render2();
+        auto mousePos = vislib::math::Point<int, 2>(static_cast<int>(_mouseX), static_cast<int>(_mouseY));
+        if (_clientArea1.Contains(mousePos)) {
+            return render1();
+        } else if (_clientArea2.Contains(mousePos)) {
+            return render2();
         } else {
             return nullptr;
         }

--- a/core_gl/include/mmcore_gl/view/SplitViewGL.h
+++ b/core_gl/include/mmcore_gl/view/SplitViewGL.h
@@ -1,15 +1,10 @@
-/*
- * SplitViewGL.h
- *
- * Copyright (C) 2012 by CGV (TU Dresden)
- * Alle Rechte vorbehalten.
+/**
+ * MegaMol
+ * Copyright (c) 2012, MegaMol Dev Team
+ * All rights reserved.
  */
 
-#ifndef MEGAMOLCORE_SPLITVIEW_H_INCLUDED
-#define MEGAMOLCORE_SPLITVIEW_H_INCLUDED
-#if (defined(_MSC_VER) && (_MSC_VER > 1000))
 #pragma once
-#endif /* (defined(_MSC_VER) && (_MSC_VER > 1000)) */
 
 #include "mmcore/CallerSlot.h"
 #include "mmcore/param/ColorParam.h"
@@ -20,10 +15,7 @@
 #include "vislib/math/Rectangle.h"
 #include "vislib_gl/graphics/gl/FramebufferObject.h"
 
-namespace megamol {
-namespace core_gl {
-namespace view {
-
+namespace megamol::core_gl::view {
 
 /**
  * Abstract base class of rendering views
@@ -244,8 +236,4 @@ private:
 };
 
 
-} /* end namespace view */
-} // namespace core_gl
-} /* end namespace megamol */
-
-#endif /* MEGAMOLCORE_SPLITVIEW_H_INCLUDED */
+} // namespace megamol::core_gl::view

--- a/core_gl/include/mmcore_gl/view/SplitViewGL.h
+++ b/core_gl/include/mmcore_gl/view/SplitViewGL.h
@@ -181,7 +181,7 @@ private:
      * Returns the hovered (mouse input) renderer.
      */
     inline CallRenderViewGL* renderHovered() const {
-        auto mousePos = vislib::math::Point<float, 2>(this->_mouseX, this->_mouseY);
+        auto mousePos = vislib::math::Point<int, 2>(static_cast<int>(this->_mouseX), static_cast<int>(this->_mouseY));
         if (this->_clientArea1.Contains(mousePos)) {
             return this->render1();
         } else if (this->_clientArea2.Contains(mousePos)) {
@@ -222,11 +222,11 @@ private:
     /** Option for forwarding mouse and keyboard events to both child views */
     core::param::ParamSlot _inputToBothSlot;
 
-    vislib::math::Rectangle<float> _clientArea;
+    vislib::math::Rectangle<int> _clientArea;
 
-    vislib::math::Rectangle<float> _clientArea1;
+    vislib::math::Rectangle<int> _clientArea1;
 
-    vislib::math::Rectangle<float> _clientArea2;
+    vislib::math::Rectangle<int> _clientArea2;
 
     std::shared_ptr<glowl::FramebufferObject> _fboFull;
 
@@ -236,9 +236,9 @@ private:
 
     int _focus;
 
-    float _mouseX;
+    double _mouseX;
 
-    float _mouseY;
+    double _mouseY;
 
     bool _dragSplitter;
 };

--- a/core_gl/src/view/SplitViewGL.cpp
+++ b/core_gl/src/view/SplitViewGL.cpp
@@ -547,13 +547,17 @@ void view::SplitViewGL::adjustClientAreas() {
     _splitOrientationSlot.ResetDirty();
 
     if (splitOrientation == HORIZONTAL) {
-        const int client1Width = static_cast<int>(static_cast<float>(_clientArea.Width() - splitWidth) * splitPos);
+        const int client1Width =
+            std::clamp(static_cast<int>(std::lround(static_cast<float>(_clientArea.Width() - splitWidth) * splitPos)),
+                0, _clientArea.Width() - splitWidth);
         _clientArea1.Set(
             _clientArea.Left(), _clientArea.Bottom(), _clientArea.Left() + client1Width, _clientArea.Top());
         _clientArea2.Set(_clientArea.Left() + client1Width + splitWidth, _clientArea.Bottom(), _clientArea.Right(),
             _clientArea.Top());
     } else {
-        const int client1Height = static_cast<int>(static_cast<float>(_clientArea.Height() - splitWidth) * splitPos);
+        int client1Height =
+            std::clamp(static_cast<int>(std::lround(static_cast<float>(_clientArea.Height() - splitWidth) * splitPos)),
+                0, _clientArea.Height() - splitWidth);
         _clientArea1.Set(
             _clientArea.Left(), _clientArea.Bottom(), _clientArea.Right(), _clientArea.Bottom() + client1Height);
         _clientArea2.Set(_clientArea.Left(), _clientArea.Bottom() + client1Height + splitWidth, _clientArea.Right(),

--- a/core_gl/src/view/SplitViewGL.cpp
+++ b/core_gl/src/view/SplitViewGL.cpp
@@ -46,94 +46,94 @@ view::SplitViewGL::SplitViewGL()
         , _mouseY(0.0)
         , _dragSplitter(false) {
 
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::InputCall::FunctionName(core::view::InputCall::FnOnKey), &AbstractView::OnKeyCallback);
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::InputCall::FunctionName(core::view::InputCall::FnOnChar), &AbstractView::OnCharCallback);
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::InputCall::FunctionName(core::view::InputCall::FnOnMouseButton),
         &AbstractView::OnMouseButtonCallback);
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::InputCall::FunctionName(core::view::InputCall::FnOnMouseMove), &AbstractView::OnMouseMoveCallback);
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::InputCall::FunctionName(core::view::InputCall::FnOnMouseScroll),
         &AbstractView::OnMouseScrollCallback);
     // AbstractCallRender
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::AbstractCallRender::FunctionName(core::view::AbstractCallRender::FnRender),
         &AbstractView::OnRenderView);
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         core::view::AbstractCallRender::FunctionName(core::view::AbstractCallRender::FnGetExtents),
         &AbstractView::GetExtents);
     // CallRenderViewGL
-    this->_lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
+    _lhsRenderSlot.SetCallback(view::CallRenderViewGL::ClassName(),
         view::CallRenderViewGL::FunctionName(view::CallRenderViewGL::CALL_RESETVIEW), &AbstractView::OnResetView);
-    this->MakeSlotAvailable(&this->_lhsRenderSlot);
+    MakeSlotAvailable(&_lhsRenderSlot);
 
-    this->_render1Slot.SetCompatibleCall<CallRenderViewGLDescription>();
-    this->MakeSlotAvailable(&this->_render1Slot);
+    _render1Slot.SetCompatibleCall<CallRenderViewGLDescription>();
+    MakeSlotAvailable(&_render1Slot);
 
-    this->_render2Slot.SetCompatibleCall<CallRenderViewGLDescription>();
-    this->MakeSlotAvailable(&this->_render2Slot);
+    _render2Slot.SetCompatibleCall<CallRenderViewGLDescription>();
+    MakeSlotAvailable(&_render2Slot);
 
     auto* orientations = new core::param::EnumParam(0);
     orientations->SetTypePair(HORIZONTAL, "Horizontal (side by side)");
     orientations->SetTypePair(VERTICAL, "Vertical");
-    this->_splitOrientationSlot << orientations;
-    this->MakeSlotAvailable(&this->_splitOrientationSlot);
+    _splitOrientationSlot << orientations;
+    MakeSlotAvailable(&_splitOrientationSlot);
 
-    this->_splitPositionSlot << new core::param::FloatParam(0.5f, 0.0f, 1.0f);
-    this->MakeSlotAvailable(&this->_splitPositionSlot);
+    _splitPositionSlot << new core::param::FloatParam(0.5f, 0.0f, 1.0f);
+    MakeSlotAvailable(&_splitPositionSlot);
 
-    this->_splitWidthSlot << new core::param::IntParam(4, 0, 100);
-    this->MakeSlotAvailable(&this->_splitWidthSlot);
+    _splitWidthSlot << new core::param::IntParam(4, 0, 100);
+    MakeSlotAvailable(&_splitWidthSlot);
 
-    this->_splitColourSlot << new core::param::ColorParam(0.75f, 0.75f, 0.75f, 1.0f);
-    this->MakeSlotAvailable(&this->_splitColourSlot);
+    _splitColourSlot << new core::param::ColorParam(0.75f, 0.75f, 0.75f, 1.0f);
+    MakeSlotAvailable(&_splitColourSlot);
 
-    this->_enableTimeSyncSlot << new core::param::BoolParam(false);
-    this->MakeSlotAvailable(&this->_enableTimeSyncSlot);
+    _enableTimeSyncSlot << new core::param::BoolParam(false);
+    MakeSlotAvailable(&_enableTimeSyncSlot);
 
-    this->_inputToBothSlot << new core::param::BoolParam(false);
-    this->MakeSlotAvailable(&this->_inputToBothSlot);
+    _inputToBothSlot << new core::param::BoolParam(false);
+    MakeSlotAvailable(&_inputToBothSlot);
 }
 
 view::SplitViewGL::~SplitViewGL(void) {
-    this->Release();
+    Release();
 }
 
 float view::SplitViewGL::DefaultTime(double instTime) const {
-    return this->_timeCtrl.Time(instTime);
+    return _timeCtrl.Time(instTime);
 }
 
 
 core::view::ImageWrapper view::SplitViewGL::Render(double time, double instanceTime) {
 
-    if (this->doHookCode()) {
-        this->doBeforeRenderHook();
+    if (doHookCode()) {
+        doBeforeRenderHook();
     }
 
-    if (this->_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
-        auto cr = this->render1();
+    if (_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
+        auto cr = render1();
         (*cr)(CallRenderViewGL::CALL_EXTENTS);
         auto fcount = cr->TimeFramesCount();
         auto insitu = cr->IsInSituTime();
-        cr = this->render2();
+        cr = render2();
         (*cr)(CallRenderViewGL::CALL_EXTENTS);
         fcount = std::min(fcount, cr->TimeFramesCount());
         insitu = insitu && cr->IsInSituTime();
 
-        this->_timeCtrl.SetTimeExtend(fcount, insitu);
+        _timeCtrl.SetTimeExtend(fcount, insitu);
         if (time > static_cast<float>(fcount)) {
             time = static_cast<float>(fcount);
         }
     }
 
-    // float sp = this->splitPositionSlot.Param<param::FloatParam>()->Value();
-    // float shw = this->splitWidthSlot.Param<param::FloatParam>()->Value() * 0.5f;
-    // auto so = static_cast<Orientation>(this->splitOrientationSlot.Param<param::EnumParam>()->Value());
+    // float sp = splitPositionSlot.Param<param::FloatParam>()->Value();
+    // float shw = splitWidthSlot.Param<param::FloatParam>()->Value() * 0.5f;
+    // auto so = static_cast<Orientation>(splitOrientationSlot.Param<param::EnumParam>()->Value());
     // if (so == HORIZONTAL) {
-    //    auto oc = this->overrideCall;
+    //    auto oc = overrideCall;
     //    float splitpos = oc->VirtualWidth() * sp;
 
     //    auto left1 = oc->TileX();
@@ -157,11 +157,10 @@ core::view::ImageWrapper view::SplitViewGL::Render(double time, double instanceT
     //} else {
     //}
 
-    if (this->_splitPositionSlot.IsDirty() || this->_splitOrientationSlot.IsDirty() ||
-        this->_splitWidthSlot.IsDirty() || this->_fbo1 == nullptr || this->_fbo2 == nullptr ||
-        !vislib::math::IsEqual(this->_clientArea.Width(), _fboFull->getWidth()) ||
-        !vislib::math::IsEqual(this->_clientArea.Height(), _fboFull->getHeight())) {
-        this->updateSize(_fboFull->getWidth(), _fboFull->getHeight());
+    if (_splitPositionSlot.IsDirty() || _splitOrientationSlot.IsDirty() || _splitWidthSlot.IsDirty() ||
+        _fbo1 == nullptr || _fbo2 == nullptr || !vislib::math::IsEqual(_clientArea.Width(), _fboFull->getWidth()) ||
+        !vislib::math::IsEqual(_clientArea.Height(), _fboFull->getHeight())) {
+        updateSize(_fboFull->getWidth(), _fboFull->getHeight());
     }
 
     // Propagate viewport changes to connected views.
@@ -179,8 +178,8 @@ core::view::ImageWrapper view::SplitViewGL::Render(double time, double instanceT
                 static_cast<unsigned int>(clientArea.Width()), static_cast<unsigned int>(clientArea.Height()));
         }
     };
-    propagateViewport(this->render1(), this->_clientArea1);
-    propagateViewport(this->render2(), this->_clientArea2);
+    propagateViewport(render1(), _clientArea1);
+    propagateViewport(render2(), _clientArea2);
 
     auto renderAndBlit = [&](std::shared_ptr<glowl::FramebufferObject> view_fbo,
                              std::shared_ptr<glowl::FramebufferObject> subview_fbo, CallRenderViewGL* crv,
@@ -192,7 +191,7 @@ core::view::ImageWrapper view::SplitViewGL::Render(double time, double instanceT
         crv->SetInstanceTime(instanceTime);
         crv->SetTime(-1.0f);
 
-        if (this->_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
             crv->SetTime(static_cast<float>(time));
         }
 
@@ -207,21 +206,21 @@ core::view::ImageWrapper view::SplitViewGL::Render(double time, double instanceT
 
         subview_fbo->bindToRead(0);
         glBlitFramebuffer(0, 0, subview_fbo->getWidth(), subview_fbo->getHeight(), ca.Left(),
-            this->_clientArea.Height() - ca.Top(), ca.Right(), this->_clientArea.Height() - ca.Bottom(),
-            GL_COLOR_BUFFER_BIT, GL_NEAREST);
+            _clientArea.Height() - ca.Top(), ca.Right(), _clientArea.Height() - ca.Bottom(), GL_COLOR_BUFFER_BIT,
+            GL_NEAREST);
 
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     };
 
     _fboFull->bind();
     // Draw the splitter through clearing without overplotting.
-    auto splitColour = this->_splitColourSlot.Param<core::param::ColorParam>()->Value();
+    auto splitColour = _splitColourSlot.Param<core::param::ColorParam>()->Value();
     ::glClearColor(splitColour[0], splitColour[1], splitColour[2], splitColour[3]);
     ::glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-    renderAndBlit(_fboFull, this->_fbo1, this->render1(), this->_clientArea1);
-    renderAndBlit(_fboFull, this->_fbo2, this->render2(), this->_clientArea2);
+    renderAndBlit(_fboFull, _fbo1, render1(), _clientArea1);
+    renderAndBlit(_fboFull, _fbo2, render2(), _clientArea2);
 
     return GetRenderingResult();
 }
@@ -238,13 +237,13 @@ core::view::ImageWrapper view::SplitViewGL::GetRenderingResult() const {
 }
 
 bool view::SplitViewGL::GetExtents(core::Call& call) {
-    if (this->_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
-        auto cr = this->render1();
+    if (_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value()) {
+        auto cr = render1();
         if (!(*cr)(CallRenderViewGL::CALL_EXTENTS))
             return false;
         auto time = cr->TimeFramesCount();
         auto insitu = cr->IsInSituTime();
-        cr = this->render2();
+        cr = render2();
         if (!(*cr)(CallRenderViewGL::CALL_EXTENTS))
             return false;
         time = std::min(time, cr->TimeFramesCount());
@@ -260,7 +259,7 @@ bool view::SplitViewGL::GetExtents(core::Call& call) {
 }
 
 void view::SplitViewGL::ResetView() {
-    for (auto crv : {this->render1(), this->render2()}) {
+    for (auto crv : {render1(), render2()}) {
         if (crv != nullptr)
             (*crv)(CallRenderViewGL::CALL_RESETVIEW);
     }
@@ -280,10 +279,10 @@ void view::SplitViewGL::Resize(unsigned int width, unsigned int height) {
         }
     }
 
-    if ((!vislib::math::IsEqual(this->_clientArea.Width(), static_cast<int>(width)) ||
-            !vislib::math::IsEqual(this->_clientArea.Height(), static_cast<int>(height))) &&
+    if ((!vislib::math::IsEqual(_clientArea.Width(), static_cast<int>(width)) ||
+            !vislib::math::IsEqual(_clientArea.Height(), static_cast<int>(height))) &&
         width != 0 && height != 0) {
-        this->updateSize(width, height);
+        updateSize(width, height);
     }
 }
 
@@ -293,14 +292,14 @@ bool view::SplitViewGL::OnRenderView(core::Call& call) {
         return false;
 
     auto time = crv->Time();
-    if (this->_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value() && time < 0.0) {
-        time = this->DefaultTime(crv->InstanceTime());
+    if (_enableTimeSyncSlot.Param<core::param::BoolParam>()->Value() && time < 0.0) {
+        time = DefaultTime(crv->InstanceTime());
     }
     auto instanceTime = crv->InstanceTime();
 
     auto fbo = _fboFull;
     _fboFull = crv->GetFramebuffer();
-    this->Render(time, instanceTime);
+    Render(time, instanceTime);
     _fboFull = fbo;
 
     return true;
@@ -308,9 +307,9 @@ bool view::SplitViewGL::OnRenderView(core::Call& call) {
 
 bool view::SplitViewGL::OnKey(
     frontend_resources::Key key, frontend_resources::KeyAction action, frontend_resources::Modifiers mods) {
-    auto* crv = this->renderHovered();
-    auto* crv1 = this->render1();
-    auto* crv2 = this->render2();
+    auto* crv = renderHovered();
+    auto* crv1 = render1();
+    auto* crv2 = render2();
 
     if (crv != nullptr) {
         core::view::InputEvent evt;
@@ -319,7 +318,7 @@ bool view::SplitViewGL::OnKey(
         evt.keyData.action = action;
         evt.keyData.mods = mods;
 
-        if (this->_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
             crv1->SetInputEvent(evt);
             auto consumed = (*crv1)(view::CallRenderViewGL::FnOnKey);
 
@@ -338,16 +337,16 @@ bool view::SplitViewGL::OnKey(
 }
 
 bool view::SplitViewGL::OnChar(unsigned int codePoint) {
-    auto* crv = this->renderHovered();
-    auto* crv1 = this->render1();
-    auto* crv2 = this->render2();
+    auto* crv = renderHovered();
+    auto* crv1 = render1();
+    auto* crv2 = render2();
 
     if (crv != nullptr) {
         core::view::InputEvent evt;
         evt.tag = core::view::InputEvent::Tag::Char;
         evt.charData.codePoint = codePoint;
 
-        if (this->_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
             crv1->SetInputEvent(evt);
             auto consumed = (*crv1)(view::CallRenderViewGL::FnOnChar);
 
@@ -367,15 +366,15 @@ bool view::SplitViewGL::OnChar(unsigned int codePoint) {
 
 bool view::SplitViewGL::OnMouseButton(frontend_resources::MouseButton button,
     frontend_resources::MouseButtonAction action, frontend_resources::Modifiers mods) {
-    auto* crv = this->renderHovered();
-    auto* crv1 = this->render1();
-    auto* crv2 = this->render2();
+    auto* crv = renderHovered();
+    auto* crv1 = render1();
+    auto* crv2 = render2();
 
-    this->_dragSplitter = false;
+    _dragSplitter = false;
 
     auto down = (action == frontend_resources::MouseButtonAction::PRESS);
     if (down && crv != crv1 && crv != crv2) {
-        this->_dragSplitter = true;
+        _dragSplitter = true;
     }
 
     if (crv != nullptr) {
@@ -385,7 +384,7 @@ bool view::SplitViewGL::OnMouseButton(frontend_resources::MouseButton button,
         evt.mouseButtonData.action = action;
         evt.mouseButtonData.mods = mods;
 
-        if (this->_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
             crv1->SetInputEvent(evt);
             auto consumed = (*crv1)(view::CallRenderViewGL::FnOnMouseButton);
 
@@ -406,32 +405,32 @@ bool view::SplitViewGL::OnMouseButton(frontend_resources::MouseButton button,
 
 bool view::SplitViewGL::OnMouseMove(double x, double y) {
     // x, y are coordinates in pixel
-    this->_mouseX = x;
-    this->_mouseY = y;
+    _mouseX = x;
+    _mouseY = y;
 
-    if (this->_dragSplitter) {
-        if (this->_splitOrientationSlot.Param<core::param::EnumParam>()->Value() == HORIZONTAL) {
-            this->_splitPositionSlot.Param<core::param::FloatParam>()->SetValue(
-                static_cast<float>(x) / static_cast<float>(this->_clientArea.Width()));
+    if (_dragSplitter) {
+        if (_splitOrientationSlot.Param<core::param::EnumParam>()->Value() == HORIZONTAL) {
+            _splitPositionSlot.Param<core::param::FloatParam>()->SetValue(
+                static_cast<float>(x) / static_cast<float>(_clientArea.Width()));
         } else {
-            this->_splitPositionSlot.Param<core::param::FloatParam>()->SetValue(
-                static_cast<float>(y) / static_cast<float>(this->_clientArea.Height()));
+            _splitPositionSlot.Param<core::param::FloatParam>()->SetValue(
+                static_cast<float>(y) / static_cast<float>(_clientArea.Height()));
         }
     }
 
-    auto* crv = this->renderHovered();
-    auto* crv1 = this->render1();
-    auto* crv2 = this->render2();
+    auto* crv = renderHovered();
+    auto* crv1 = render1();
+    auto* crv2 = render2();
 
     double mx;
     double my;
 
     if (crv == crv1) {
-        mx = this->_mouseX - this->_clientArea1.Left();
-        my = this->_mouseY - this->_clientArea1.Bottom();
+        mx = _mouseX - _clientArea1.Left();
+        my = _mouseY - _clientArea1.Bottom();
     } else if (crv == crv2) {
-        mx = this->_mouseX - this->_clientArea2.Left();
-        my = this->_mouseY - this->_clientArea2.Bottom();
+        mx = _mouseX - _clientArea2.Left();
+        my = _mouseY - _clientArea2.Bottom();
     } else {
         return false;
     }
@@ -442,7 +441,7 @@ bool view::SplitViewGL::OnMouseMove(double x, double y) {
         evt.mouseMoveData.x = mx;
         evt.mouseMoveData.y = my;
 
-        if (this->_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
             crv1->SetInputEvent(evt);
             auto consumed = (*crv1)(view::CallRenderViewGL::FnOnMouseMove);
 
@@ -462,9 +461,9 @@ bool view::SplitViewGL::OnMouseMove(double x, double y) {
 
 
 bool view::SplitViewGL::OnMouseScroll(double dx, double dy) {
-    auto* crv = this->renderHovered();
-    auto* crv1 = this->render1();
-    auto* crv2 = this->render2();
+    auto* crv = renderHovered();
+    auto* crv1 = render1();
+    auto* crv2 = render2();
 
     if (crv != nullptr) {
         core::view::InputEvent evt;
@@ -472,7 +471,7 @@ bool view::SplitViewGL::OnMouseScroll(double dx, double dy) {
         evt.mouseScrollData.dx = dx;
         evt.mouseScrollData.dy = dy;
 
-        if (this->_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
+        if (_inputToBothSlot.Param<core::param::BoolParam>()->Value()) {
             crv1->SetInputEvent(evt);
             auto consumed = (*crv1)(view::CallRenderViewGL::FnOnMouseScroll);
 
@@ -507,9 +506,9 @@ void view::SplitViewGL::release() {
 }
 
 void view::SplitViewGL::updateSize(size_t width, size_t height) {
-    this->_clientArea.SetWidth(static_cast<int>(width));
-    this->_clientArea.SetHeight(static_cast<int>(height));
-    this->adjustClientAreas();
+    _clientArea.SetWidth(static_cast<int>(width));
+    _clientArea.SetHeight(static_cast<int>(height));
+    adjustClientAreas();
 
 #if defined(DEBUG) || defined(_DEBUG)
     unsigned int otl = vislib::Trace::GetInstance().GetLevel();
@@ -519,12 +518,12 @@ void view::SplitViewGL::updateSize(size_t width, size_t height) {
     if (width != 0 && height != 0) {
         glBindFramebuffer(GL_FRAMEBUFFER, 0); // better safe then sorry, "unbind" fbo before delting one
         try {
-            _fbo1 = std::make_shared<glowl::FramebufferObject>(static_cast<unsigned int>(this->_clientArea1.Width()),
-                static_cast<unsigned int>(this->_clientArea1.Height()));
+            _fbo1 = std::make_shared<glowl::FramebufferObject>(
+                static_cast<unsigned int>(_clientArea1.Width()), static_cast<unsigned int>(_clientArea1.Height()));
             _fbo1->createColorAttachment(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE);
 
-            _fbo2 = std::make_shared<glowl::FramebufferObject>(static_cast<unsigned int>(this->_clientArea2.Width()),
-                static_cast<unsigned int>(this->_clientArea2.Height()));
+            _fbo2 = std::make_shared<glowl::FramebufferObject>(
+                static_cast<unsigned int>(_clientArea2.Width()), static_cast<unsigned int>(_clientArea2.Height()));
             _fbo2->createColorAttachment(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE);
 
             // TODO: check completness and throw if not?
@@ -540,30 +539,28 @@ void view::SplitViewGL::updateSize(size_t width, size_t height) {
 }
 
 void view::SplitViewGL::adjustClientAreas() {
-    const float splitPos = this->_splitPositionSlot.Param<core::param::FloatParam>()->Value();
-    const int splitWidth = this->_splitWidthSlot.Param<core::param::IntParam>()->Value();
+    const float splitPos = _splitPositionSlot.Param<core::param::FloatParam>()->Value();
+    const int splitWidth = _splitWidthSlot.Param<core::param::IntParam>()->Value();
     const auto splitOrientation =
-        static_cast<Orientation>(this->_splitOrientationSlot.Param<core::param::EnumParam>()->Value());
-    this->_splitPositionSlot.ResetDirty();
-    this->_splitWidthSlot.ResetDirty();
-    this->_splitOrientationSlot.ResetDirty();
+        static_cast<Orientation>(_splitOrientationSlot.Param<core::param::EnumParam>()->Value());
+    _splitPositionSlot.ResetDirty();
+    _splitWidthSlot.ResetDirty();
+    _splitOrientationSlot.ResetDirty();
 
     if (splitOrientation == HORIZONTAL) {
-        const int client1Width =
-            static_cast<int>(static_cast<float>(this->_clientArea.Width() - splitWidth) * splitPos);
-        this->_clientArea1.Set(this->_clientArea.Left(), this->_clientArea.Bottom(),
-            this->_clientArea.Left() + client1Width, this->_clientArea.Top());
-        this->_clientArea2.Set(this->_clientArea.Left() + client1Width + splitWidth, this->_clientArea.Bottom(),
-            this->_clientArea.Right(), this->_clientArea.Top());
+        const int client1Width = static_cast<int>(static_cast<float>(_clientArea.Width() - splitWidth) * splitPos);
+        _clientArea1.Set(
+            _clientArea.Left(), _clientArea.Bottom(), _clientArea.Left() + client1Width, _clientArea.Top());
+        _clientArea2.Set(_clientArea.Left() + client1Width + splitWidth, _clientArea.Bottom(), _clientArea.Right(),
+            _clientArea.Top());
     } else {
-        const int client1Height =
-            static_cast<int>(static_cast<float>(this->_clientArea.Height() - splitWidth) * splitPos);
-        this->_clientArea1.Set(this->_clientArea.Left(), this->_clientArea.Bottom(), this->_clientArea.Right(),
-            this->_clientArea.Bottom() + client1Height);
-        this->_clientArea2.Set(this->_clientArea.Left(), this->_clientArea.Bottom() + client1Height + splitWidth,
-            this->_clientArea.Right(), this->_clientArea.Top());
+        const int client1Height = static_cast<int>(static_cast<float>(_clientArea.Height() - splitWidth) * splitPos);
+        _clientArea1.Set(
+            _clientArea.Left(), _clientArea.Bottom(), _clientArea.Right(), _clientArea.Bottom() + client1Height);
+        _clientArea2.Set(_clientArea.Left(), _clientArea.Bottom() + client1Height + splitWidth, _clientArea.Right(),
+            _clientArea.Top());
     }
 
-    this->_clientArea1.EnforcePositiveSize();
-    this->_clientArea2.EnforcePositiveSize();
+    _clientArea1.EnforcePositiveSize();
+    _clientArea2.EnforcePositiveSize();
 }

--- a/core_gl/src/view/SplitViewGL.cpp
+++ b/core_gl/src/view/SplitViewGL.cpp
@@ -1,9 +1,9 @@
-/*
- * SplitViewGL.cpp
- *
- * Copyright (C) 2012 by CGV (TU Dresden)
- * Alle Rechte vorbehalten.
+/**
+ * MegaMol
+ * Copyright (c) 2012, MegaMol Dev Team
+ * All rights reserved.
  */
+
 #include "mmcore_gl/view/SplitViewGL.h"
 #include "mmcore/param/BoolParam.h"
 #include "mmcore/param/ColorParam.h"
@@ -11,7 +11,6 @@
 #include "mmcore/param/FloatParam.h"
 #include "mmcore/param/IntParam.h"
 #include "mmcore_gl/view/CallRenderViewGL.h"
-#include "stdafx.h"
 
 #include "mmcore/utility/log/Log.h"
 #include "vislib/Trace.h"


### PR DESCRIPTION
## Summary of Changes
- do SplitView internal calculations with integer values, to avoid rounding errors
- Breaking Change: param `split.width` changed from FloatParam to IntParam