### PR TITLE
Clang format update

### DIFF
--- a/.ci/check_format.sh
+++ b/.ci/check_format.sh
@@ -53,17 +53,17 @@ while read -r file; do
   # ClangFormat
   if [[ "$is_cpp" == true ]]; then
     if [[ $1 == "fix" ]]; then
-      clang-format-12 -i "$file"
+      clang-format-14 -i "$file"
     else
       # Workaround "set -e" and store exit code
       format_exit_code=0
-      output="$(clang-format-12 --dry-run --Werror "$file" 2>&1)" || format_exit_code=$?
+      output="$(clang-format-14 --dry-run --Werror "$file" 2>&1)" || format_exit_code=$?
       if [[ $format_exit_code -ne 0 ]]; then
         EXIT_CODE=1
         echo "::error::ClangFormat found issues in: $file"
         #echo "$output"
         # Show detailed diff. Requires ClangFormat to run again, but should mostly affect only a few files.
-        clang-format-12 "$file" | diff --color=always -u "$file" - || true
+        clang-format-14 "$file" | diff --color=always -u "$file" - || true
       fi
     fi
   fi

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   style_check:
     name: Style-Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Run format check
@@ -26,7 +26,7 @@ jobs:
           path: pr/
   plugin_check:
     name: Plugin-Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Run plugin check

--- a/.github/workflows/style_check_comment.yml
+++ b/.github/workflows/style_check_comment.yml
@@ -11,7 +11,7 @@ jobs:
   style_check_comment:
     name: Style-Check-Comment
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Download artifact

--- a/.github/workflows/style_fix.yml
+++ b/.github/workflows/style_fix.yml
@@ -6,7 +6,7 @@ jobs:
   style_fix:
     name: Style-Fix
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/format' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Get PR Info
         id: pr-info

--- a/core/src/CoreInstance.cpp
+++ b/core/src/CoreInstance.cpp
@@ -276,7 +276,9 @@ void megamol::core::CoreInstance::Initialise() {
                 } else {
                     profiler::Manager::Instance().SetMode(profiler::Manager::PROFILE_NONE);
                 }
-            } catch (...) { profiler::Manager::Instance().SetMode(profiler::Manager::PROFILE_NONE); }
+            } catch (...) {
+                profiler::Manager::Instance().SetMode(profiler::Manager::PROFILE_NONE);
+            }
         }
     } else {
         // Do not profile on default

--- a/core/src/utility/LuaHostService.cpp
+++ b/core/src/utility/LuaHostService.cpp
@@ -167,7 +167,9 @@ void megamol::core::utility::LuaHostService::serve() {
     } catch (std::exception& error) {
         Log::DefaultLog.WriteError("Error on LRH Server: %s", error.what());
 
-    } catch (...) { Log::DefaultLog.WriteError("Error on LRH Server: unknown exception"); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Error on LRH Server: unknown exception");
+    }
 
     try {
         socket.close();
@@ -216,7 +218,9 @@ void core::utility::LuaHostService::servePair() {
     } catch (std::exception& error) {
         Log::DefaultLog.WriteError("Error on LRH Pair Server: %s", error.what());
 
-    } catch (...) { Log::DefaultLog.WriteError("Error on LRH Pair Server: unknown exception"); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Error on LRH Pair Server: unknown exception");
+    }
 
     try {
         socket.close();

--- a/core/src/utility/xml/ConditionalParser.cpp
+++ b/core/src/utility/xml/ConditionalParser.cpp
@@ -586,12 +586,16 @@ bool ConditionalParser::evaluateCondition(
         if (tokenz[0].Equals("bitwidth", false)) {
             try {
                 return vislib::CharTraitsA::ParseInt(tokenz[2]) == int(vislib::sys::SystemInformation::SelfWordSize());
-            } catch (...) { return false; }
+            } catch (...) {
+                return false;
+            }
         }
         if (tokenz[2].Equals("bitwidth", false)) {
             try {
                 return vislib::CharTraitsA::ParseInt(tokenz[0]) == int(vislib::sys::SystemInformation::SelfWordSize());
-            } catch (...) { return false; }
+            } catch (...) {
+                return false;
+            }
         }
         if (tokenz[0].Equals("computer", false)) {
             return tokenz[2].Equals(vislib::sys::SystemInformation::ComputerNameA(), false);

--- a/core/src/view/CameraSerializer.cpp
+++ b/core/src/view/CameraSerializer.cpp
@@ -298,7 +298,9 @@ bool CameraSerializer::getCamFromJsonObject(Camera& cam, nlohmann::json::value_t
             //TODO
         }
 
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
     // TODO
     //  try {

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -643,7 +643,9 @@ std::vector<std::string> megamol::frontend::extract_config_file_paths(const int 
 
         return config_files;
 
-    } catch (cxxopts::OptionException ex) { exit(ex.what()); }
+    } catch (cxxopts::OptionException ex) {
+        exit(ex.what());
+    }
 }
 
 #define add_option(X) (std::get<0>(X), std::get<1>(X), std::get<2>(X))
@@ -832,7 +834,9 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_config(
                 }
             }
 
-        } catch (cxxopts::OptionException ex) { exit(std::string(ex.what()) + "\nIn file: " + file); }
+        } catch (cxxopts::OptionException ex) {
+            exit(std::string(ex.what()) + "\nIn file: " + file);
+        }
 
         config.configuration_file_contents.push_back(file_contents);
         config.configuration_file_contents_as_cli.push_back(
@@ -882,7 +886,9 @@ megamol::frontend_resources::RuntimeConfig megamol::frontend::handle_cli(
             }
         }
 
-    } catch (cxxopts::OptionException ex) { exit(std::string(ex.what()) + "\n" + options.help({""})); }
+    } catch (cxxopts::OptionException ex) {
+        exit(std::string(ex.what()) + "\n" + options.help({""}));
+    }
 
     return config;
 }

