### PR TITLE
Disable warnings in CI build

### DIFF
--- a/.ci/check_plugins.sh
+++ b/.ci/check_plugins.sh
@@ -20,6 +20,17 @@ for pdir in *; do
     pname="megamolplugin"
   fi
 
+  # Check main dirs for being lower casing
+  for dir in "include" "src" "shaders" "resources"; do
+    found_dir=$(find "$pdir" -maxdepth 1 -type d -iname "$dir")
+    if [[ -d "$found_dir" ]]; then
+      if [[ $found_dir != "$pdir/$dir" ]]; then
+        EXIT_CODE=1
+        echo "The directory \"$found_dir\" must be all lower case!"
+      fi
+    fi
+  done
+
   # Check include dir has exactly one subdir <plugin-name>
   if [[ -d "$pdir/include" ]]; then
     count=$(ls -1q "$pdir/include" | wc -l)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ pr:
 
 variables:
   defaultConfig: >-
+    -DMEGAMOL_WARNING_LEVEL="Off"
     -DBUILD_PLUGIN_ASTRO=ON
     -DBUILD_PLUGIN_ASTRO_GL=ON
     -DBUILD_PLUGIN_IMAGE_GL=ON
@@ -16,6 +17,7 @@ variables:
     -DBUILD_PLUGIN_MMVTKM_GL=ON
     -DBUILD_PLUGIN_REMOTE=OFF
   nonGlConfig: >-
+    -DMEGAMOL_WARNING_LEVEL="Off"
     -DENABLE_GL=OFF
 
 jobs:

--- a/externals/CMakeExternals.cmake
+++ b/externals/CMakeExternals.cmake
@@ -10,7 +10,7 @@ find_package(Git REQUIRED)
 if (NOT EXISTS "${CMAKE_BINARY_DIR}/script-externals")
   message(STATUS "Downloading external scripts")
   execute_process(COMMAND
-    ${GIT_EXECUTABLE} clone -b v2.5 https://github.com/UniStuttgart-VISUS/megamol-cmake-externals.git script-externals --depth 1
+    ${GIT_EXECUTABLE} clone -b v2.6 https://github.com/UniStuttgart-VISUS/megamol-cmake-externals.git script-externals --depth 1
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif ()


### PR DESCRIPTION
## Summary of Changes
- Disable warnings in CI build. They are so many, no one will read it anyway and makes it actually harder to find actual errors.