### PR TITLE
Timer Queries

### DIFF
--- a/frontend/services/profiling_service/Profiling_Service.hpp
+++ b/frontend/services/profiling_service/Profiling_Service.hpp
@@ -55,6 +55,8 @@ public:
 private:
     void fill_lua_callbacks();
 
+    void start_timer_queries();
+
     void notify_timer_queries();
 
     std::unordered_map<int64_t, std::tuple<int, int64_t, int64_t>> timer_map_;
@@ -62,6 +64,8 @@ private:
     std::mt19937_64 rng_;
 
     std::uniform_int_distribution<int64_t> distro_;
+
+    int64_t timer_id_ = 0;
 };
 
 } // namespace frontend

--- a/frontend/services/profiling_service/Profiling_Service.hpp
+++ b/frontend/services/profiling_service/Profiling_Service.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <fstream>
-#include <tuple>
 #include <random>
+#include <tuple>
 
 #include "AbstractFrontendService.hpp"
 #include "PerformanceManager.h"

--- a/frontend/services/profiling_service/Profiling_Service.hpp
+++ b/frontend/services/profiling_service/Profiling_Service.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <fstream>
+#include <tuple>
+#include <random>
 
 #include "AbstractFrontendService.hpp"
 #include "PerformanceManager.h"
@@ -39,13 +41,27 @@ public:
     const std::vector<std::string> getRequestedResourceNames() const override {
         return _requestedResourcesNames;
     }
-    void setRequestedResources(std::vector<FrontendResource> resources) override {}
+    void setRequestedResources(std::vector<FrontendResource> resources) override {
+        _requestedResourcesReferences = resources;
+    }
 
     std::vector<FrontendResource> _providedResourceReferences;
     std::vector<std::string> _requestedResourcesNames;
+    std::vector<FrontendResource> _requestedResourcesReferences;
 
     megamol::frontend_resources::PerformanceManager _perf_man;
     std::ofstream log_file;
+
+private:
+    void fill_lua_callbacks();
+
+    void notify_timer_queries();
+
+    std::unordered_map<int64_t, std::tuple<int, int64_t, int64_t>> timer_map_;
+
+    std::mt19937_64 rng_;
+
+    std::uniform_int_distribution<int64_t> distro_;
 };
 
 } // namespace frontend


### PR DESCRIPTION
<!--Add a description here.
Include a list of issues it fixes in the "Fixes #[]" format if applicable.-->
Interface to get start and end timestamps for a specified number of rendered frames.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->
Modified profiling service.
Added three new lua command:
- mmCreateTimeQuery
- mmStartTimeQuery
- mmPokeTimeQuery