--- a/frontend/services/lua_service_wrapper/LuaRemoteConnectionsBroker.h
+++ b/frontend/services/lua_service_wrapper/LuaRemoteConnectionsBroker.h
@@ -157,7 +157,9 @@ public:
 
         try {
             socket.close();
-        } catch (...) { Log::DefaultLog.WriteInfo("LRH Server socket close threw exception"); }
+        } catch (...) {
+            Log::DefaultLog.WriteInfo("LRH Server socket close threw exception");
+        }
         Log::DefaultLog.WriteInfo("LRH Server socket closed");
     }
 
@@ -228,7 +230,9 @@ public:
         } catch (std::exception& error) {
             Log::DefaultLog.WriteError("Error on LRH Pair Server: %s", error.what());
 
-        } catch (...) { Log::DefaultLog.WriteError("Error on LRH Pair Server: unknown exception"); }
+        } catch (...) {
+            Log::DefaultLog.WriteError("Error on LRH Pair Server: unknown exception");
+        }
 
         try {
             socket.close();

--- a/frontend/services/remote_service/comm/FBOCommFabric.cpp
+++ b/frontend/services/remote_service/comm/FBOCommFabric.cpp
@@ -97,7 +97,9 @@ bool megamol::remote::ZMQCommFabric::Bind(std::string const& address) {
         bound_ = true;
         // this->socket_.setsockopt(ZMQ_CONFLATE, true);
         this->socket_.setsockopt(ZMQ_LINGER, 0);
-    } catch (zmq::error_t const& e) { printf("ZMQ ERROR: %s", e.what()); }
+    } catch (zmq::error_t const& e) {
+        printf("ZMQ ERROR: %s", e.what());
+    }
     return this->socket_.connected();
 }
 

--- a/frontend/services/vr_service/VR_Service.cpp
+++ b/frontend/services/vr_service/VR_Service.cpp
@@ -171,7 +171,7 @@ void VR_Service::setRequestedResources(std::vector<FrontendResource> resources) 
     m_entry_points_registry.rename_entry_point = [&](auto const& name, auto const& newname) -> bool { return true; };
     m_entry_points_registry.clear_entry_points = [&]() -> void { vr_device(clear_entry_points()); };
     m_entry_points_registry.subscribe_to_entry_point_changes = [&](auto const& func) -> void {};
-    m_entry_points_registry.get_entry_point = [&](std::string const& name) -> auto {
+    m_entry_points_registry.get_entry_point = [&](std::string const& name) -> auto{
         return std::nullopt;
     };
 

--- a/plugins/cluster/src/ClusterController.cpp
+++ b/plugins/cluster/src/ClusterController.cpp
@@ -118,7 +118,9 @@ void cluster::ClusterController::SendUserMsg(const UINT32 msgType, const BYTE* m
         }
     } catch (vislib::Exception ex) {
         Log::DefaultLog.WriteError("Failed to send user message %u: %s\n", msgType, ex.GetMsgA());
-    } catch (...) { Log::DefaultLog.WriteError("Failed to send user message %u: unknown exception\n", msgType); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Failed to send user message %u: unknown exception\n", msgType);
+    }
 }
 
 
@@ -136,7 +138,9 @@ void cluster::ClusterController::SendUserMsg(const cluster::ClusterController::P
         }
     } catch (vislib::Exception ex) {
         Log::DefaultLog.WriteError("Failed to send user message %u: %s\n", msgType, ex.GetMsgA());
-    } catch (...) { Log::DefaultLog.WriteError("Failed to send user message %u: unknown exception\n", msgType); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Failed to send user message %u: unknown exception\n", msgType);
+    }
 }
 
 
@@ -382,7 +386,9 @@ void cluster::ClusterController::OnUserMessage(vislib::net::cluster::DiscoverySe
         }
     } catch (vislib::Exception ex) {
         VLTRACE(VISLIB_TRCELVL_ERROR, "Illegal vislib exception in OnUserMessage \"%s\"\n", ex.GetMsgA());
-    } catch (...) { VLTRACE(VISLIB_TRCELVL_ERROR, "Illegal exception in OnUserMessage\n"); }
+    } catch (...) {
+        VLTRACE(VISLIB_TRCELVL_ERROR, "Illegal exception in OnUserMessage\n");
+    }
 }
 
 

--- a/plugins/cluster/src/mpi/MpiProvider.cpp
+++ b/plugins/cluster/src/mpi/MpiProvider.cpp
@@ -98,7 +98,9 @@ bool megamol::core::cluster::mpi::MpiProvider::OnCallProvideMpi(Call& call) {
             return false;
         }
 
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
 #else  /* MEGAMOL_USE_MPI */
     return false;

--- a/plugins/datatools/src/OverrideParticleGlobals.cpp
+++ b/plugins/datatools/src/OverrideParticleGlobals.cpp
@@ -87,7 +87,9 @@ bool datatools::OverrideParticleGlobals::manipulateData(
     try {
         vislib::graphics::ColourParser::FromString(
             this->colorSlot.Param<core::param::StringParam>()->Value().c_str(), color[0], color[1], color[2], color[3]);
-    } catch (...) { ::memset(color, 0, 4); }
+    } catch (...) {
+        ::memset(color, 0, 4);
+    }
 
     outData = inData; // also transfers the unlocker to 'outData'
 

--- a/plugins/datatools/src/io/CPERAWDataSource.cpp
+++ b/plugins/datatools/src/io/CPERAWDataSource.cpp
@@ -184,7 +184,9 @@ bool CPERAWDataSource::getDataCallback(core::Call& c) {
             mdc->SetParticleListCount(0);
             return true;
         }
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
     return true;
 }
