### PR TITLE
Graph Param Subscription Fixes

### DIFF
--- a/core/include/mmcore/MegaMolGraph.h
+++ b/core/include/mmcore/MegaMolGraph.h
@@ -90,6 +90,8 @@ public:
 
     frontend_resources::MegaMolGraph_SubscriptionRegistry& GraphSubscribers();
 
+    bool Broadcast_graph_subscribers_parameter_changes();
+
 private:
     [[nodiscard]] ModuleList_t::iterator find_module(std::string const& name);
     [[nodiscard]] ModuleList_t::iterator find_module_by_prefix(std::string const& name);
@@ -133,6 +135,16 @@ private:
     MegaMolGraph_Convenience convenience_functions;
 
     frontend_resources::MegaMolGraph_SubscriptionRegistry graph_subscribers;
+
+    // module params may change their internal value on their own
+    // the graph uses the AbstractParam::indicateChange() mechanism to inject
+    // a callback that notifies the graph of param changes.
+    // these parameter changes get collected in the following queue and are issued to graph subscribers when possible.
+    std::vector<core::param::AbstractParamSlot*> module_param_changes_queue;
+    core::param::AbstractParam::ParamChangeCallback param_change_callback = [&](core::param::AbstractParamSlot* slot) {
+        module_param_changes_queue.push_back(slot);
+        return true;
+    };
 };
 
 

--- a/core/include/mmcore/param/AbstractParam.h
+++ b/core/include/mmcore/param/AbstractParam.h
@@ -17,6 +17,8 @@
 #include "vislib/String.h"
 #include "vislib/tchar.h"
 
