### PR TITLE
Clean up linear/sRGB workflows for compositing_gl deferred lighting

### DIFF
--- a/plugins/compositing_gl/shaders/compositing_gl/normalFromDepth.comp.glsl
+++ b/plugins/compositing_gl/shaders/compositing_gl/normalFromDepth.comp.glsl
@@ -1,25 +1,13 @@
 #version 430
 
+#include "mmstd_gl/shading/transformations.inc.glsl"
+
 uniform sampler2D src_tx2D;
 
 layout(RGBA16) writeonly uniform image2D tgt_tx2D;
 
 uniform mat4 inv_view_mx;
 uniform mat4 inv_proj_mx;
-
-vec3 depthToWorldPos(float depth, vec2 uv) {
-    float z = depth * 2.0 - 1.0;
-
-    vec4 cs_pos = vec4(uv * 2.0 - 1.0, z, 1.0);
-    vec4 vs_pos = inv_proj_mx * cs_pos;
-
-    // Perspective division
-    vs_pos /= vs_pos.w;
-    
-    vec4 ws_pos = inv_view_mx * vs_pos;
-
-    return ws_pos.xyz;
-}
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
@@ -44,13 +32,13 @@ void main()
     
 
     if ((depth_c > 0.0f) && (depth_c < 1.0f)){
-        vec3 position_c = depthToWorldPos(depth_c,pixel_coords_norm);
+        vec3 position_c = depthToWorldPos(depth_c,pixel_coords_norm,inv_view_mx,inv_proj_mx);
 
-        vec3 position_bt = ((depth_t) > 0.0f && (depth_t < 1.0f)) ? depthToWorldPos(depth_t,pixel_coords_norm + vec2(0.0, pixel_offset.y)) :
-            ((depth_b > 0.0f) && (depth_b < 1.0f)) ? depthToWorldPos(depth_b,pixel_coords_norm - vec2(0.0, pixel_offset.y)) : position_c;
+        vec3 position_bt = ((depth_t) > 0.0f && (depth_t < 1.0f)) ? depthToWorldPos(depth_t,pixel_coords_norm + vec2(0.0, pixel_offset.y),inv_view_mx,inv_proj_mx) :
+            ((depth_b > 0.0f) && (depth_b < 1.0f)) ? depthToWorldPos(depth_b,pixel_coords_norm - vec2(0.0, pixel_offset.y),inv_view_mx,inv_proj_mx) : position_c;
 
-        vec3 position_t = ((depth_r > 0.0f) && (depth_r < 1.0f)) ? depthToWorldPos(depth_r,pixel_coords_norm + vec2(pixel_offset.x, 0.0)) :
-            ((depth_l > 0.0f) && (depth_l < 1.0f)) ? depthToWorldPos(depth_l,pixel_coords_norm - vec2(pixel_offset.x, 0.0)) : position_c;
+        vec3 position_t = ((depth_r > 0.0f) && (depth_r < 1.0f)) ? depthToWorldPos(depth_r,pixel_coords_norm + vec2(pixel_offset.x, 0.0),inv_view_mx,inv_proj_mx) :
+            ((depth_l > 0.0f) && (depth_l < 1.0f)) ? depthToWorldPos(depth_l,pixel_coords_norm - vec2(pixel_offset.x, 0.0),inv_view_mx,inv_proj_mx) : position_c;
 
         vec3 tangent = normalize(position_t - position_c);
         vec3 bitangent = normalize(position_bt - position_c);

--- a/plugins/compositing_gl/shaders/compositing_gl/phong.comp.glsl
+++ b/plugins/compositing_gl/shaders/compositing_gl/phong.comp.glsl
@@ -1,5 +1,8 @@
 #version 430
 
+#include "mmstd_gl/shading/color.inc.glsl"
+#include "mmstd_gl/shading/transformations.inc.glsl"
+
 struct LightParams
 {
     float x,y,z,intensity;
@@ -33,20 +36,6 @@ uniform float k_spec;
 uniform float k_exp;
 
 //TODO M_PI
-
-vec3 depthToWorldPos(float depth, vec2 uv) {
-    float z = depth * 2.0 - 1.0;
-
-    vec4 cs_pos = vec4(uv * 2.0 - 1.0, z, 1.0);
-    vec4 vs_pos = inv_proj_mx * cs_pos;
-
-    // Perspective division
-    vs_pos /= vs_pos.w;
-    
-    vec4 ws_pos = inv_view_mx * vs_pos;
-
-    return ws_pos.xyz;
-}
 
 //TODO: ambient part adding via light component through uniforms like Point/Distant lights
 
@@ -93,7 +82,7 @@ void main() {
 
     if (depth > 0.0f && depth < 1.0f)
     {
-        vec3 world_pos = depthToWorldPos(depth,pixel_coords_norm);
+        vec3 world_pos = depthToWorldPos(depth,pixel_coords_norm,inv_view_mx,inv_proj_mx);
 
         vec3 reflected_light = vec3(0.0);
         for(int i=0; i<point_light_cnt; ++i)
@@ -115,7 +104,7 @@ void main() {
         }
         //Sets pixelcolor to illumination + color (alpha channels remains the same)
         //albedo = ambi/diff koeff auf albedo 
-        retval.rgb = reflected_light * albedo.rgb;
+        retval.rgb = toSRGB(vec4(reflected_light,1.0)).rgb * albedo.rgb;
     }
 
     imageStore(tgt_tx2D, pixel_coords , retval );

--- a/plugins/compositing_gl/shaders/compositing_gl/toon.comp.glsl
+++ b/plugins/compositing_gl/shaders/compositing_gl/toon.comp.glsl
@@ -1,5 +1,9 @@
 #version 430
 
+#include "mmstd_gl/shading/color.inc.glsl"
+#include "mmstd_gl/shading/tonemapping.inc.glsl"
+#include "mmstd_gl/shading/transformations.inc.glsl"
+
 struct LightParams
 {
     float x,y,z,intensity;
@@ -23,20 +27,6 @@ uniform mat4 inv_proj_mx;
 
 uniform float exposure_avg_intensity;
 uniform float roughness;
-
-vec3 depthToWorldPos(float depth, vec2 uv) {
-    float z = depth * 2.0 - 1.0;
-
-    vec4 cs_pos = vec4(uv * 2.0 - 1.0, z, 1.0);
-    vec4 vs_pos = inv_proj_mx * cs_pos;
-
-    // Perspective division
-    vs_pos /= vs_pos.w;
-    
-    vec4 ws_pos = inv_view_mx * vs_pos;
-
-    return ws_pos.xyz;
-}
 
 struct LightIntensities{
     float diffuse;
@@ -74,18 +64,6 @@ float toonRamp(float light_intensity, float shadow, float midtone, float light){
     return light_intensity > midtone ? midtone_to_light : shadow_to_midtone;
 };
 
-// see https://64.github.io/tonemapping/
-vec3 reinhardExt(vec3 c, vec3 c_white){
-    return (c * (vec3(1.0)+(c/pow(c_white,vec3(2.0)))))/(vec3(1.0)+c);
-}
-float reinhardExt(float c, float c_white){
-    return (c * (1.0+(c/pow(c_white,2.0))))/(1.0+c);
-}
-
-vec3 gamma(vec3 c){
-    return pow(  c, vec3(1.0/2.2) );
-};
-
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 void main() {
@@ -107,7 +85,7 @@ void main() {
 
     if (depth > 0.0f && depth < 1.0f)
     {
-        vec3 world_pos = depthToWorldPos(depth,pixel_coords_norm);
+        vec3 world_pos = depthToWorldPos(depth,pixel_coords_norm, inv_view_mx, inv_proj_mx);
 
         LightIntensities reflected_light;
         reflected_light.diffuse = 0.0;
@@ -190,14 +168,13 @@ void main() {
 
         // combines specular and rim lighting with max operator, then balance with diffuse based on roughness
         float specular = max(reflected_light.specular, reflected_light.rim);
-        vec3 final_rgb =vec3(mix(specular, reflected_light.diffuse, roughness)) * albedo.rgb;
-        //final_rgb = vec3(specular);
+        vec3 final_light_intensity =vec3(mix(specular, reflected_light.diffuse, roughness));
 
-        // apply tone mapping
-        final_rgb = reinhardExt(final_rgb,vec3(1.0));
+        // apply tone mapping and gamma correction
+        final_light_intensity = toSRGB(vec4(reinhardExt(final_light_intensity,vec3(1.0)),1.0)).rgb;
 
-        // gamma correction
-        retval.rgb = gamma(final_rgb);
+        // multiply sRGB color with gamma corrected light intensity
+        retval.rgb = (albedo.rgb * final_light_intensity);
     }
 
     imageStore(tgt_tx2D, pixel_coords , retval );

--- a/plugins/mesh_gl/shaders/mesh_gl/dfr_gltf_textured_example.frag.glsl
+++ b/plugins/mesh_gl/shaders/mesh_gl/dfr_gltf_textured_example.frag.glsl
@@ -1,6 +1,7 @@
 #version 450
 #extension GL_ARB_bindless_texture : require
 
+#include "mmstd_gl/shading/color.inc.glsl"
 
 struct MeshShaderParams {
     mat4 transform;
@@ -27,17 +28,6 @@ layout(location = 0) out vec4 albedo_out;
 layout(location = 1) out vec3 normal_out;
 layout(location = 2) out vec3 metallic_roughness_out;
 
-// Source: https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
-// Converts a color from sRGB gamma to linear light gamma
-vec4 toLinear(vec4 sRGB)
-{
-    bvec4 cutoff = lessThan(sRGB, vec4(0.04045));
-    vec4 higher = pow((sRGB + vec4(0.055))/vec4(1.055), vec4(2.4));
-    vec4 lower = sRGB/vec4(12.92);
-
-    return mix(higher, lower, cutoff);
-}
-
 void main(void) {
 
     sampler2D base_tx_hndl = sampler2D(mesh_shader_params[draw_id].albedo_texture_handle);
@@ -50,8 +40,11 @@ void main(void) {
 
     bool is_sRGB = true;
     if(is_sRGB){
-        albedo_tx_value = toLinear(albedo_tx_value);
-        //roughness_tx_value = toLinear(roughness_tx_value);
+        // Use sRGB for albedoe texture output for compatibility with sRGB transfer functions of SciVis renderers
+        //albedo_tx_value = toLinear(albedo_tx_value);
+    }
+    else{
+        albedo_tx_value = toSRGB(albedo_tx_value);
     }
 
     if(albedo_tx_value.a < 0.01){

--- a/plugins/mmstd_gl/shaders/mmstd_gl/shading/color.inc.glsl
+++ b/plugins/mmstd_gl/shaders/mmstd_gl/shading/color.inc.glsl
@@ -1,0 +1,20 @@
+
+// Source: https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
+// Converts a color from sRGB gamma to linear light gamma
+vec4 toLinear(vec4 sRGB)
+{
+    bvec3 cutoff = lessThan(sRGB.rgb, vec3(0.04045));
+    vec3 higher = pow((sRGB.rgb + vec3(0.055))/vec3(1.055), vec3(2.4));
+    vec3 lower = sRGB.rgb/vec3(12.92);
+
+    return vec4(mix(higher, lower, cutoff), sRGB.a);
+}
+// Converts a color from linear light gamma to sRGB gamma
+vec4 toSRGB(vec4 linearRGB)
+{
+    bvec3 cutoff = lessThan(linearRGB.rgb, vec3(0.0031308));
+    vec3 higher = vec3(1.055)*pow(linearRGB.rgb, vec3(1.0/2.4)) - vec3(0.055);
+    vec3 lower = linearRGB.rgb * vec3(12.92);
+
+    return vec4(mix(higher, lower, cutoff), linearRGB.a);
+}

--- a/plugins/mmstd_gl/shaders/mmstd_gl/shading/tonemapping.inc.glsl
+++ b/plugins/mmstd_gl/shaders/mmstd_gl/shading/tonemapping.inc.glsl
@@ -1,0 +1,7 @@
+// see https://64.github.io/tonemapping/
+vec3 reinhardExt(vec3 c, vec3 c_white){
+    return (c * (vec3(1.0)+(c/pow(c_white,vec3(2.0)))))/(vec3(1.0)+c);
+}
+float reinhardExt(float c, float c_white){
+    return (c * (1.0+(c/pow(c_white,2.0))))/(1.0+c);
+}

--- a/plugins/mmstd_gl/shaders/mmstd_gl/shading/transformations.inc.glsl
+++ b/plugins/mmstd_gl/shaders/mmstd_gl/shading/transformations.inc.glsl
@@ -1,0 +1,13 @@
+vec3 depthToWorldPos(float depth, vec2 uv, mat4 inverse_view_matrix, mat4 inverse_projection_matrix) {
+    float z = depth * 2.0 - 1.0;
+
+    vec4 cs_pos = vec4(uv * 2.0 - 1.0, z, 1.0);
+    vec4 vs_pos = inverse_projection_matrix * cs_pos;
+
+    // Perspective division
+    vs_pos /= vs_pos.w;
+    
+    vec4 ws_pos = inverse_view_matrix * vs_pos;
+
+    return ws_pos.xyz;
+}

--- a/plugins/protein_gl/shaders/protein_gl/deferred/lighting.frag.glsl
+++ b/plugins/protein_gl/shaders/protein_gl/deferred/lighting.frag.glsl
@@ -35,22 +35,9 @@ uniform bool no_lighting = false;
 
 in vec2 uv_coord;
 
+#include "mmstd_gl/shading/transformations.inc.glsl"
 #include "protein_gl/deferred/blinn_phong.glsl"
 #include "protein_gl/deferred/lambert.glsl"
-
-vec3 depthToWorldPos(float depth, vec2 uv, mat4 invview, mat4 invproj) {
-    float z = depth * 2.0 - 1.0;
-
-    vec4 cs_pos = vec4(uv * 2.0 - 1.0, z, 1.0);
-    vec4 vs_pos = invproj * cs_pos;
-
-    // Perspective division
-    vs_pos /= vs_pos.w;
-    
-    vec4 ws_pos = invview * vs_pos;
-
-    return ws_pos.xyz;
-}
 
 void main(void) {
     vec4 albedo = texture(albedo_tx2D, uv_coord);


### PR DESCRIPTION
Fixes inconsistend handling of surface color in LocalLighting (compositing_gl). Before, toon shading was only working with textured gltf rendering because it expected linear color values. However, transfer function color maps (in SciVis renderers) are perceptually linear (i.e., sRGB). Furthermore, Lambert and Phong shading did not convert linear light intensities to sRGB for the final output color.

## Summary of Changes
- Textured gltf geometry pass now outputs albedo color in sRGB
- LocalLighting (compositing_gl) now expects surface/albedo color in sRGB
- Lambert and Phong shading in LocalLighting (compositing_gl) now output sRGB color
- Several reuseable glsl functions now available in mmstd_gl/shading