@@ -218,7 +220,9 @@ bool CPERAWDataSource::getExtentCallback(core::Call& c) {
         } else {
             return false;
         }
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
     return true;
 }

--- a/plugins/infovis/src/DiagramSeries.cpp
+++ b/plugins/infovis/src/DiagramSeries.cpp
@@ -102,7 +102,9 @@ bool megamol::infovis::DiagramSeries::seriesSelectionCB(core::Call& c) {
                 return false;
             }
         }
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
     return true;
 }

--- a/plugins/infovis_gl/src/ScatterplotMatrixRenderer2D.cpp
+++ b/plugins/infovis_gl/src/ScatterplotMatrixRenderer2D.cpp
@@ -462,7 +462,9 @@ bool ScatterplotMatrixRenderer2D::Render(mmstd_gl::CallRender2DGL& call) {
 
         this->drawScreen();
 
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 
     return true;
 }

--- a/plugins/mmospray/src/AbstractOSPRayRenderer.cpp
+++ b/plugins/mmospray/src/AbstractOSPRayRenderer.cpp
@@ -225,7 +225,9 @@ void AbstractOSPRayRenderer::setupOSPRay(const char* renderer_name) {
 
             return ret_tex;
 
-        } catch (std::runtime_error e) { std::cerr << e.what() << std::endl; }
+        } catch (std::runtime_error e) {
+            std::cerr << e.what() << std::endl;
+        }
     } else {
         std::cerr << "File type not supported. Only PPM file format allowed." << std::endl;
     }

--- a/plugins/mmstd/src/special/StubModule.cpp
+++ b/plugins/mmstd/src/special/StubModule.cpp
@@ -49,7 +49,9 @@ bool megamol::core::special::StubModule::stub(Call& c) {
             for (unsigned int idx = 0; idx < cd->FunctionCount(); idx++) {
                 try {
                     this->inSlot.Call(idx);
-                } catch (...) { return false; }
+                } catch (...) {
+                    return false;
+                }
             }
         }
     }

--- a/plugins/mmstd/src/view/AbstractView.cpp
+++ b/plugins/mmstd/src/view/AbstractView.cpp
@@ -346,7 +346,9 @@ bool view::AbstractView::OnKeyCallback(Call& call) {
         auto& evt = cr.GetInputEvent();
         ASSERT(evt.tag == InputEvent::Tag::Key && "Callback invocation mismatched input event");
         return this->OnKey(evt.keyData.key, evt.keyData.action, evt.keyData.mods);
-    } catch (...) { ASSERT("OnKeyCallback call cast failed\n"); }
+    } catch (...) {
+        ASSERT("OnKeyCallback call cast failed\n");
+    }
     return false;
 }
 
@@ -356,7 +358,9 @@ bool view::AbstractView::OnCharCallback(Call& call) {
         auto& evt = cr.GetInputEvent();
         ASSERT(evt.tag == InputEvent::Tag::Char && "Callback invocation mismatched input event");
         return this->OnChar(evt.charData.codePoint);
-    } catch (...) { ASSERT("OnCharCallback call cast failed\n"); }
+    } catch (...) {
+        ASSERT("OnCharCallback call cast failed\n");
+    }
     return false;
 }
 
@@ -366,7 +370,9 @@ bool view::AbstractView::OnMouseButtonCallback(Call& call) {
         auto& evt = cr.GetInputEvent();
         ASSERT(evt.tag == InputEvent::Tag::MouseButton && "Callback invocation mismatched input event");
         return this->OnMouseButton(evt.mouseButtonData.button, evt.mouseButtonData.action, evt.mouseButtonData.mods);
-    } catch (...) { ASSERT("OnMouseButtonCallback call cast failed\n"); }
+    } catch (...) {
+        ASSERT("OnMouseButtonCallback call cast failed\n");
+    }
     return false;
 }
 
@@ -376,7 +382,9 @@ bool view::AbstractView::OnMouseMoveCallback(Call& call) {
         auto& evt = cr.GetInputEvent();
         ASSERT(evt.tag == InputEvent::Tag::MouseMove && "Callback invocation mismatched input event");
         return this->OnMouseMove(evt.mouseMoveData.x, evt.mouseMoveData.y);
-    } catch (...) { ASSERT("OnMouseMoveCallback call cast failed\n"); }
+    } catch (...) {
+        ASSERT("OnMouseMoveCallback call cast failed\n");
+    }
     return false;
 }
 
@@ -386,7 +394,9 @@ bool view::AbstractView::OnMouseScrollCallback(Call& call) {
         auto& evt = cr.GetInputEvent();
         ASSERT(evt.tag == InputEvent::Tag::MouseScroll && "Callback invocation mismatched input event");
         return this->OnMouseScroll(evt.mouseScrollData.dx, evt.mouseScrollData.dy);
-    } catch (...) { ASSERT("OnMouseScrollCallback call cast failed\n"); }
+    } catch (...) {
+        ASSERT("OnMouseScrollCallback call cast failed\n");
+    }
     return false;
 }
 

--- a/plugins/moldyn/src/io/AbstractSimpleStoringParticleDataSource.cpp
+++ b/plugins/moldyn/src/io/AbstractSimpleStoringParticleDataSource.cpp
@@ -57,7 +57,9 @@ void AbstractSimpleStoringParticleDataSource::assertData(bool needLoad) {
         } catch (vislib::Exception ex) {
             megamol::core::utility::log::Log::DefaultLog.WriteError(
                 "Exception: %s [%s, %d]\n", ex.GetMsgA(), ex.GetFile(), ex.GetLine());
-        } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("Unexpected exception"); }
+        } catch (...) {
+            megamol::core::utility::log::Log::DefaultLog.WriteError("Unexpected exception");
+        }
     }
 }
 

