### PR TITLE
Fixes ParameterSlot lookup in CSVFileSequence

### DIFF
--- a/plugins/datatools/src/CSVFileSequence.cpp
+++ b/plugins/datatools/src/CSVFileSequence.cpp
@@ -8,6 +8,7 @@
 #include "CSVFileSequence.h"
 #include "datatools/table/TableDataCall.h"
 #include "mmcore/CoreInstance.h"
+#include "mmcore/MegaMolGraph.h"
 #include "mmcore/factories/CallDescriptionManager.h"
 #include "mmcore/param/BoolParam.h"
 #include "mmcore/param/FilePathParam.h"
@@ -451,20 +452,8 @@ bool datatools::CSVFileSequence::onFileNameSlotNameChanged(core::param::ParamSlo
 core::param::ParamSlot* datatools::CSVFileSequence::findFileNameSlot(void) {
     core::param::StringParam* P = this->fileNameSlotNameSlot.Param<core::param::StringParam>();
     if (P != NULL) {
-        AbstractNamedObjectContainer::ptr_type anoc =
-            AbstractNamedObjectContainer::dynamic_pointer_cast(this->shared_from_this());
-        while (anoc) {
-            core::param::ParamSlot* slot =
-                dynamic_cast<core::param::ParamSlot*>(anoc->FindNamedObject(P->Value().c_str()).get());
-            if (slot != NULL) {
-                if ((slot->Param<core::param::FilePathParam>() != NULL) ||
-                    (slot->Param<core::param::StringParam>() != NULL)) {
-                    // everything is fine
-                    return slot;
-                }
-            }
-            anoc = AbstractNamedObjectContainer::dynamic_pointer_cast(anoc->Parent());
-        }
+        auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
+        return megamolgraph.FindParameterSlot(P->Value());
     }
     return NULL;
 }

--- a/plugins/datatools/src/CSVFileSequence.h
+++ b/plugins/datatools/src/CSVFileSequence.h
@@ -26,6 +26,14 @@ namespace datatools {
  */
 class CSVFileSequence : public core::Module {
 public:
+    typedef core::Module Base;
+
+    std::vector<std::string> requested_lifetime_resources() override {
+        auto lifetime_resources = Base::requested_lifetime_resources();
+        lifetime_resources.push_back("MegaMolGraph");
+        return lifetime_resources;
+    }
+
     /**
      * Answer the name of this module.
      *


### PR DESCRIPTION
The CSVFileSequence module did not accept the filename slot name correctly. This fix addresses the issue.

## Summary of Changes
- Updated CSVFileSequence to use the MegaMolGraph for finding the corresponding filename slot by its name