### PR TITLE
mmScreenshot: use read buffer ids as actually defined by GL

### DIFF
--- a/frontend/resources/include/Screenshots.h
+++ b/frontend/resources/include/Screenshots.h
@@ -82,7 +82,14 @@ private:
 
 class GLScreenshotSource : public IScreenshotSource {
 public:
-    enum ReadBuffer { FRONT, BACK, COLOR_ATT0, COLOR_ATT1, COLOR_ATT2, COLOR_ATT3 };
+    enum ReadBuffer {
+        FRONT = 0x0404,                              // GL_FRONT
+        BACK = 0x0405,                               // GL_BACK
+        COLOR_ATTACHMENT0 = 0x8CE0,                  // GL_COLOR_ATTACHMENT0
+        COLOR_ATTACHMENT1 = (COLOR_ATTACHMENT0 + 1), // GL_COLOR_ATTACHMENT1
+        COLOR_ATTACHMENT2 = (COLOR_ATTACHMENT0 + 2), // GL_COLOR_ATTACHMENT2
+        COLOR_ATTACHMENT3 = (COLOR_ATTACHMENT0 + 3), // GL_COLOR_ATTACHMENT3
+    };
 
     void set_read_buffer(ReadBuffer buffer) GL_STUB();
 

--- a/frontend/services/screenshot_service/gl/GLScreenshotSource.cpp
+++ b/frontend/services/screenshot_service/gl/GLScreenshotSource.cpp
@@ -12,30 +12,6 @@
 
 void megamol::frontend_resources::GLScreenshotSource::set_read_buffer(ReadBuffer buffer) {
     m_read_buffer = buffer;
-    GLenum read_buffer;
-
-    switch (buffer) {
-    default:
-        [[fallthrough]];
-    case ReadBuffer::FRONT:
-        read_buffer = GL_FRONT;
-        break;
-    case ReadBuffer::BACK:
-        read_buffer = GL_BACK;
-        break;
-    case ReadBuffer::COLOR_ATT0:
-        read_buffer = GL_COLOR_ATTACHMENT0;
-        break;
-    case ReadBuffer::COLOR_ATT1:
-        read_buffer = GL_COLOR_ATTACHMENT0 + 1;
-        break;
-    case ReadBuffer::COLOR_ATT2:
-        read_buffer = GL_COLOR_ATTACHMENT0 + 2;
-        break;
-    case ReadBuffer::COLOR_ATT3:
-        read_buffer = GL_COLOR_ATTACHMENT0 + 3;
-        break;
-    }
 }
 
 megamol::frontend_resources::ScreenshotImageData const&


### PR DESCRIPTION
Fixes reading screenshots from GL frontbuffer to actually use the correct GL_FRONT value. 