--- a/plugins/moldyn/src/io/IMDAtomDataSource.cpp
+++ b/plugins/moldyn/src/io/IMDAtomDataSource.cpp
@@ -248,7 +248,9 @@ private:
             this->pos = 0;
             try {
                 return (this->file.Read(dst, size) == size);
-            } catch (...) { return false; }
+            } catch (...) {
+                return false;
+            }
         }
 
         try {
@@ -286,7 +288,9 @@ private:
             try {
                 this->file.Seek(size, vislib::sys::File::CURRENT);
                 return true;
-            } catch (...) { return false; }
+            } catch (...) {
+                return false;
+            }
         }
 
         try { // read into buffer
@@ -352,7 +356,9 @@ public:
         const char* c = this->sift(fail);
         try {
             return static_cast<UINT32>(vislib::CharTraitsA::ParseInt(c));
-        } catch (...) { fail = true; }
+        } catch (...) {
+            fail = true;
+        }
         return 0;
     }
 
@@ -368,7 +374,9 @@ public:
         const char* c = this->sift(fail);
         try {
             return static_cast<float>(vislib::CharTraitsA::ParseDouble(c));
-        } catch (...) { fail = true; }
+        } catch (...) {
+            fail = true;
+        }
         return 0.0f;
     }
 
@@ -1405,7 +1413,9 @@ bool IMDAtomDataSource::readHeader(vislib::sys::File& file, IMDAtomDataSource::H
 
     } catch (vislib::Exception ex) {
         Log::DefaultLog.WriteError("Failed to parse IMD header: %s\n", ex.GetMsgA());
-    } catch (...) { Log::DefaultLog.WriteError("Failed to parse IMD header: unexpected exception\n"); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Failed to parse IMD header: unexpected exception\n");
+    }
 
     return false;
 }
@@ -1527,7 +1537,9 @@ bool IMDAtomDataSource::readData(
                         static_cast<int>(header.captions.Count()) - 1);
                     typecolumn = UINT_MAX;
                 }
-            } catch (...) { typecolumn = UINT_MAX; }
+            } catch (...) {
+                typecolumn = UINT_MAX;
+            }
         }
 
         if (typecolumn == UINT_MAX) {
@@ -1568,7 +1580,9 @@ bool IMDAtomDataSource::readData(
                         static_cast<int>(header.captions.Count()) - 1);
                     colcolumn = UINT_MAX;
                 }
-            } catch (...) { colcolumn = UINT_MAX; }
+            } catch (...) {
+                colcolumn = UINT_MAX;
+            }
         }
 
         if (colcolumn == UINT_MAX) {
@@ -1606,7 +1620,9 @@ bool IMDAtomDataSource::readData(
                         static_cast<int>(header.captions.Count()) - 1);
                     dircolcolumn = UINT_MAX;
                 }
-            } catch (...) { dircolcolumn = UINT_MAX; }
+            } catch (...) {
+                dircolcolumn = UINT_MAX;
+            }
         }
         if (dircolcolumn == UINT_MAX) {
             megamol::core::utility::log::Log::DefaultLog.WriteError(

--- a/plugins/moldyn/src/io/MMSPDDataSource.cpp
+++ b/plugins/moldyn/src/io/MMSPDDataSource.cpp
@@ -1895,7 +1895,9 @@ bool MMSPDDataSource::filenameChanged(core::param::ParamSlot& slot) {
                 try {
                     UINT64 pc = vislib::CharTraitsA::ParseUInt64(ln);
                     pcnt = vislib::math::Max(pcnt, pc);
-                } catch (...) { _ERROR_OUT("Frame marker error"); }
+                } catch (...) {
+                    _ERROR_OUT("Frame marker error");
+                }
             }
 
             dataSizeInMem = static_cast<SIZE_T>(pcnt * maxFields * sizeof(float));

--- a/plugins/moldyn/src/io/SIFFWriter.cpp
+++ b/plugins/moldyn/src/io/SIFFWriter.cpp
@@ -242,7 +242,9 @@ bool SIFFWriter::run(void) {
         Log::DefaultLog.WriteInfo("Completed writing data\n");
     } catch (Exception ex) {
         Log::DefaultLog.WriteError("Failed to write: %s (%s, %d)\n", ex.GetMsgA(), ex.GetFile(), ex.GetLine());
-    } catch (...) { Log::DefaultLog.WriteError("Failed to write: unexpected exception\n"); }
+    } catch (...) {
+        Log::DefaultLog.WriteError("Failed to write: unexpected exception\n");
+    }
     file.Close();
 
     return true;

--- a/plugins/moldyn/src/io/VIMDataSource.cpp
+++ b/plugins/moldyn/src/io/VIMDataSource.cpp
@@ -105,7 +105,9 @@ bool VIMDataSource::Frame::LoadFrame(
 
     try {
         lScale = static_cast<float>(vislib::CharTraitsA::ParseDouble(startLine.PeekBuffer()));
-    } catch (...) { lScale = 1.0f; }
+    } catch (...) {
+        lScale = 1.0f;
+    }
 
     this->frame = idx;
 
@@ -797,7 +799,9 @@ bool VIMDataSource::readHeader(const vislib::TString& filename) {
                     types.Last() = *element;
                 }
                 element = NULL;
-            } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("Error parsing type line."); }
+            } catch (...) {
+                megamol::core::utility::log::Log::DefaultLog.WriteError("Error parsing type line.");
+            }
             SAFE_DELETE(element);
         } else if (line[0] == '>') {
             // very extream file redirection

--- a/plugins/moldyn/src/io/VisIttDataSource.cpp
+++ b/plugins/moldyn/src/io/VisIttDataSource.cpp
@@ -240,7 +240,9 @@ void VisIttDataSource::loadFrame(core::view::AnimDataModule::Frame* frame, unsig
             line[end] = 0;
             try {
                 typeId = vislib::CharTraitsA::ParseInt(line + start);
-            } catch (...) { typeId = 0; }
+            } catch (...) {
+                typeId = 0;
+            }
             line[end] = endChar;
         }
 
