### PR TITLE
filepath param fix

### DIFF
--- a/core/src/param/FilePathParam.cpp
+++ b/core/src/param/FilePathParam.cpp
@@ -50,7 +50,9 @@ bool FilePathParam::ParseValue(std::string const& v) {
 void FilePathParam::SetValue(const std::filesystem::path& v, bool setDirty) {
 
     try {
-        auto new_value = v;
+        auto tmp_val_str = v.generic_u8string();
+        std::replace(tmp_val_str.begin(), tmp_val_str.end(), '\\', '/');
+        auto new_value = std::filesystem::path(tmp_val_str);
         if (this->value != new_value) {
             auto error_flags = FilePathParam::ValidatePath(new_value, this->extensions, this->flags);
 

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -1580,8 +1580,10 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
             std::get<std::string>(this->gui_widget_value), file_extensions, file_flags);
         ImGui::SameLine();
         ImGui::InputText(label.c_str(), &std::get<std::string>(this->gui_widget_value), ImGuiInputTextFlags_None);
-        if (button_edit || ImGui::IsItemDeactivatedAfterEdit()) {
-            val = std::filesystem::u8path(std::get<std::string>(this->gui_widget_value));
+        if (button_edit || ImGui::IsItemDeactivatedAfterEdit()) {y
+            auto tmp_val_str = std::get<std::string>(this->gui_widget_value);
+            std::replace(tmp_val_str.begin(), tmp_val_str.end(), '\\', '/');
+            val = std::filesystem::path(tmp_val_str);
             try {
                 if (last_val != val) {
                     auto error_flags = FilePathParam::ValidatePath(val, file_extensions, file_flags);

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -1580,7 +1580,7 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
             std::get<std::string>(this->gui_widget_value), file_extensions, file_flags);
         ImGui::SameLine();
         ImGui::InputText(label.c_str(), &std::get<std::string>(this->gui_widget_value), ImGuiInputTextFlags_None);
-        if (button_edit || ImGui::IsItemDeactivatedAfterEdit()) {y
+        if (button_edit || ImGui::IsItemDeactivatedAfterEdit()) {
             auto tmp_val_str = std::get<std::string>(this->gui_widget_value);
             std::replace(tmp_val_str.begin(), tmp_val_str.end(), '\\', '/');
             val = std::filesystem::path(tmp_val_str);


### PR DESCRIPTION
convert windows separator '\' to default separator '/' to make "windows formatted" paths work under linux ....

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
