### PR TITLE
Added support for IDs and velocities in ADIOSFlexConverter

### DIFF
--- a/plugins/mmadios/src/ADIOSFlexConvert.h
+++ b/plugins/mmadios/src/ADIOSFlexConvert.h
@@ -87,6 +87,10 @@ private:
     core::param::ParamSlot flexYSlot;
     core::param::ParamSlot flexZSlot;
     core::param::ParamSlot flexAlignedPosSlot;
+    core::param::ParamSlot flexIDSlot;
+    core::param::ParamSlot flexVXSlot;
+    core::param::ParamSlot flexVYSlot;
+    core::param::ParamSlot flexVZSlot;
 
 
     std::vector<float> mix;
@@ -96,6 +100,7 @@ private:
     geocalls::SimpleSphericalParticles::ColourDataType colType = geocalls::SimpleSphericalParticles::COLDATA_NONE;
     geocalls::SimpleSphericalParticles::VertexDataType vertType = geocalls::SimpleSphericalParticles::VERTDATA_NONE;
     geocalls::SimpleSphericalParticles::IDDataType idType = geocalls::SimpleSphericalParticles::IDDATA_NONE;
+    geocalls::SimpleSphericalParticles::DirDataType dirType = geocalls::SimpleSphericalParticles::DIRDATA_NONE;
 
     size_t stride = 0;
 


### PR DESCRIPTION
<!--Add a description here.
Include a list of issues it fixes in the "Fixes #[]" format if applicable.-->
The `ADIOSFlexConverter` was missing some options to select the velocity and/or ID sources of the particles. This PR adds the functionality to the existing module.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->
- Added ID and velocity source selection to the `ADIOSFlexConverter` module

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