@@ -256,7 +258,9 @@ void VisIttDataSource::loadFrame(core::view::AnimDataModule::Frame* frame, unsig
             line[end] = 0;
             try {
                 pid = static_cast<unsigned int>(vislib::CharTraitsA::ParseInt(line + start));
-            } catch (...) { pid = static_cast<unsigned int>(pids[typeId].size()); }
+            } catch (...) {
+                pid = static_cast<unsigned int>(pids[typeId].size());
+            }
             line[end] = endChar;
             pids[typeId].push_back(
                 std::pair<unsigned int, unsigned int>(static_cast<unsigned int>(pids[typeId].size()), pid));
@@ -278,7 +282,9 @@ void VisIttDataSource::loadFrame(core::view::AnimDataModule::Frame* frame, unsig
             line[end] = 0;
             try {
                 pos[j] = static_cast<float>(vislib::CharTraitsA::ParseDouble(line + start));
-            } catch (...) { pos[j] = 0.0f; }
+            } catch (...) {
+                pos[j] = 0.0f;
+            }
             line[end] = endChar;
         }
     }

--- a/plugins/molsurfmapcluster_gl/src/DBScanClusteringProvider.cpp
+++ b/plugins/molsurfmapcluster_gl/src/DBScanClusteringProvider.cpp
@@ -140,7 +140,9 @@ void DBScanClusteringProvider::loadMapFromFile(const core::CoreInstance& coreIns
                 } else if (i == 1) {
                     try {
                         res.second = std::stoi(substr);
-                    } catch (...) { res.second = -1; }
+                    } catch (...) {
+                        res.second = -1;
+                    }
                 }
                 ++i;
             }

--- a/plugins/molsurfmapcluster_gl/src/EnzymeClassProvider.cpp
+++ b/plugins/molsurfmapcluster_gl/src/EnzymeClassProvider.cpp
@@ -150,7 +150,9 @@ void EnzymeClassProvider::loadMapFromFile(const core::CoreInstance& coreInstance
                         int val;
                         try {
                             val = std::stoi(idsubstr);
-                        } catch (...) { val = -1; }
+                        } catch (...) {
+                            val = -1;
+                        }
                         res.second[j] = val;
                         ++j;
                     }

--- a/plugins/optix_hpg/src/optix/SBT.h
+++ b/plugins/optix_hpg/src/optix/SBT.h
@@ -89,7 +89,7 @@ public:
         }
     }
 
