### PR TITLE
Fix performance issue when tf is set via setparamvalue in project file

### DIFF
--- a/core/include/mmcore/view/TransferFunction.h
+++ b/core/include/mmcore/view/TransferFunction.h
@@ -81,6 +81,9 @@ private:
      * @return 'true' on success, 'false' otherwise.
      */
     bool requestTF(core::Call& call);
+
+    /** A flag that signals whether the tf range from the project file should be ignored */
+    bool ignore_project_range = true;
 };
 
 

--- a/core/src/view/TransferFunction.cpp
+++ b/core/src/view/TransferFunction.cpp
@@ -28,19 +28,27 @@ view::TransferFunction::TransferFunction(void) : Module(), AbstractTransferFunct
 
 bool TransferFunction::requestTF(core::Call& call) {
 
-    CallGetTransferFunction* cgtf = dynamic_cast<CallGetTransferFunction*>(&call);
+    auto cgtf = dynamic_cast<CallGetTransferFunction*>(&call);
     if (cgtf == nullptr)
         return false;
 
-    if (this->tfParam.IsDirty() || cgtf->UpdateRange()) {
-        this->tfParam.ResetDirty();
+    // update transfer function if still uninitialized
+    bool something_has_changed = false;
 
+    // update transfer function if tf param is dirty
+    if (this->tfParam.IsDirty()) {
         // Check if range of initially loaded project value should be ignored
         auto tf_param_value = this->tfParam.Param<TransferFunctionParam>()->Value();
-        bool tmp_ignore_project_range = TransferFunctionParam::IgnoreProjectRange(tf_param_value);
+        this->ignore_project_range = TransferFunctionParam::IgnoreProjectRange(tf_param_value);
+        this->tfParam.ResetDirty();
+        something_has_changed = true;
+    }
 
+    // update transfer function if call ask for range update range from project file is ignored
+    if (cgtf->UpdateRange() && this->ignore_project_range) {
         // Update changed range propagated from the module via the call
-        if (tmp_ignore_project_range && cgtf->ConsumeRangeUpdate()) {
+        if (cgtf->ConsumeRangeUpdate()) {
+            auto tf_param_value = this->tfParam.Param<TransferFunctionParam>()->Value();
             auto tmp_range = this->range;
             auto tmp_interpol = this->interpolMode;
             auto tmp_tex_size = this->texSize;
@@ -55,8 +63,11 @@ bool TransferFunction::requestTF(core::Call& call) {
                     this->tfParam.Param<TransferFunctionParam>()->SetValue(tf_str);
                 }
             }
+            something_has_changed = true;
         }
+    }
 
+    if (something_has_changed) {
         // Get current values from parameter string (Values are checked, too).
         TransferFunctionParam::NodeVector_t tmp_nodes;
         if (!TransferFunctionParam::GetParsedTransferFunctionData(this->tfParam.Param<TransferFunctionParam>()->Value(),

--- a/core_gl/include/mmcore_gl/view/TransferFunctionGL.h
+++ b/core_gl/include/mmcore_gl/view/TransferFunctionGL.h
@@ -83,6 +83,9 @@ private:
 
     /** The OpenGL texture object id */
     unsigned int texID;
+
+    /** A flag that signals whether the tf range from the project file should be ignored */
+    bool ignore_project_range = true;
 };
 
 

--- a/core_gl/src/view/TransferFunctionGL.cpp
+++ b/core_gl/src/view/TransferFunctionGL.cpp
@@ -58,7 +58,7 @@ bool TransferFunctionGL::requestTF(core::Call& call) {
         something_has_changed = true;
     }
 
-    // update transfer function if call ask for range update range from project file is ignored
+    // update transfer function if call asks for range update and range from project file is ignored
     if (cgtf->UpdateRange() && this->ignore_project_range) {
         // Update changed range propagated from the module via the call
         if (cgtf->ConsumeRangeUpdate()) {


### PR DESCRIPTION
Improved handling of updates in TransferFunctionGL. Previously, setting the transfer function (tf) in a project file via mmSetParamValue caused an update of the tf in each frame (including expensive parsing of the json string), because range updates from the incoming call to the tf were blocked from being consumed, but still triggered updates each frame.

## Test Instructions
All tf functionality should still work as before. In a project file with a tf (e.g. infovis), use mmSetParamValue to set the tf param value string. Performance should not decrease.
