### PR TITLE
Fixes SphereRenderer not using connected transfer function

### DIFF
--- a/plugins/mmstd_gl/include/mmstd_gl/renderer/CallGetTransferFunctionGL.h
+++ b/plugins/mmstd_gl/include/mmstd_gl/renderer/CallGetTransferFunctionGL.h
@@ -90,7 +90,7 @@ public:
 
     void BindConvenience(std::unique_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform);
 
-    void BindConvenience(std::shared_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform);
+    void BindConvenience(glowl::GLSLProgram& shader, GLenum activeTexture, int textureUniform);
 
     /**
      * Unbinds convenience.

--- a/plugins/mmstd_gl/include/mmstd_gl/renderer/CallGetTransferFunctionGL.h
+++ b/plugins/mmstd_gl/include/mmstd_gl/renderer/CallGetTransferFunctionGL.h
@@ -90,6 +90,8 @@ public:
 
     void BindConvenience(std::unique_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform);
 
+    void BindConvenience(std::shared_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform);
+
     /**
      * Unbinds convenience.
      */

--- a/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
+++ b/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
@@ -34,11 +34,10 @@ void CallGetTransferFunctionGL::BindConvenience(
 
 void CallGetTransferFunctionGL::BindConvenience(
     std::unique_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform) {
-        BindConvenience(*shader, activeTexture, textureUniform);
+    BindConvenience(*shader, activeTexture, textureUniform);
 }
 
-void CallGetTransferFunctionGL::BindConvenience(
-    glowl::GLSLProgram& shader, GLenum activeTexture, int textureUniform) {
+void CallGetTransferFunctionGL::BindConvenience(glowl::GLSLProgram& shader, GLenum activeTexture, int textureUniform) {
     glEnable(GL_TEXTURE_1D);
     glActiveTexture(activeTexture);
     glBindTexture(GL_TEXTURE_1D, this->texID);

--- a/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
+++ b/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
@@ -34,20 +34,16 @@ void CallGetTransferFunctionGL::BindConvenience(
 
 void CallGetTransferFunctionGL::BindConvenience(
     std::unique_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform) {
-    glEnable(GL_TEXTURE_1D);
-    glActiveTexture(activeTexture);
-    glBindTexture(GL_TEXTURE_1D, this->texID);
-    shader->setUniform("tfTexture", textureUniform);
-    glUniform2fv(shader->getUniformLocation("tfRange"), 1, this->range.data());
+        BindConvenience(*shader, activeTexture, textureUniform);
 }
 
 void CallGetTransferFunctionGL::BindConvenience(
-    std::shared_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform) {
+    glowl::GLSLProgram& shader, GLenum activeTexture, int textureUniform) {
     glEnable(GL_TEXTURE_1D);
     glActiveTexture(activeTexture);
     glBindTexture(GL_TEXTURE_1D, this->texID);
-    shader->setUniform("tfTexture", textureUniform);
-    glUniform2fv(shader->getUniformLocation("tfRange"), 1, this->range.data());
+    shader.setUniform("tfTexture", textureUniform);
+    shader.setUniform("tfRange", this->range[0], this->range[1]);
 }
 
 void CallGetTransferFunctionGL::UnbindConvenience() {

--- a/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
+++ b/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
@@ -41,6 +41,15 @@ void CallGetTransferFunctionGL::BindConvenience(
     glUniform2fv(shader->getUniformLocation("tfRange"), 1, this->range.data());
 }
 
+void CallGetTransferFunctionGL::BindConvenience(
+    std::shared_ptr<glowl::GLSLProgram>& shader, GLenum activeTexture, int textureUniform) {
+    glEnable(GL_TEXTURE_1D);
+    glActiveTexture(activeTexture);
+    glBindTexture(GL_TEXTURE_1D, this->texID);
+    shader->setUniform("tfTexture", textureUniform);
+    glUniform2fv(shader->getUniformLocation("tfRange"), 1, this->range.data());
+}
+
 void CallGetTransferFunctionGL::UnbindConvenience() {
     glDisable(GL_TEXTURE_1D);
     glBindTexture(GL_TEXTURE_1D, 0);

--- a/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
+++ b/plugins/mmstd_gl/src/renderer/CallGetTransferFunctionGL.cpp
@@ -43,7 +43,7 @@ void CallGetTransferFunctionGL::BindConvenience(
     glActiveTexture(activeTexture);
     glBindTexture(GL_TEXTURE_1D, this->texID);
     shader.setUniform("tfTexture", textureUniform);
-    shader.setUniform("tfRange", this->range[0], this->range[1]);
+    glUniform2fv(shader.getUniformLocation("tfRange"), 1, this->range.data());
 }
 
 void CallGetTransferFunctionGL::UnbindConvenience() {

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
@@ -2045,7 +2045,6 @@ bool SphereRenderer::enableTransferFunctionTexture(std::shared_ptr<glowl::GLSLPr
 
     mmstd_gl::CallGetTransferFunctionGL* cgtf = this->get_tf_slot_.CallAs<mmstd_gl::CallGetTransferFunctionGL>();
     if ((cgtf != nullptr) && (*cgtf)(0)) {
-        // TODO: how to do with unique?
         cgtf->BindConvenience(*prgm, GL_TEXTURE0, 0);
     } else {
         glEnable(GL_TEXTURE_1D);

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
@@ -2046,7 +2046,7 @@ bool SphereRenderer::enableTransferFunctionTexture(std::shared_ptr<glowl::GLSLPr
     mmstd_gl::CallGetTransferFunctionGL* cgtf = this->get_tf_slot_.CallAs<mmstd_gl::CallGetTransferFunctionGL>();
     if ((cgtf != nullptr) && (*cgtf)(0)) {
         // TODO: how to do with unique?
-        //cgtf->BindConvenience(prgm, GL_TEXTURE0, 0);
+        cgtf->BindConvenience(prgm, GL_TEXTURE0, 0);
     } else {
         glEnable(GL_TEXTURE_1D);
         glActiveTexture(GL_TEXTURE0);

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
@@ -2046,7 +2046,7 @@ bool SphereRenderer::enableTransferFunctionTexture(std::shared_ptr<glowl::GLSLPr
     mmstd_gl::CallGetTransferFunctionGL* cgtf = this->get_tf_slot_.CallAs<mmstd_gl::CallGetTransferFunctionGL>();
     if ((cgtf != nullptr) && (*cgtf)(0)) {
         // TODO: how to do with unique?
-        cgtf->BindConvenience(prgm, GL_TEXTURE0, 0);
+        cgtf->BindConvenience(*prgm, GL_TEXTURE0, 0);
     } else {
         glEnable(GL_TEXTURE_1D);
         glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
Fixes #1094

## Summary of Changes
- Added new binding to `CallGetTransferFunctionGL.BindConvenience` where `GLSLProgram` is passed by reference
