### PR TITLE
Fixed/improved chaining (and compositing) for volume renderer

### DIFF
--- a/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-DVR.comp.glsl
+++ b/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-DVR.comp.glsl
@@ -20,7 +20,6 @@ uniform int use_depth_tx;
 void compute(float t, const float tfar, const Ray ray, const float rayStep, const ivec2 pixel_coords) {
     // Get pixel texture coordinates and depth value at original position
     vec2 pixel_tex_coords = vec2(pixel_coords.x / rt_resolution.x, pixel_coords.y / rt_resolution.y);
-    //const float input_depth = texture(depth_tx2D, pixel_tex_coords).x;
 
     // Initialize results
     vec4 result = vec4(0.0f);
@@ -33,18 +32,19 @@ void compute(float t, const float tfar, const Ray ray, const float rayStep, cons
         texCoords *= 1.0 - 2.0 * halfVoxelSize;
         texCoords += halfVoxelSize;
 
-        // if (use_depth_tx != 0) {
-        //     // Compare depth values and decide to abort
-        //     const float depth = calculate_depth(pos);
+        if (use_depth_tx != 0) {
+            // Compare depth values and decide to abort
+            const float input_depth = texture(depth_tx2D, pixel_tex_coords).x;
+            const float depth = calculate_depth(pos);
 
-        //     if (depth > input_depth) {
-        //         const vec4 color = texture(color_tx2D, pixel_tex_coords);
+            if (depth > input_depth) {
+                const vec4 color = texture(color_tx2D, pixel_tex_coords);
 
-        //         result += (1.0f - result.w) * color;
+                result += (1.0f - result.w) * color;
 
-        //         break;
-        //     }
-        // }
+                break;
+            }
+        }
 
         // Get sample
         vec4 vol_sample = texture(tf_tx1D, (texture(volume_tx3D, texCoords).x - valRange.x) / (valRange.y-valRange.x));

--- a/plugins/volume_gl/src/RaycastVolumeRenderer.h
+++ b/plugins/volume_gl/src/RaycastVolumeRenderer.h
@@ -140,16 +140,12 @@ private:
     core::param::ParamSlot m_material_color;
 
     /** caller slot */
-    megamol::core::CallerSlot m_renderer_callerSlot;
     megamol::core::CallerSlot m_volumetricData_callerSlot;
     megamol::core::CallerSlot m_lights_callerSlot;
     megamol::core::CallerSlot m_transferFunction_callerSlot;
 
     std::array<float, 2> valRange;
     bool valRangeNeedsUpdate = false;
-
-    /** FBO for chaining renderers */
-    std::shared_ptr<glowl::FramebufferObject> fbo;
 };
 
 } // namespace megamol::volume_gl

--- a/plugins/volume_gl/src/RaycastVolumeRenderer.h
+++ b/plugins/volume_gl/src/RaycastVolumeRenderer.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <memory>
 
+#include <glowl/FramebufferObject.hpp>
 #include <glowl/Texture2D.hpp>
 #include <glowl/Texture3D.hpp>
 
@@ -148,7 +149,7 @@ private:
     bool valRangeNeedsUpdate = false;
 
     /** FBO for chaining renderers */
-    vislib_gl::graphics::gl::FramebufferObject fbo;
+    std::shared_ptr<glowl::FramebufferObject> fbo;
 };
 
 } // namespace megamol::volume_gl


### PR DESCRIPTION
Fixed and improved chaining (and compositing) for the raycast volume renderer.
It should now work to chain with other renderers on both sides. However, results will differ, as only chaining to the right side can be considered in the computation of the volume rendering. Renderings after this, i.e., when the raycaster is on the right side of another renderer, are not provided with a depth and thus can only fully overdraw the volume instead of blending into it.

## Summary of Changes
- Removed custom chain renderer slot that was previously used for compositing (and did not work after global changes to framebuffer handling)
- Uses default frame buffer provided by View3D, and filled from chaining to the right, as input for the renderer
- Uncommented depth handling for compositing with chained rendering (don't know why this was commented out, maybe previously untested)