-    operator OptixShaderBindingTable const *() const {
+    operator OptixShaderBindingTable const*() const {
         return &sbt_;
     }
 

--- a/plugins/protein_cuda/src/VolumeMeshRenderer.cpp
+++ b/plugins/protein_cuda/src/VolumeMeshRenderer.cpp
@@ -403,7 +403,9 @@ void VolumeMeshRenderer::release(void) {
             CUDA_VERIFY(cudaFree(modified));
         if (segmentsRemoved)
             CUDA_VERIFY(cudaFree(segmentsRemoved));
-    } catch (vislib::Exception e) { Log::DefaultLog.WriteError("Unable to release CUDA resources: %s\n", e.GetMsgA()); }
+    } catch (vislib::Exception e) {
+        Log::DefaultLog.WriteError("Unable to release CUDA resources: %s\n", e.GetMsgA());
+    }
 }
 
 /*

--- a/plugins/protein_gl/src/SequenceRenderer.cpp
+++ b/plugins/protein_gl/src/SequenceRenderer.cpp
@@ -592,7 +592,9 @@ bool SequenceRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
     view::Camera::OrthographicParameters cam_intrin;
     try {
         cam_intrin = cam_.get<core::view::Camera::OrthographicParameters>();
-    } catch (...) { return consumeEvent; }
+    } catch (...) {
+        return consumeEvent;
+    }
     double world_x = ((x * 2.0 / static_cast<double>(screen_.x)) - 1.0);
     double world_y = 1.0 - (y * 2.0 / static_cast<double>(screen_.y));
     world_x = world_x * 0.5 * cam_intrin.frustrum_height * cam_intrin.aspect + cam_pose.position.x;

--- a/plugins/pwdemos_gl/src/QuartzCrystalDataSource.cpp
+++ b/plugins/pwdemos_gl/src/QuartzCrystalDataSource.cpp
@@ -108,12 +108,16 @@ void CrystalDataSource::loadFile(const vislib::TString& filename) {
                     static_cast<float>(vislib::CharTraitsA::ParseDouble(file[l].Word(2))));
                 // Do not normalize! Length of v is radius of base-sphere for that plane
                 crystal.AddFace(v);
-            } catch (...) { Log::DefaultLog.WriteWarn("Error parsing vector line \"%d\"", static_cast<int>(l)); }
+            } catch (...) {
+                Log::DefaultLog.WriteWarn("Error parsing vector line \"%d\"", static_cast<int>(l));
+            }
         } else if (file[l].Count() == 2) {
             try {
                 crystal.SetBaseRadius(static_cast<float>(vislib::CharTraitsA::ParseDouble(file[l].Word(1))));
                 crystal.SetBoundingRadius(static_cast<float>(vislib::CharTraitsA::ParseDouble(file[l].Word(0))));
-            } catch (...) { Log::DefaultLog.WriteWarn("Error parsing radius line \"%d\"", static_cast<int>(l)); }
+            } catch (...) {
+                Log::DefaultLog.WriteWarn("Error parsing radius line \"%d\"", static_cast<int>(l));
+            }
             if (!crystal.IsEmpty())
                 this->crystals.Add(crystal);
             crystal.Clear();

--- a/plugins/pwdemos_gl/src/QuartzParticleFortLoader.cpp
+++ b/plugins/pwdemos_gl/src/QuartzParticleFortLoader.cpp
@@ -383,7 +383,9 @@ void ParticleFortLoader::assertData(void) {
 
         } catch (vislib::Exception ex) {
             Log::DefaultLog.WriteError("Unexpected exception: %s\n", ex.GetMsgA());
-        } catch (...) { Log::DefaultLog.WriteError("Unknown exception"); }
+        } catch (...) {
+            Log::DefaultLog.WriteError("Unknown exception");
+        }
     }
 }
 

--- a/plugins/remote/src/FBOCommFabric.cpp
+++ b/plugins/remote/src/FBOCommFabric.cpp
@@ -97,7 +97,9 @@ bool megamol::remote::ZMQCommFabric::Bind(std::string const& address) {
         bound_ = true;
         // this->socket_.setsockopt(ZMQ_CONFLATE, true);
         this->socket_.setsockopt(ZMQ_LINGER, 0);
-    } catch (zmq::error_t const& e) { printf("ZMQ ERROR: %s", e.what()); }
+    } catch (zmq::error_t const& e) {
+        printf("ZMQ ERROR: %s", e.what());
+    }
     return this->socket_.connected();
 }
 

--- a/plugins/remote/src/FBOCompositor2.cpp
+++ b/plugins/remote/src/FBOCompositor2.cpp
@@ -503,7 +503,9 @@ void megamol::remote::FBOCompositor2::receiverJob(
                 try {
                     fbo_msg_future->SetPromise(msg);
                     break;
-                } catch (std::future_error const& e) { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
+                } catch (std::future_error const& e) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
             }
 
 #if 0
@@ -525,7 +527,9 @@ void megamol::remote::FBOCompositor2::receiverJob(
         megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: ReceiverJob died: %s\n", e.what());
     } catch (vislib::Exception& e) {
         megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: ReceiverJob died: %s\n", e.GetMsgA());
-    } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: ReceiverJob died\n"); }
+    } catch (...) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: ReceiverJob died\n");
+    }
 }
 
 
@@ -660,7 +664,9 @@ void megamol::remote::FBOCompositor2::collectorJob(std::vector<FBOCommFabric>&& 
             job.join();
         }
         megamol::core::utility::log::Log::DefaultLog.WriteWarn("FBOCompositor2: Closing collectorJob\n");
-    } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: CollectorJob\n"); }
+    } catch (...) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: CollectorJob\n");
+    }
 }
 
 
@@ -724,7 +730,9 @@ void megamol::remote::FBOCompositor2::registerJob(std::vector<std::string>& addr
         if (!this->shutdown_) {
             this->isRegistered_.store(true);
         }
-    } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: RegisterJob died\n"); }
+    } catch (...) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError("FBOCompositor2: RegisterJob died\n");
+    }
 }
 
 

--- a/plugins/remote/src/FBOTransmitter2.cpp
+++ b/plugins/remote/src/FBOTransmitter2.cpp
@@ -396,7 +396,9 @@ void megamol::remote::FBOTransmitter2::transmitterJob() {
                 }
             }
         }
-    } catch (...) { megamol::core::utility::log::Log::DefaultLog.WriteError("FBOTransmitter2: TransmitterJob died\n"); }
+    } catch (...) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError("FBOTransmitter2: TransmitterJob died\n");
+    }
 }
 
 

--- a/plugins/trisoup_gl/src/WavefrontObjDataSource.cpp
+++ b/plugins/trisoup_gl/src/WavefrontObjDataSource.cpp
@@ -342,7 +342,9 @@ bool WavefrontObjDataSource::load(const vislib::TString& filename) {
         } catch (vislib::Exception ex) {
             Log::DefaultLog.WriteError(
                 "Error parsing line %u: %s (%s, %d)", li, ex.GetMsgA(), ex.GetFile(), ex.GetLine());
-        } catch (...) { Log::DefaultLog.WriteError("Error parsing line %u: unexpected exception", li); }
+        } catch (...) {
+            Log::DefaultLog.WriteError("Error parsing line %u: unexpected exception", li);
+        }
     }
     if (lineVerts.Count() > 0) {
         for (size_t loop = 0; loop < lineVerts.Count(); loop++) {
@@ -499,7 +501,9 @@ void WavefrontObjDataSource::loadMaterialLibrary(
         } catch (vislib::Exception ex) {
             Log::DefaultLog.WriteError(
                 "Error parsing line %u: %s (%s, %d)", li, ex.GetMsgA(), ex.GetFile(), ex.GetLine());
-        } catch (...) { Log::DefaultLog.WriteError("Error parsing line %u: unexpected exception", li); }
+        } catch (...) {
+            Log::DefaultLog.WriteError("Error parsing line %u: unexpected exception", li);
+        }
     }
 
     ASSERT(names.Count() == this->mats.Count());

--- a/plugins/volume/src/VolumetricDataSource.cpp
+++ b/plugins/volume/src/VolumetricDataSource.cpp
@@ -1009,7 +1009,9 @@ void megamol::volume::VolumetricDataSource::release(void) {
             this->stopAsyncLoad(true);
         }
         ASSERT(!this->loaderThread.IsRunning());
-    } catch (vislib::Exception e) { Log::DefaultLog.WriteError(e.GetMsg()); } catch (...) {
+    } catch (vislib::Exception e) {
+        Log::DefaultLog.WriteError(e.GetMsg());
+    } catch (...) {
         Log::DefaultLog.WriteError(_T("Unexpected exception while ")
                                    _T("stopping volume loader thread during release of data source."));
     }
@@ -1069,7 +1071,9 @@ void megamol::volume::VolumetricDataSource::stopAsyncLoad(const bool isWait) {
             this->loaderThread.Join();
             ASSERT(this->loaderStatus.load() == LOADER_STATUS_STOPPED);
         }
-    } catch (vislib::Exception e) { Log::DefaultLog.WriteError(e.GetMsg()); }
+    } catch (vislib::Exception e) {
+        Log::DefaultLog.WriteError(e.GetMsg());
+    }
 }
 
 
@@ -1296,7 +1300,9 @@ size_t megamol::volume::VolumetricDataSource::assertBuffersUnsafe(size_t cntFram
         }
 
         retval = this->buffers.Count();
-    } catch (vislib::Exception e) { Log::DefaultLog.WriteError(e.GetMsg()); } catch (...) {
+    } catch (vislib::Exception e) {
+        Log::DefaultLog.WriteError(e.GetMsg());
+    } catch (...) {
         Log::DefaultLog.WriteError(_T("Unexpected exception while ")
                                    _T("preparing data buffers. Not all of the requested memory ")
                                    _T("might be available."));

--- a/remoteconsole/src/Connection.cpp
+++ b/remoteconsole/src/Connection.cpp
@@ -32,7 +32,9 @@ std::string Connection::sendCommand(const std::string& cmd) {
         } else {
             return "Reply timeout, probably MegaMol was closed. Please reconnect.";
         }
-    } catch (zmq::error_t const& ex) { throw std::runtime_error("zmq send/recv error: " + std::string(ex.what())); }
+    } catch (zmq::error_t const& ex) {
+        throw std::runtime_error("zmq send/recv error: " + std::string(ex.what()));
+    }
 }
 
 Connection::~Connection() {

--- a/remoteconsole/src/ConnectionFactory.cpp
+++ b/remoteconsole/src/ConnectionFactory.cpp
@@ -12,7 +12,9 @@ ConnectionFactory::ConnectionFactory(std::string host) : host_(std::move(host)) 
         pre_socket_ = std::make_unique<zmq::socket_t>(*context_, ZMQ_REQ);
         pre_socket_->setsockopt(ZMQ_LINGER, 0);
         pre_socket_->connect(host_);
-    } catch (zmq::error_t const& ex) { throw std::runtime_error("Error init zmq: " + std::string(ex.what())); }
+    } catch (zmq::error_t const& ex) {
+        throw std::runtime_error("Error init zmq: " + std::string(ex.what()));
+    }
 }
 
 ConnectionFactory::~ConnectionFactory() {

--- a/vislib/include/vislib/math/AbstractMatrix.h
+++ b/vislib/include/vislib/math/AbstractMatrix.h
@@ -733,7 +733,9 @@ AbstractMatrix<T, 3, L, S>::operator Quaternion<T>(void) const {
             this->components[Super::indexOf(1, 1)], this->components[Super::indexOf(1, 2)],
             this->components[Super::indexOf(2, 0)], this->components[Super::indexOf(2, 1)],
             this->components[Super::indexOf(2, 2)]);
-    } catch (...) { throw IllegalStateException("Matrix is not rotation-only", __FILE__, __LINE__); }
+    } catch (...) {
+        throw IllegalStateException("Matrix is not rotation-only", __FILE__, __LINE__);
+    }
     return q;
 }
 
@@ -1031,7 +1033,9 @@ AbstractMatrix<T, 4, L, S>::operator Quaternion<T>(void) const {
             this->components[Super::indexOf(1, 1)], this->components[Super::indexOf(1, 2)],
             this->components[Super::indexOf(2, 0)], this->components[Super::indexOf(2, 1)],
             this->components[Super::indexOf(2, 2)]);
-    } catch (...) { throw IllegalStateException("Matrix is not rotation-only", __FILE__, __LINE__); }
+    } catch (...) {
+        throw IllegalStateException("Matrix is not rotation-only", __FILE__, __LINE__);
+    }
     return q;
 }
 

--- a/vislib/src/graphics/ColourParser.cpp
+++ b/vislib/src/graphics/ColourParser.cpp
@@ -442,19 +442,27 @@ bool vislib::graphics::ColourParser::parseArray(
     float r, g, b, a;
     try {
         r = static_cast<float>(vislib::CharTraitsA::ParseDouble(rStr));
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
     try {
         g = static_cast<float>(vislib::CharTraitsA::ParseDouble(gStr));
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
     try {
         b = static_cast<float>(vislib::CharTraitsA::ParseDouble(bStr));
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
     if (aStr.IsEmpty()) {
         a = isFloat ? 1.0f : 255.0f;
     } else {
         try {
             a = static_cast<float>(vislib::CharTraitsA::ParseDouble(aStr));
-        } catch (...) { return false; }
+        } catch (...) {
+            return false;
+        }
     }
 
     if (!isFloat) {

--- a/vislib/src/net/DiscoveryService.cpp
+++ b/vislib/src/net/DiscoveryService.cpp
@@ -542,7 +542,9 @@ void vislib::net::cluster::DiscoveryService::Start(const char* name, const Disco
 vislib::StringA vislib::net::cluster::DiscoveryService::ToStringA(const PeerHandle& hPeer) const {
     try {
         return this->GetResponseAddress(hPeer).ToStringA();
-    } catch (...) { return "Invalid Handle"; }
+    } catch (...) {
+        return "Invalid Handle";
+    }
 }
 
 
@@ -552,7 +554,9 @@ vislib::StringA vislib::net::cluster::DiscoveryService::ToStringA(const PeerHand
 vislib::StringW vislib::net::cluster::DiscoveryService::ToStringW(const PeerHandle& hPeer) const {
     try {
         return this->GetResponseAddress(hPeer).ToStringW();
-    } catch (...) { return L"Invalid Handle"; }
+    } catch (...) {
+        return L"Invalid Handle";
+    }
 }
 
 

--- a/vislib/src/net/NetworkInformation.cpp
+++ b/vislib/src/net/NetworkInformation.cpp
@@ -1222,7 +1222,9 @@ float vislib::net::NetworkInformation::guessRemoteEndPoint(IPEndPoint& outEndPoi
                         if (al[i].GetPrefix(prefixLen) != address.GetPrefix(prefixLen)) {
                             retval += NetworkInformation::PENALTY_WRONG_PREFIX;
                         }
-                    } catch (...) { retval += NetworkInformation::PENALTY_WRONG_PREFIX; }
+                    } catch (...) {
+                        retval += NetworkInformation::PENALTY_WRONG_PREFIX;
+                    }
                 }
 
                 if (al[i].GetAddressFamily() != address.GetAddressFamily()) {
@@ -1412,12 +1414,16 @@ void vislib::net::NetworkInformation::initAdapters(void) {
         /* Retrieve adapter type. */
         try {
             adapter.type.Set(NetworkInformation::mapAdapterType(cur->IfType), VALID);
-        } catch (IllegalParamException) { adapter.type.Set(Adapter::TYPE_OTHER, GUESSED); }
+        } catch (IllegalParamException) {
+            adapter.type.Set(Adapter::TYPE_OTHER, GUESSED);
+        }
 
         /* Retrieve adapter status. */
         try {
             adapter.status.Set(NetworkInformation::mapOperationStatus(cur->OperStatus), VALID);
-        } catch (IllegalParamException) { adapter.status.Set(Adapter::OPERSTATUS_UNKNOWN, GUESSED); }
+        } catch (IllegalParamException) {
+            adapter.status.Set(Adapter::OPERSTATUS_UNKNOWN, GUESSED);
+        }
 
         //pDnServer = pCurrAddresses->FirstDnsServerAddress;
         //if (pDnServer) {