+#include <functional>
+
 
 namespace megamol {
 namespace core {
@@ -33,6 +35,8 @@ class AbstractParamSlot;
 class AbstractParam : public AbstractParamPresentation {
 public:
     friend class AbstractParamSlot;
+
+    using ParamChangeCallback = std::function<void(AbstractParamSlot*)>;
 
     /**
      * Dtor.
@@ -101,6 +105,10 @@ public:
         return val;
     }
 
+    void setChangeCallback(ParamChangeCallback const& callback) {
+        this->change_callback = callback;
+    }
+
 protected:
     /**
      * Ctor.
@@ -120,6 +128,7 @@ protected:
      */
     void indicateChange() {
         has_changed = true;
+        change_callback(slot);
     }
 
 private:
@@ -136,6 +145,14 @@ private:
      * Indicating that the value has changed.
      */
     bool has_changed;
+
+    /**
+     * The change callback is set by the MegaMol Graph/Frontend as a notification mechanism
+     * to be made aware of module-driven or other parameters changes not made via the lua parameter setter function
+     */
+    ParamChangeCallback change_callback = [](auto*) {
+        // needs default init for randomly created modules/params not to crash for default SetValue() calls
+    };
 };
 
 

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -218,17 +218,46 @@ bool megamol::core::MegaMolGraph::SetParameter(std::string const& paramName, std
     if (!param_ptr)
         return false;
 
+    // unused since generic param changes mechanism does not allow passing 'old value' to graph subscribers
     auto old_value = param_ptr->ValueString();
 
     bool success = param_ptr->ParseValue(value);
 
+    // param changes are queued in the graphs parameter changes queue
+    // and get passed to graph subscribers at beginning of each frame by the Lua Service
+    // using MegaMolGraph::Broadcast_graph_subscribers_parameter_changes()
+
     if (!success)
         return false;
 
+    return true;
+}
+
+bool megamol::core::MegaMolGraph::Broadcast_graph_subscribers_parameter_changes() {
     for (auto& subscriber : graph_subscribers.subscribers) {
-        if (!subscriber.ParameterChanged(param_slot_ptr, old_value, value)) {
-            log_error("graph subscriber " + subscriber.Name() + " failed to process parameter change: " + paramName +
-                      " from " + old_value + " to " + value);
+
+        for (megamol::core::param::AbstractParamSlot* changed_param_ptr : module_param_changes_queue) {
+            if (!changed_param_ptr) {
+                log_error("AbstractParamSlot* of a changed module parameter turned out nullptr. can not propagate "
+                          "changed param value to graph subscribers.");
+                return false;
+            }
+
+            auto param_value = changed_param_ptr->Parameter()->ValueString();
+            param::ParamSlot* param_slot_ptr = dynamic_cast<param::ParamSlot*>(changed_param_ptr);
+
+            if (!param_slot_ptr) {
+                log_error(" casting AbstractParamSlot* to ParamSlot* failed. Can not propagate changed param value " +
+                          param_value + " to graph subscribers");
+                return false;
+            }
+
+            auto param_name = std::string{param_slot_ptr->FullName().PeekBuffer()};
+
+            if (!subscriber.ParameterChanged(param_slot_ptr, param_value)) {
+                log_error("graph subscriber " + subscriber.Name() +
+                          " failed to process parameter change: " + param_name + " to " + param_value);
+            }
         }
     }
 
@@ -549,6 +578,7 @@ bool megamol::core::MegaMolGraph::add_module(ModuleInstantiationRequest_t const&
     std::vector<ParamSlotPtr> param_ptrs = module_ptr->GetSlots<std::remove_pointer<ParamSlotPtr>::type>();
     for (auto& param_ptr : param_ptrs) {
         assert(param_ptr != nullptr);
+        param_ptr->Parameter()->setChangeCallback(this->param_change_callback);
     }
     for (auto& subscriber : graph_subscribers.subscribers) {
         if (!subscriber.AddParameters(param_ptrs)) {

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -257,9 +257,12 @@ bool megamol::core::MegaMolGraph::Broadcast_graph_subscribers_parameter_changes(
             if (!subscriber.ParameterChanged(param_slot_ptr, param_value)) {
                 log_error("graph subscriber " + subscriber.Name() +
                           " failed to process parameter change: " + param_name + " to " + param_value);
+                return false;
             }
         }
     }
+
+    module_param_changes_queue.clear();
 
     return true;
 }

--- a/core/src/MegaMolGraph.cpp
+++ b/core/src/MegaMolGraph.cpp
@@ -403,6 +403,14 @@ bool megamol::core::MegaMolGraph::SetGraphEntryPoint(std::string module) {
     module_it->isGraphEntryPoint = true;
     log("set graph entry point: " + moduleName);
 
+    for (auto& subscriber : graph_subscribers.subscribers) {
+        if (!subscriber.EnableEntryPoint(*module_it)) {
+            log_error("graph subscriber " + subscriber.Name() + " failed to process enabling entry point " +
+                      module_it->request.id);
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -430,6 +438,14 @@ bool megamol::core::MegaMolGraph::RemoveGraphEntryPoint(std::string module) {
 
     module_it->isGraphEntryPoint = false;
     log("remove graph entry point: " + moduleName);
+
+    for (auto& subscriber : graph_subscribers.subscribers) {
+        if (!subscriber.DisableEntryPoint(*module_it)) {
+            log_error("graph subscriber " + subscriber.Name() + " failed to process disabling entry point " +
+                      module_it->request.id);
+            return false;
+        }
+    }
 
     return true;
 }

--- a/frontend/resources/include/ModuleGraphSubscription.h
+++ b/frontend/resources/include/ModuleGraphSubscription.h
@@ -94,6 +94,16 @@ public:
      * The call still exists and will be deleted soon after execution of this callback.
      */
     std::function<bool(core::CallInstance_t const&)> DeleteCall = [](auto const&) { return true; };
+
+    /**
+     * Informs about a graph module (view) becoming a graph entry point, a graph module that is poked for rendering
+     */
+    std::function<bool(core::ModuleInstance_t const&)> EnableEntryPoint = [](auto const&) { return true; };
+
+    /**
+     * Informs about a graph module (view) becoming disabled as an entry point
+     */
+    std::function<bool(core::ModuleInstance_t const&)> DisableEntryPoint = [](auto const&) { return true; };
 };
 
 struct MegaMolGraph_SubscriptionRegistry {

--- a/frontend/resources/include/ModuleGraphSubscription.h
+++ b/frontend/resources/include/ModuleGraphSubscription.h
@@ -69,13 +69,12 @@ public:
     };
 
     /**
-     * Notifies subscriber about change of a paramter value, providing the parameter, its new value, and the old value.
+     * Notifies subscriber about change of a paramter value, providing the parameter and its new value.
      * Gets called after parameter value changed to new value.
      * All ParamSlotPtr values are non-null.
      */
-    std::function<bool(
-        ParamSlotPtr const& /*param*/, std::string const& /*old_value*/, std::string const& /*new_value*/)>
-        ParameterChanged = [](auto const&, auto const&, auto const&) { return true; };
+    std::function<bool(ParamSlotPtr const& /*param*/, std::string const& /*new_value*/)> ParameterChanged =
+        [](auto const&, auto const&) { return true; };
 
     /**
      * Informs about renaming of a module.

--- a/frontend/services/gui/src/GUIManager.h
+++ b/frontend/services/gui/src/GUIManager.h
@@ -296,6 +296,12 @@ public:
     bool NotifyRunningGraph_DeleteCall(core::CallInstance_t const& call_inst) {
         return this->win_configurator_ptr->GetGraphCollection().NotifyRunningGraph_DeleteCall(call_inst);
     }
+    bool NotifyRunningGraph_EnableEntryPoint(core::ModuleInstance_t const& module_inst) {
+        return this->win_configurator_ptr->GetGraphCollection().NotifyRunningGraph_EnableEntryPoint(module_inst);
+    }
+    bool NotifyRunningGraph_DisableEntryPoint(core::ModuleInstance_t const& module_inst) {
+        return this->win_configurator_ptr->GetGraphCollection().NotifyRunningGraph_DisableEntryPoint(module_inst);
+    }
 
     ///////////////////////////////////////////////////////////////////////
 

--- a/frontend/services/gui/src/GUIManager.h
+++ b/frontend/services/gui/src/GUIManager.h
@@ -286,9 +286,9 @@ public:
     }
     bool NotifyRunningGraph_ParameterChanged(
         megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr const& param_slot,
-        std::string const& old_value, std::string const& new_value) {
+        std::string const& new_value) {
         return this->win_configurator_ptr->GetGraphCollection().NotifyRunningGraph_ParameterChanged(
-            param_slot, old_value, new_value);
+            param_slot, new_value);
     }
     bool NotifyRunningGraph_AddCall(core::CallInstance_t const& call_inst) {
         return this->win_configurator_ptr->GetGraphCollection().NotifyRunningGraph_AddCall(call_inst);

--- a/frontend/services/gui/src/GUI_Service.cpp
+++ b/frontend/services/gui/src/GUI_Service.cpp
@@ -397,9 +397,8 @@ void GUI_Service::setRequestedResources(std::vector<FrontendResource> resources)
         };
     gui_subscription.ParameterChanged =
         [&](megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr const& param_slot,
-            std::string const& old_value, std::string const& new_value) {
-            return m_gui->NotifyRunningGraph_ParameterChanged(param_slot, old_value, new_value);
-        };
+            std::string const& new_value) { return m_gui->NotifyRunningGraph_ParameterChanged(param_slot, new_value); };
+
     gui_subscription.AddCall = [&](core::CallInstance_t const& call_inst) {
         return m_gui->NotifyRunningGraph_AddCall(call_inst);
     };

--- a/frontend/services/gui/src/GUI_Service.cpp
+++ b/frontend/services/gui/src/GUI_Service.cpp
@@ -405,6 +405,12 @@ void GUI_Service::setRequestedResources(std::vector<FrontendResource> resources)
     gui_subscription.DeleteCall = [&](core::CallInstance_t const& call_inst) {
         return m_gui->NotifyRunningGraph_DeleteCall(call_inst);
     };
+    gui_subscription.EnableEntryPoint = [&](core::ModuleInstance_t const& module_inst) {
+        return m_gui->NotifyRunningGraph_EnableEntryPoint(module_inst);
+    };
+    gui_subscription.DisableEntryPoint = [&](core::ModuleInstance_t const& module_inst) {
+        return m_gui->NotifyRunningGraph_DisableEntryPoint(module_inst);
+    };
 
     megamolgraph_subscription.subscribe(gui_subscription);
 

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -436,7 +436,10 @@ bool megamol::gui::GraphCollection::SynchronizeGraphs(
                     std::get<0>((*input_lua_func)("mmDeleteCall([=[" + data.caller + "]=],[=[" + data.callee + "]=])"));
             } break;
             case (Graph::QueueAction::CREATE_GRAPH_ENTRY): {
-                (*input_lua_func)("mmSetGraphEntryPoint([=[" + data.name_id + "]=])");
+                // megamol currently does not handle well having multiple entrypoints active
+                (*input_lua_func)("mmRemoveAllGraphEntryPoints()\n"
+                                  "mmSetGraphEntryPoint([=[" +
+                                  data.name_id + "]=])");
             } break;
             case (Graph::QueueAction::REMOVE_GRAPH_ENTRY): {
                 (*input_lua_func)("mmRemoveGraphEntryPoint([=[" + data.name_id + "]=])");
@@ -1870,6 +1873,15 @@ bool megamol::gui::GraphCollection::NotifyRunningGraph_DeleteCall(core::CallInst
     return false;
 }
 
+bool megamol::gui::GraphCollection::NotifyRunningGraph_EnableEntryPoint(core::ModuleInstance_t const& module_inst) {
+    TODO EntryPoint subscription
+    //return false;
+}
+
+bool megamol::gui::GraphCollection::NotifyRunningGraph_DisableEntryPoint(core::ModuleInstance_t const& module_inst) {
+    TODO EntryPoint subscription
+    //return false;
+}
 
 bool megamol::gui::GraphCollection::save_graph_dialog(ImGuiID graph_uid, bool& open_dialog) {
 

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -1715,7 +1715,7 @@ bool megamol::gui::GraphCollection::NotifyRunningGraph_RemoveParameters(
 
 
 bool megamol::gui::GraphCollection::NotifyRunningGraph_ParameterChanged(
-    megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr const& param_slot, std::string const& old_value,
+    megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr const& param_slot,
     std::string const& new_value) {
 
     if (!this->initialized_syncing) {

--- a/frontend/services/gui/src/graph/GraphCollection.h
+++ b/frontend/services/gui/src/graph/GraphCollection.h
@@ -98,7 +98,7 @@ public:
         std::vector<megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr> const& param_slots);
     bool NotifyRunningGraph_ParameterChanged(
         megamol::frontend_resources::ModuleGraphSubscription::ParamSlotPtr const& param_slot,
-        std::string const& old_value, std::string const& new_value);
+        std::string const& new_value);
     bool NotifyRunningGraph_AddCall(core::CallInstance_t const& call_inst);
     bool NotifyRunningGraph_DeleteCall(core::CallInstance_t const& call_inst);
 

--- a/frontend/services/gui/src/graph/GraphCollection.h
+++ b/frontend/services/gui/src/graph/GraphCollection.h
@@ -101,6 +101,8 @@ public:
         std::string const& new_value);
     bool NotifyRunningGraph_AddCall(core::CallInstance_t const& call_inst);
     bool NotifyRunningGraph_DeleteCall(core::CallInstance_t const& call_inst);
+    bool NotifyRunningGraph_EnableEntryPoint(core::ModuleInstance_t const& module_inst);
+    bool NotifyRunningGraph_DisableEntryPoint(core::ModuleInstance_t const& module_inst);
 
 private:
     // VARIABLES --------------------------------------------------------------

--- a/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
+++ b/frontend/services/lua_service_wrapper/Lua_Service_Wrapper.cpp
@@ -181,6 +181,12 @@ void Lua_Service_Wrapper::setRequestedResources(std::vector<FrontendResource> re
         return;
 
 void Lua_Service_Wrapper::updateProvidedResources() {
+    // during the previous frame module parameters of the graph may have changed.
+    // submit the queued parameter changes to graph subscribers before other services do their thing
+    auto& graph = const_cast<megamol::core::MegaMolGraph&>(
+        m_requestedResourceReferences[5].getResource<megamol::core::MegaMolGraph>());
+    graph.Broadcast_graph_subscribers_parameter_changes();
+
     recursion_guard;
     // we want lua to be the first thing executed in main loop
     // so we do all the lua work here


### PR DESCRIPTION
Fixes broken graph subscription for parameters. 

Parameters not only change their values via lua calls, but also when modules do their normal thing.
For graph subscribers to be able to get notified of _all_ parameter changes (e.g. the GUI needs those), we hook ourselves into the `AbstractParameter.indicateChange()` mechanism and tell the graph about param those changes.

At the very beginning of the next frame, the lua service pokes the graph to broadcast all queued parameter changes to graph subscribers. 

**Entry Point Subscription**
This PR also implements graph subscriptions for entry points. This lets the GUI know when to switch entry points, and thus fixes issues e.g. with SplitView/View2D rendering in the infovis example when switching between views (entry points).

Note that this PR currently does not compile because the implementation of the entry point subscription in the GUI service is intentionally left empty.