### PR TITLE
Fixed ADIOSFlexConvert not handling the optional color correctly

### DIFF
--- a/plugins/mmadios/src/ADIOSFlexConvert.cpp
+++ b/plugins/mmadios/src/ADIOSFlexConvert.cpp
@@ -323,6 +323,7 @@ bool ADIOSFlexConvert::getDataCallback(core::Call& call) {
 
         size_t vel_offset = 0;
         size_t id_offset = 0;
+        size_t col_offset = 0;
 
         for (size_t i = 0; i < p_count; i++) {
             if (pos_str != "undef") {
@@ -339,10 +340,13 @@ bool ADIOSFlexConvert::getDataCallback(core::Call& call) {
                 mix[float_step * i + 2] = XYZW[4 * i + 2];
             }
 
+            size_t offset = 3;
             if (col_str != "undef") {
+                col_offset = offset;
                 mix[float_step * i + 3] = col[i];
                 imin = std::min(imin, col[i]);
                 imax = std::max(imax, col[i]);
+                offset += 1;
             }
             if (box_str == "undef") {
                 xmin = std::min(xmin, mix[float_step * i + 0]);
@@ -353,7 +357,6 @@ bool ADIOSFlexConvert::getDataCallback(core::Call& call) {
                 zmax = std::max(zmax, mix[float_step * i + 2]);
             }
 
-            size_t offset = 4;
             if (hasVel) {
                 vel_offset = offset;
                 mix[float_step * i + offset + 0] = VX[i];
@@ -383,7 +386,7 @@ bool ADIOSFlexConvert::getDataCallback(core::Call& call) {
         mpdc->AccessParticles(0).SetVertexData(vertType, mix.data(), stride);
         //mpdc->AccessParticles(0).SetColourData(
         //    colType, mix.data() + geocalls::SimpleSphericalParticles::VertexDataSize[vertType], stride);
-        mpdc->AccessParticles(0).SetColourData(colType, &mix[3], stride);
+        mpdc->AccessParticles(0).SetColourData(colType, &mix[col_offset], stride);
 
         mpdc->AccessParticles(0).SetColourMapIndexValues(imin, imax);
 


### PR DESCRIPTION
<!--Add a description here.
Include a list of issues it fixes in the "Fixes #[]" format if applicable.-->
This PR fixes a bug introduced by #1105 where if the color field was left blank, the stride of the data would be calculated correctly, whereas the offset would not.
This leads to an issue, if for example no color is given, the ID of one particle would be overwritten by the first item (e.g. position) of the next particle.

## Summary of Changes
<!--A list of changes that will be copied into the merge commit message and changelog.-->

## References and Context
<!--Optional. A list of references of this PR, for instance related PRs or scientific papers,
or any other context about this PR relevant for the devs.-->

## Test Instructions
<!--Optional. For large feature PRs, test instructions are required for the devs to review the PR.
Include, if possible, the expected behavior.-->
