### PR TITLE
Fix flag storage in SphereRenderer

### DIFF
--- a/plugins/moldyn_gl/shaders/moldyn_gl/sphere_renderer/inc/flags_snippet.inc.glsl
+++ b/plugins/moldyn_gl/shaders/moldyn_gl/sphere_renderer/inc/flags_snippet.inc.glsl
@@ -1,5 +1,5 @@
 
-#ifdef flags_available
+#ifdef FLAGS_AVAILABLE
 #extension GL_ARB_shader_storage_buffer_object : require
 #extension GL_ARB_gpu_shader_fp64 : enable
 #endif

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
@@ -370,10 +370,6 @@ void SphereRenderer::release() {
 
 
 bool SphereRenderer::resetOpenGLResources() {
-
-    this->flags_enabled_ = false;
-    this->flags_available_ = false;
-
     if (this->grey_tf_ != 0) {
         glDeleteTextures(1, &this->grey_tf_);
     }
@@ -510,7 +506,7 @@ bool SphereRenderer::createResources() {
 
     std::string flags_shader_snippet;
     if (this->flags_available_) {
-        shader_options_flags_->addDefinition("flags_available");
+        shader_options_flags_->addDefinition("FLAGS_AVAILABLE");
     }
 
     try {
@@ -977,6 +973,9 @@ bool SphereRenderer::Render(mmstd_gl::CallRender3DGL& call) {
     const SIZE_T hash = mpdc->DataHash();
     const unsigned int frame_id = mpdc->FrameID();
     this->state_invalid_ = ((hash != this->old_hash_) || (frame_id != this->old_frame_id_));
+
+    // Check for flag storage before render mode because info is needed for resource creation
+    isFlagStorageAvailable();
 
     // Checking for changed render mode
     auto current_render_mode = static_cast<RenderMode>(this->render_mode_param_.Param<param::EnumParam>()->Value());


### PR DESCRIPTION
Fixes use of flag storage in SphereRenderer

## Summary of Changes
- fix lower case define
- actually call code to check for flag storage per frame and remove random reset code

## Test Instructions
- Run new infovis-spheres example