@@ -1542,7 +1548,9 @@ void vislib::net::NetworkInformation::initAdapters(void) {
                         NetworkInformation::guessBroadcastAddress(
                             static_cast<IPAddress>(addr.GetIPAddress()), static_cast<IPAddress>(mask.GetIPAddress())),
                         GUESSED);
-                } catch (...) { adapter->broadcastAddress.SetConfidence(INVALID); }
+                } catch (...) {
+                    adapter->broadcastAddress.SetConfidence(INVALID);
+                }
             } /* end if (cur->ifa_broadaddr != NULL) */
         } break;
 
@@ -1619,7 +1627,9 @@ void vislib::net::NetworkInformation::initAdapters(void) {
 
             try {
                 adapter.type.Set(NetworkInformation::mapAdapterType(sll->sll_family), VALID);
-            } catch (IllegalParamException) { adapter.type.SetConfidence(INVALID); }
+            } catch (IllegalParamException) {
+                adapter.type.SetConfidence(INVALID);
+            }
         }
 
     } /* end for (SIZE_T i = 0; i < NetworkInformation::adapters.Count(); ... */
@@ -2135,7 +2145,9 @@ float vislib::net::NetworkInformation::wildGuessAdapter(Adapter& outAdapter, con
                 (a.GetStatus() == Adapter::OPERSTATUS_LOWER_LAYER_DOWN)) {
                 wildness[i] += NetworkInformation::PENALTY_ADAPTER_DOWN;
             }
