### PR TITLE
Added IDs to the TableToParticles module

### DIFF
--- a/plugins/datatools/src/table/TableToParticles.cpp
+++ b/plugins/datatools/src/table/TableToParticles.cpp
@@ -452,7 +452,9 @@ bool TableToParticles::assertData(table::TableDataCall* ft, unsigned int frameID
             currOut[j] = ftData[cols * i + indicesToCollect[j]];
         }
         if (this->haveIDs) {
-            currOut[idOffset] = static_cast<uint32_t>(currOut[idOffset]);
+            // First cast the float to a int, then save bits w/o casting in currOut
+            uint32_t id = static_cast<uint32_t>(currOut[idOffset]);
+            currOut[idOffset] = *reinterpret_cast<float*>(&id);
         }
         if (this->haveTensor) {
             glm::mat3 rotate_world_into_tensor;

--- a/plugins/datatools/src/table/TableToParticles.cpp
+++ b/plugins/datatools/src/table/TableToParticles.cpp
@@ -42,7 +42,7 @@ TableToParticles::TableToParticles(void)
         , slotColumnX("xcolumnname", "The name of the column holding the x-coordinate.")
         , slotColumnY("ycolumnname", "The name of the column holding the y-coordinate.")
         , slotColumnZ("zcolumnname", "The name of the column holding the z-coordinate.")
-        , slotColumnID("idcolumnname", "The name of the column holding the particle id.")
+        , slotColumnID("idcolumnname", "The name of the column holding the particle id. Stored as uint32_t.")
         , slotColumnVX("direction::vxcolumnname", "The name of the column holding the vx-coordinate.")
         , slotColumnVY("direction::vycolumnname", "The name of the column holding the vy-coordinate.")
         , slotColumnVZ("direction::vzcolumnname", "The name of the column holding the vz-coordinate.")
@@ -360,9 +360,11 @@ bool TableToParticles::assertData(table::TableDataCall* ft, unsigned int frameID
 
     std::string c = cleanUpColumnHeader(this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString());
     haveIDs = this->columnIndex.find(c) != columnIndex.end();
+    size_t idOffset;
     if (haveIDs) {
         retValue = retValue && pushColumnIndex(indicesToCollect,
                                    this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString().c_str());
+        idOffset = indicesToCollect.size() - 1;
         stride += 1;
     }
 
@@ -448,6 +450,9 @@ bool TableToParticles::assertData(table::TableDataCall* ft, unsigned int frameID
         float* currOut = &everything[i * stride];
         for (uint32_t j = 0; j < numIndices; j++) {
             currOut[j] = ftData[cols * i + indicesToCollect[j]];
+        }
+        if (this->haveIDs) {
+            currOut[idOffset] = static_cast<uint32_t>(currOut[idOffset]);
         }
         if (this->haveTensor) {
             glm::mat3 rotate_world_into_tensor;

--- a/plugins/datatools/src/table/TableToParticles.cpp
+++ b/plugins/datatools/src/table/TableToParticles.cpp
@@ -325,6 +325,16 @@ bool TableToParticles::assertData(table::TableDataCall* ft, unsigned int frameID
     retValue = retValue && pushColumnIndex(indicesToCollect,
                                this->slotColumnZ.Param<core::param::FlexEnumParam>()->ValueString().c_str());
 
+    std::string c = cleanUpColumnHeader(this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString());
+    haveIDs = this->columnIndex.find(c) != columnIndex.end();
+    size_t idOffset;
+    if (haveIDs) {
+        retValue = retValue && pushColumnIndex(indicesToCollect,
+                                   this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString().c_str());
+        idOffset = indicesToCollect.size() - 1;
+        stride += 1;
+    }
+
     if (this->slotRadiusMode.Param<core::param::EnumParam>()->Value() == 0) { // particle
         if (!pushColumnIndex(
                 indicesToCollect, this->slotColumnRadius.Param<core::param::FlexEnumParam>()->ValueString().c_str())) {
@@ -356,16 +366,6 @@ bool TableToParticles::assertData(table::TableDataCall* ft, unsigned int frameID
         break;
     case 2: // global RGB
         break;
-    }
-
-    std::string c = cleanUpColumnHeader(this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString());
-    haveIDs = this->columnIndex.find(c) != columnIndex.end();
-    size_t idOffset;
-    if (haveIDs) {
-        retValue = retValue && pushColumnIndex(indicesToCollect,
-                                   this->slotColumnID.Param<core::param::FlexEnumParam>()->ValueString().c_str());
-        idOffset = indicesToCollect.size() - 1;
-        stride += 1;
     }
 
     bool vx, vy, vz;
@@ -611,6 +611,12 @@ bool TableToParticles::getMultiParticleData(core::Call& call) {
                     break;
                 }
 
+                if (haveIDs) {
+                    c->AccessParticles(0).SetIDData(geocalls::MultiParticleDataCall::Particles::IDDATA_UINT32,
+                        this->everything.data() + colOffset, static_cast<unsigned int>(stride * sizeof(float)));
+                    colOffset += 1;
+                }
+
                 switch (this->slotColorMode.Param<core::param::EnumParam>()->Value()) {
                 case 0: // RGB
                     c->AccessParticles(0).SetColourData(geocalls::MultiParticleDataCall::Particles::COLDATA_FLOAT_RGB,
@@ -625,10 +631,6 @@ bool TableToParticles::getMultiParticleData(core::Call& call) {
                     c->AccessParticles(0).SetColourData(
                         geocalls::MultiParticleDataCall::Particles::COLDATA_NONE, nullptr);
                     break;
-                }
-                if (haveIDs) {
-                    c->AccessParticles(0).SetIDData(geocalls::MultiParticleDataCall::Particles::IDDATA_UINT32,
-                        this->everything.data() + colOffset + 1, static_cast<unsigned int>(stride * sizeof(float)));
                 }
                 if (haveVelocities) {
                     c->AccessParticles(0).SetDirData(geocalls::MultiParticleDataCall::Particles::DIRDATA_FLOAT_XYZ,
@@ -676,6 +678,12 @@ bool TableToParticles::getMultiParticleData(core::Call& call) {
                     break;
                 }
 
+                if (haveIDs) {
+                    c->AccessParticles(0).SetIDData(geocalls::MultiParticleDataCall::Particles::IDDATA_UINT32,
+                        this->everything.data() + colOffset, static_cast<unsigned int>(stride * sizeof(float)));
+                    colOffset += 1;
+                }
+
                 switch (this->slotColorMode.Param<core::param::EnumParam>()->Value()) {
                 case 0: // RGB
                     e->AccessParticles(0).SetColourData(geocalls::MultiParticleDataCall::Particles::COLDATA_FLOAT_RGB,
@@ -695,10 +703,6 @@ bool TableToParticles::getMultiParticleData(core::Call& call) {
                 //    e->AccessParticles(0).SetDirData(geocalls::MultiParticleDataCall::Particles::DIRDATA_FLOAT_XYZ,
                 //        this->everything.data() + (stride - 3), static_cast<unsigned int>(stride * sizeof(float)));
                 //}
-                if (haveIDs) {
-                    c->AccessParticles(0).SetIDData(geocalls::MultiParticleDataCall::Particles::IDDATA_UINT32,
-                        this->everything.data() + colOffset + 1, static_cast<unsigned int>(stride * sizeof(float)));
-                }
 
                 if (haveTensor) {
                     e->AccessParticles(0).SetRadData(

--- a/plugins/datatools/src/table/TableToParticles.h
+++ b/plugins/datatools/src/table/TableToParticles.h
@@ -144,6 +144,9 @@ private:
     /** The name of the float column holding the z-coordinate. */
     core::param::ParamSlot slotColumnZ;
 
+    /** The name of the int column holding the particle id. */
+    core::param::ParamSlot slotColumnID;
+
     /** The name of the float column holding the vx-coordinate. */
     core::param::ParamSlot slotColumnVX;
 
@@ -164,6 +167,7 @@ private:
 
     std::vector<float> everything;
 
+    bool haveIDs = false;
     bool haveVelocities = false;
     bool haveTensor = false;
     bool haveTensorMagnitudes = false;


### PR DESCRIPTION
<!--Add a description here.
Include a list of issues it fixes in the "Fixes #[]" format if applicable.-->
The `TableToParticles` module was missing the capability to output the particle ids even if they are given in the table.
This was fixed with this PR.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->
- Added ability to output ids from the `TableToParticles` module

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
