### PR TITLE
Vcpkg optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ megamol_feature_option(MPI "Enable MPI support" OFF)
 megamol_feature_option(OPENGL "Enable OpenGL support" ON)
 megamol_feature_option(OSPRAY "Enable OSPRay support" OFF)
 megamol_feature_option(PROFILING "Enable profiling support" OFF)
+megamol_feature_option(VTKM "Enable VTK-m support" OFF)
 # dependent options
 megamol_feature_option(CUESDK "Enable Corsair CUESDK support" OFF "WIN32")
 megamol_feature_option(VR_INTEROP "Enable MegaMol-Unity VR Interop via Spout2" OFF "MEGAMOL_USE_OPENGL")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ find_package(Git REQUIRED)
 
 FetchContent_Declare(vcpkg-download
   GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
-  GIT_TAG 2022.08.15)
+  GIT_TAG 2022.08.15
+  GIT_SHALLOW TRUE)
 FetchContent_GetProperties(vcpkg-download)
 if (NOT vcpkg-download_POPULATED)
   message(STATUS "Fetch vcpkg ...")

--- a/plugins/mmvtkm/CMakeLists.txt
+++ b/plugins/mmvtkm/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 megamol_plugin(mmvtkm
   BUILD_DEFAULT OFF
+  DEPENDS_FEATURES
+    vtkm
   DEPENDS_PLUGINS
     mmstd
     PUBLIC mesh

--- a/plugins/mmvtkm_gl/CMakeLists.txt
+++ b/plugins/mmvtkm_gl/CMakeLists.txt
@@ -7,6 +7,7 @@ megamol_plugin(mmvtkm_gl
   BUILD_DEFAULT OFF
   DEPENDS_FEATURES
     opengl
+    vtkm
   DEPENDS_PLUGINS
     mmstd
     mmstd_gl

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -47,7 +47,6 @@
     "tinygltf",
     "tinyobjloader",
     "tinyply",
-    "vtk-m",
     "zeromq",
     "zfp",
     "zlib"
@@ -120,6 +119,12 @@
       "description": "Use VR Interop",
       "dependencies": [
         "mwk-mint-interop"
+      ]
+    },
+    "use-vtkm": {
+      "description": "Use VTK-m",
+      "dependencies": [
+        "vtk-m"
       ]
     }
   }


### PR DESCRIPTION
## Summary of Changes
- include VTK-m as feature
- shallow clone vcpkg for faster download
  - Fetching the vcpkg repo: ~15s for non shallow clone, ~9s for shallow clone, ~5s for archive download. Unfortunately vcpkg requires the git metadata for getting versioning baseline. Maybe if we in future want to use specific versions, a full clone would be required, but for now shallow clone seems good.