### PR TITLE
Fixed mesh data reupload to GPU every frame

### DIFF
--- a/plugins/mesh_gl/src/TriangleMeshRenderer3D.cpp
+++ b/plugins/mesh_gl/src/TriangleMeshRenderer3D.cpp
@@ -202,7 +202,7 @@ bool TriangleMeshRenderer3D::get_input_data() {
         this->mesh_data_hash = mdc_ptr->DataHash();
     }
 
-    if (mdc_ptr != nullptr && !this->data_set.Param<core::param::FlexEnumParam>()->Value().empty()) {
+    if (mdc_ptr != nullptr && (!this->data_set.Param<core::param::FlexEnumParam>()->Value().empty() && this->data_set.IsDirty())) {
         this->render_data.values = mdc_ptr->get_data(this->data_set.Param<core::param::FlexEnumParam>()->Value());
 
         this->data_set.ResetDirty();
@@ -219,6 +219,7 @@ bool TriangleMeshRenderer3D::get_input_data() {
 
         const auto& color = this->default_color.Param<core::param::ColorParam>()->Value();
         this->default_color.ResetDirty();
+        this->data_set.ResetDirty();
 
         std::stringstream ss;
         ss << "{\"Interpolation\":\"LINEAR\",\"Nodes\":["


### PR DESCRIPTION
As it currently stands, when given (mesh) data sets, the `mesh::TriangleMeshRenderer3D` indicates that the data has changed, even when no change occurred. This happens every frame, which causes a tremendous slowdown for larger data sets, as the entire data-block has to be uploaded to the GPU.

This is fixed by only indicating a change, if the `data_set` slot is dirty. Thus I've added 1 missing check & one update of the dirty parameter which should address the issue.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
