### PR TITLE
CSVFileSequence: access data source module via call

### DIFF
--- a/core/src/AbstractNamedObject.cpp
+++ b/core/src/AbstractNamedObject.cpp
@@ -36,7 +36,8 @@ vislib::StringA AbstractNamedObject::FullName() const {
                 break;
             }
             name.Prepend(ano->Name());
-            name.Prepend("::");
+            if (!name.StartsWith("::", false))
+                name.Prepend("::");
             ano = ano->Parent();
         }
         return name;

--- a/core/src/LuaAPI.cpp
+++ b/core/src/LuaAPI.cpp
@@ -1,7 +1,7 @@
 /*
- * LuaState.cpp
+ * LuaAPI.cpp
  *
- * Copyright (C) 2017 by Universitaet Stuttgart (VIS).
+ * Copyright (C) 2020 by Universitaet Stuttgart (VIS).
  * Alle Rechte vorbehalten.
  */
 

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -399,8 +399,7 @@ bool megamol::gui::GraphCollection::SynchronizeGraphs(megamol::core::MegaMolGrap
                             if (param_slot != nullptr) {
                                 std::string param_full_name(param_slot->FullName().PeekBuffer());
                                 for (auto& parameter : module_ptr->Parameters()) {
-                                    if (gui_utils::CaseInsensitiveStringEqual(
-                                            parameter.FullNameCore(), param_full_name)) {
+                                    if (gui_utils::CaseInsensitiveStringEqual(parameter.FullName(), param_full_name)) {
                                         megamol::gui::Parameter::ReadNewCoreParameterToExistingParameter(
                                             (*param_slot), parameter, true, false, true);
                                     }
@@ -428,7 +427,7 @@ bool megamol::gui::GraphCollection::SynchronizeGraphs(megamol::core::MegaMolGrap
                     if (p.IsValueDirty()) {
                         p.ResetValueDirty(); // ! Reset before calling lua cmd because of instantly triggered subscription callback
                         param_sync_success &= std::get<0>((*input_lua_func)(
-                            "mmSetParamValue([=[" + p.FullNameCore() + "]=],[=[" + p.GetValueString() + "]=])"));
+                            "mmSetParamValue([=[" + p.FullName() + "]=],[=[" + p.GetValueString() + "]=])"));
                     }
                 }
             }
@@ -803,8 +802,7 @@ bool megamol::gui::GraphCollection::LoadOrAddProjectFromFile(
                 if (graph_ptr != nullptr) {
                     for (auto& module_ptr : graph_ptr->Modules()) {
                         for (auto& parameter : module_ptr->Parameters()) {
-                            if (gui_utils::CaseInsensitiveStringEqual(
-                                    parameter.FullNameProject(), param_slot_full_name)) {
+                            if (gui_utils::CaseInsensitiveStringEqual(parameter.FullName(), param_slot_full_name)) {
                                 parameter.SetValueString(value_str);
                             }
                         }
@@ -878,7 +876,7 @@ bool megamol::gui::GraphCollection::SaveProjectToFile(
                         // - Ignore button parameters
                         if ((graph_ptr->IsRunning() || parameter.DefaultValueMismatch()) &&
                             (parameter.Type() != ParamType_t::BUTTON)) {
-                            confParams << "mmSetParamValue(\"" << parameter.FullNameProject() << "\",[=["
+                            confParams << "mmSetParamValue(\"" << parameter.FullName() << "\",[=["
                                        << parameter.GetValueString() << "]=])\n";
                         }
                     }

--- a/frontend/services/gui/src/graph/Module.cpp
+++ b/frontend/services/gui/src/graph/Module.cpp
@@ -684,7 +684,7 @@ bool megamol::gui::Module::StateToJSON(nlohmann::json& inout_json) {
     bool retval = this->gui_param_groups.StateToJSON(inout_json, this->FullName());
     // Parameters
     for (auto& param : this->parameters) {
-        retval &= param.StateToJSON(inout_json, param.FullNameProject());
+        retval &= param.StateToJSON(inout_json, param.FullName());
     }
     return retval;
 }
@@ -696,7 +696,7 @@ bool megamol::gui::Module::StateFromJSON(const nlohmann::json& in_json) {
     bool retval = this->gui_param_groups.StateFromJSON(in_json, this->FullName());
     // Parameters
     for (auto& param : this->parameters) {
-        retval &= param.StateFromJSON(in_json, param.FullNameProject());
+        retval &= param.StateFromJSON(in_json, param.FullName());
         param.ForceSetGUIStateDirty();
     }
     return retval;

--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -752,7 +752,7 @@ bool megamol::gui::Parameter::Draw(megamol::gui::Parameter::WidgetScope scope) {
                     ImGui::SameLine();
 
                     // Lua
-                    ButtonWidgets::LuaButton("param_lua_button", (*this), this->FullNameProject());
+                    ButtonWidgets::LuaButton("param_lua_button", (*this), this->FullName());
                     this->gui_tooltip.ToolTip("Copy lua command to clipboard.");
 
                     ImGui::SameLine();
@@ -1530,7 +1530,7 @@ bool megamol::gui::Parameter::widget_filepath(megamol::gui::Parameter::WidgetSco
 
     auto popup_flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar;
     if (ImGui::BeginPopupModal(popup_name.c_str(), nullptr, popup_flags)) {
-        ImGui::Text("Parameter: %s", this->FullNameProject().c_str());
+        ImGui::Text("Parameter: %s", this->FullName().c_str());
         ImGui::TextColored(GUI_COLOR_TEXT_WARN, "Message: %s", this->gui_popup_msg.c_str());
         bool close = false;
         if (ImGui::Button("Ok")) {
@@ -2063,7 +2063,7 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
             ImGui::SameLine();
             gui_utils::PushReadOnly(param_externally_connected);
             if (ImGui::Button("Connect")) {
-                this->tf_editor_external_ptr->SetConnectedParameter(this, this->FullNameProject());
+                this->tf_editor_external_ptr->SetConnectedParameter(this, this->FullName());
                 this->tf_editor_external_ptr->Config().show = true;
                 retval = true;
             }

--- a/frontend/services/gui/src/graph/Parameter.h
+++ b/frontend/services/gui/src/graph/Parameter.h
@@ -191,12 +191,8 @@ public:
         return name_space;
     }
     // ::<module_group>::<module_name> + :: + <param_namespace>::<param_name>
-    inline std::string FullNameProject() const {
+    inline std::string FullName() const {
         return std::string(this->parent_module_name + "::" + this->param_name);
-    }
-    // :: + ::<module_group>::<module_name> + :: + <param_namespace>::<param_name>
-    inline std::string FullNameCore() const {
-        return std::string("::" + this->parent_module_name + "::" + this->param_name);
     }
 
     std::string GetValueString() const;

--- a/frontend/services/gui/src/graph/ParameterGroups.cpp
+++ b/frontend/services/gui/src/graph/ParameterGroups.cpp
@@ -29,7 +29,7 @@ void megamol::gui::ParameterGroups::DrawParameter(megamol::gui::Parameter& inout
     } else {
         /// LOCAL
 
-        auto param_fullname = inout_param.FullNameProject();
+        auto param_fullname = inout_param.FullName();
         bool param_searched = true;
         if (in_scope == Parameter::WidgetScope::LOCAL) {
             param_searched = gui_utils::FindCaseInsensitiveSubstring(param_fullname, in_search);

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -72,7 +72,7 @@ bool Configurator::Update() {
             for (auto& module_ptr : graph_ptr->Modules()) {
                 std::string module_full_name = module_ptr->FullName();
                 for (auto& param : module_ptr->Parameters()) {
-                    std::string param_full_name = param.FullNameProject();
+                    std::string param_full_name = param.FullName();
                     if (gui_utils::CaseInsensitiveStringEqual(tf_param_connect_request, param_full_name) &&
                         (param.Type() == ParamType_t::TRANSFERFUNCTION)) {
                         win_tfeditor_ptr->SetConnectedParameter(&param, param_full_name);

--- a/plugins/datatools/src/CSVFileSequence.cpp
+++ b/plugins/datatools/src/CSVFileSequence.cpp
@@ -8,7 +8,6 @@
 #include "CSVFileSequence.h"
 #include "PluginsResource.h"
 #include "datatools/table/TableDataCall.h"
-#include "mmcore/MegaMolGraph.h"
 #include "mmcore/factories/CallDescriptionManager.h"
 #include "mmcore/param/BoolParam.h"
 #include "mmcore/param/FilePathParam.h"

--- a/plugins/datatools/src/CSVFileSequence.cpp
+++ b/plugins/datatools/src/CSVFileSequence.cpp
@@ -34,7 +34,8 @@ datatools::CSVFileSequence::CSVFileSequence()
         , fileNumberMinSlot("fileNumberMin", "Slot for the minimum file number")
         , fileNumberMaxSlot("fileNumberMax", "Slot for the maximum file number")
         , fileNumberStepSlot("fileNumberStep", "Slot for the file number increase step")
-        , fileNameSlotNameSlot("fileNameSlotName", "The name of the data source file name parameter slot")
+        , fileNameSlotNameSlot("fileNameSlotName", "The name of the data source file name parameter slot (e.g. "
+                                                   "'filename', not the whole path to module and slot)")
         , useClipBoxAsBBox("useClipBoxAsBBox", "If true will use the all-data clip box as bounding box")
         , outDataSlot("outData", "The slot for publishing data to the writer")
         , inDataSlot("inData", "The slot for requesting data from the source")
@@ -452,11 +453,28 @@ bool datatools::CSVFileSequence::onFileNameSlotNameChanged(core::param::ParamSlo
  */
 core::param::ParamSlot* datatools::CSVFileSequence::findFileNameSlot() {
     core::param::StringParam* P = this->fileNameSlotNameSlot.Param<core::param::StringParam>();
-    if (P != NULL) {
-        auto& megamolgraph = frontend_resources.get<megamol::core::MegaMolGraph>();
-        return megamolgraph.FindParameterSlot(P->Value());
-    }
-    return NULL;
+
+    // target slot has name
+    if (!P)
+        return nullptr;
+
+    // there is a target module connected via call
+    if (this->inDataSlot.GetStatus() != megamol::core::AbstractSlot::STATUS_CONNECTED)
+        return nullptr;
+
+    core::param::ParamSlot* slot =
+        dynamic_cast<core::param::ParamSlot*>(AbstractNamedObjectContainer::dynamic_pointer_cast(
+            this->inDataSlot
+                .CallAs<megamol::core::Call>() // connected Call
+                ->PeekCalleeSlotNoConst()      // slot of target Module
+                ->Parent()                     // target Module
+                ->shared_from_this())          // cast to AbstractNamedObjectContainer
+                                                  // TODO: find slot by full name, not just by slot name
+                                                  ->FindChild(P->Value().c_str()) // Find target Slot by name in Module
+                                                  .get()                          // get value of smart ptr
+        );
+
+    return slot;
 }
 
 

--- a/plugins/datatools/src/CSVFileSequence.cpp
+++ b/plugins/datatools/src/CSVFileSequence.cpp
@@ -497,6 +497,14 @@ void datatools::CSVFileSequence::assertData() {
         return;
     }
 
+    // we want to inject our variations of the file name into the referenced file path param
+    auto* fileParam = fnSlot->Param<core::param::FilePathParam>();
+    if (fileParam == NULL) {
+        Log::DefaultLog.WriteMsg(Log::LEVEL_ERROR, "file name slot is not a FilePathParam");
+        return;
+    }
+    auto curent_file_param_value = fileParam->ValueString();
+
     table::TableDataCall* gdc = this->inDataSlot.CallAs<table::TableDataCall>();
     if (gdc == NULL) {
         Log::DefaultLog.WriteError("Unable to get input data call");
@@ -506,16 +514,23 @@ void datatools::CSVFileSequence::assertData() {
     // count really available frames
     for (unsigned int i = this->fileNumMin; i <= this->fileNumMax; i += this->fileNumStep) {
         filename.Format(this->fileNameTemplate, i);
-        if (vislib::sys::File::Exists(filename)) {
+
+        // we need to use the file path param to check for existence of the file
+        fileParam->ParseValue(filename.PeekBuffer());
+
+        if (std::filesystem::exists(fileParam->Value())) {
             this->frameCnt++;
         } else {
             break;
         }
     }
+    fileParam->ParseValue(curent_file_param_value);
+
     if (this->frameCnt == 0) {
         Log::DefaultLog.WriteError("CSVFileSequence: No data files found");
         return;
     }
+
 
     // collect heuristic approach for clipping box
     filename.Format(this->fileNameTemplate, this->fileNumMin);

--- a/plugins/datatools/src/CSVFileSequence.cpp
+++ b/plugins/datatools/src/CSVFileSequence.cpp
@@ -500,7 +500,7 @@ void datatools::CSVFileSequence::assertData() {
     // we want to inject our variations of the file name into the referenced file path param
     auto* fileParam = fnSlot->Param<core::param::FilePathParam>();
     if (fileParam == NULL) {
-        Log::DefaultLog.WriteMsg(Log::LEVEL_ERROR, "file name slot is not a FilePathParam");
+        Log::DefaultLog.WriteMsg(Log::log_level::error, "file name slot is not a FilePathParam");
         return;
     }
     auto curent_file_param_value = fileParam->ValueString();

--- a/plugins/datatools/src/CSVFileSequence.h
+++ b/plugins/datatools/src/CSVFileSequence.h
@@ -31,7 +31,6 @@ public:
 
     static void requested_lifetime_resources(frontend_resources::ResourceRequest& req) {
         Base::requested_lifetime_resources(req);
-        req.require<core::MegaMolGraph>();
         req.require<frontend_resources::PluginsResource>();
     }
 

--- a/plugins/datatools/src/table/TableColumnFilter.cpp
+++ b/plugins/datatools/src/table/TableColumnFilter.cpp
@@ -66,7 +66,7 @@ bool TableColumnFilter::processData(core::Call& c) {
 
         if (this->datahash != inCall->DataHash() || this->frameID != inCall->GetFrameID() ||
             this->selectionStringSlot.IsDirty()) {
-            this->datahash++;
+            this->datahash = inCall->DataHash();
             this->selectionStringSlot.ResetDirty();
             this->frameID = inCall->GetFrameID();
 

--- a/plugins/moldyn/src/io/TestSpheresDataSource.cpp
+++ b/plugins/moldyn/src/io/TestSpheresDataSource.cpp
@@ -230,7 +230,10 @@ bool TestSpheresDataSource::getDataCallback(core::Call& caller) {
 #endif
 
     mpdc->SetFrameID(f->FrameNumber());
-    mpdc->SetDataHash(1);
+    // assume that sphere count and frame count are only relevant up to the first two bytes
+    // because who will ever need more than ~2^16 frames or spheres from this test data source?
+    int hash = sphereCount | (frameCount << 16);
+    mpdc->SetDataHash(hash);
     mpdc->SetExtent(frameCount, -1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f);
     mpdc->SetParticleListCount(1);
     mpdc->AccessParticles(0).SetCount(sphereCount);


### PR DESCRIPTION
This PR patches the CSVFileSequence to access a connected data module (via `inSlot`) to modify the target filename param using the call connected to `inSlot`, instead of using the MegaMolGraph resource to access the data module globally.

This remove the MegaMolGraph as a resource requirement from CSVFileSequence and thus future proofs the module for a time when the graph can not be accessed or manipulated using that resource.

## Summary of Changes
* modify CSVFileSequence target filename param access
* remove MegaMolGraph resource access
* small fixes in FlagStorage and TableColumnFilter
* AbstractNamedObject fix prepending too many :: to module names
* other minor fixes

## Test Instructions
`csv\csv_file_sequence.lua` in the examples repository, along with `sampledata\csv_sequence\testspheres.*.csv` as file sequence inputs:



https://user-images.githubusercontent.com/44215465/230109790-b8ff2693-298c-4f49-97b2-1176c841f224.mp4