-        } catch (NoConfidenceException) { wildness[i] += NetworkInformation::PENALTY_ADAPTER_DOWN / 2.0f; }
+        } catch (NoConfidenceException) {
+            wildness[i] += NetworkInformation::PENALTY_ADAPTER_DOWN / 2.0f;
+        }
     } /* end for (SIZE_T i = 0; i < NetworkInformation::adapters.Count() ... */
 
     retval = NetworkInformation::consolidateWildness(wildness, candidateIdx);

--- a/vislib/src/sys/Thread.cpp
+++ b/vislib/src/sys/Thread.cpp
@@ -163,7 +163,9 @@ bool vislib::sys::Thread::IsRunning(void) const {
         return ((this->id != 0)
 #endif /* _WIN32 */
                 && (this->GetExitCode() == STILL_ACTIVE));
-    } catch (SystemException) { return false; }
+    } catch (SystemException) {
+        return false;
+    }
 }
 
 

--- a/vislib_gl/src/graphics/gl/FramebufferObject.cpp
+++ b/vislib_gl/src/graphics/gl/FramebufferObject.cpp
@@ -465,7 +465,9 @@ bool vislib_gl::graphics::gl::FramebufferObject::IsValid(void) const throw() {
             // FBO without colour attachment cannot be valid.
             return false;
         }
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 }
 
 

--- a/vislib_gl/src/graphics/gl/OpenGLTexture2D.cpp
+++ b/vislib_gl/src/graphics/gl/OpenGLTexture2D.cpp
@@ -74,7 +74,9 @@ GLenum vislib_gl::graphics::gl::OpenGLTexture2D::Create(const uint32_t width, co
     if (!this->IsValid()) {
         try {
             this->createId();
-        } catch (OpenGLException e) { return e.GetErrorCode(); }
+        } catch (OpenGLException e) {
+            return e.GetErrorCode();
+        }
     }
 
     GL_VERIFY_EXPR_RETURN(this->Bind());


### PR DESCRIPTION
## Summary of Changes
- Update to clang-format-14. Seems most of us now have VS 2022 or CLion with a more recent clang-format version than 12 and clang-format-12 is especially annoying because it does not handle catch blocks correctly. Up to date VS 2022 uses already clang-format-15, but there is no relevant difference in the generated output to 14 and 14 is directly available in the GitHub Actions Ubuntu 22.04 runners.