### PR TITLE
Update glowl

### DIFF
--- a/cmake/vcpkg_ports/glowl/portfile.cmake
+++ b/cmake/vcpkg_ports/glowl/portfile.cmake
@@ -1,15 +1,29 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO invor/glowl
-  REF dafee75f11c5d759df30ff651d6763e4e674dd0e
-  SHA512 e29524be04a5eb65c4cf41190392eb7b09632ef85cf0ede53a36f8af8a84eda3a21dde2fcce7f20a61b9a269c604b31e33537aa473e20d8385562eb62c032c82
+  REF e80ae434618d7a3b0056f2765dcca9d6d64c1db7
+  SHA512 d2db2e5d5753e157a1b6d394a7154a2bfe4d2b8410e7e0d65cbfc437c99c66b20fbcb57753ac7eddf8836e020c0208a4f2ce9fdeb751898e3bc507e6fb90e731
   HEAD_REF master
 )
+
+if ("glm" IN_LIST FEATURES)
+  set(USE_GLM ON)
+else ()
+  set(USE_GLM OFF)
+endif ()
+if ("gl-extensions" IN_LIST FEATURES)
+  set(USE_GL_EXT ON)
+else ()
+  set(USE_GL_EXT OFF)
+endif ()
 
 vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}
   OPTIONS
     -DGLOWL_OPENGL_INCLUDE=GLAD2
+    -DGLOWL_USE_GLM=${USE_GLM}
+    -DGLOWL_USE_ARB_BINDLESS_TEXTURE=${USE_GL_EXT}
+    -DGLOWL_USE_NV_MESH_SHADER=${USE_GL_EXT}
 )
 
 vcpkg_cmake_install()

--- a/cmake/vcpkg_ports/glowl/vcpkg.json
+++ b/cmake/vcpkg_ports/glowl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glowl",
-  "version-string": "0.4g",
+  "version-date": "2022-09-23",
   "port-version": 0,
   "description": "OpenGL Object-Wrapper-Library.",
   "homepage": "https://github.com/invor/glowl",
@@ -14,5 +14,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "glm": {
+      "description": "Use glm functions.",
+      "dependencies": [
+        "glm"
+      ]
+    },
+    "gl-extensions": {
+      "description": "Use ARB_bindless_texture and NV_mesh_shader extensions."
+    }
+  }
 }

--- a/plugins/mmstd_gl/src/upscaling/ResolutionScalerBase.h
+++ b/plugins/mmstd_gl/src/upscaling/ResolutionScalerBase.h
@@ -207,7 +207,7 @@ protected:
                 inter_tl_ = input_fbo_tl;
             }
 
-            if (scaled_fbo_->checkStatus(0) != GL_FRAMEBUFFER_COMPLETE) {
+            if (scaled_fbo_->checkStatus() != GL_FRAMEBUFFER_COMPLETE) {
                 megamol::core::utility::log::Log::DefaultLog.WriteError(
                     "The scaled_fbo_ in ResolutionScalerBase did not return GL_FRAMEBUFFER_COMPLETE");
                 return false;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -90,13 +90,19 @@
       "description": "Use OpenGL",
       "dependencies": [
         {
+          "name": "glowl",
+          "features": [
+            "glm",
+            "gl-extensions"
+          ]
+        },
+        {
           "name": "imgui",
           "features": [
             "opengl3-binding"
           ]
         },
-        "megamol-shader-factory",
-        "glowl"
+        "megamol-shader-factory"
       ]
     },
     "use-ospray": {


### PR DESCRIPTION
## Summary of Changes
- Update glowl
- MegaMol should work with RenderDoc again after this update if bindless texture is not explicitly used