### PR TITLE
Improved ID Handling

### DIFF
--- a/plugins/geometry_calls/include/geometry_calls/Accessor.h
+++ b/plugins/geometry_calls/include/geometry_calls/Accessor.h
@@ -218,4 +218,49 @@ public:
 private:
 };
 
+
+/**
+ * Dummy accessor for reporting the idx back;
+ */
+class Accessor_Idx : public Accessor {
+public:
+    Accessor_Idx() = default;
+
+    Accessor_Idx(Accessor_Idx const& rhs) = default;
+
+    Accessor_Idx(Accessor_Idx&& rhs) = default;
+
+    Accessor_Idx& operator=(Accessor_Idx const& rhs) = default;
+
+    Accessor_Idx& operator=(Accessor_Idx&& rhs) = default;
+
+    float Get_f(size_t idx) const override {
+        return static_cast<float>(idx);
+    }
+
+    double Get_d(size_t idx) const override {
+        return static_cast<double>(idx);
+    }
+
+    uint64_t Get_u64(size_t idx) const override {
+        return static_cast<uint64_t>(idx);
+    }
+
+    unsigned int Get_u32(size_t idx) const override {
+        return static_cast<unsigned int>(idx);
+    }
+
+    unsigned short Get_u16(size_t idx) const override {
+        return static_cast<unsigned short>(idx);
+    }
+
+    unsigned char Get_u8(size_t idx) const override {
+        return static_cast<unsigned char>(idx);
+    }
+
+    ~Accessor_Idx() override = default;
+
+private:
+};
+
 } // end namespace megamol::geocalls

--- a/plugins/geometry_calls/include/geometry_calls/SimpleSphericalParticles.h
+++ b/plugins/geometry_calls/include/geometry_calls/SimpleSphericalParticles.h
@@ -201,7 +201,7 @@ public:
             } break;
             case SimpleSphericalParticles::IDDATA_NONE:
             default: {
-                this->id_acc_ = std ::make_shared<Accessor_0>();
+                this->id_acc_ = std ::make_shared<Accessor_Idx>();
             }
             }
         }

--- a/plugins/mmadios/src/ls1ParticleFormat.cpp
+++ b/plugins/mmadios/src/ls1ParticleFormat.cpp
@@ -77,8 +77,6 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
     }
     bool datahashChanged = (datahash != cad->getDataHash());
     if ((mpdc->FrameID() != currentFrame) || datahashChanged || representationDirty) {
-        representationDirty = false;
-
         cad->setFrameIDtoLoad(mpdc->FrameID());
 
         try {
@@ -92,6 +90,7 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
             cad->inquireVar("ry");
             cad->inquireVar("rz");
             cad->inquireVar("component_id");
+            cad->inquireVar("molecule_id");
             cad->inquireVar("vx");
             cad->inquireVar("vy");
             cad->inquireVar("vz");
@@ -123,6 +122,7 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
 
 
             auto comp_id = cad->getData("component_id")->GetAsUInt64();
+            auto m_id = cad->getData("molecule_id")->GetAsUInt64();
 
             auto X = cad->getData("rx")->GetAsFloat();
             auto Y = cad->getData("ry")->GetAsFloat();
@@ -170,9 +170,20 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
                 mix.resize(num_plists);
                 dirs.clear();
                 dirs.resize(num_plists);
+                ids.clear();
+                ids.resize(num_plists);
                 list_radii.clear();
                 list_radii.resize(num_plists);
                 plist_count.resize(num_plists, 0);
+
+                for (uint64_t pl_idx = 0; pl_idx < num_plists; ++pl_idx) {
+                    auto const count = std::count(comp_id.begin(), comp_id.end(), pl_idx);
+                    plist_count[pl_idx] = count;
+
+                    mix[pl_idx].reserve(count * 3);
+                    dirs[pl_idx].reserve(count * 3);
+                    ids[pl_idx].reserve(count);
+                }
 
                 for (int i = 0; i < p_count; ++i) {
                     mix[comp_id[i]].push_back(X[i]);
@@ -181,7 +192,7 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
                     dirs[comp_id[i]].push_back(VX[i]);
                     dirs[comp_id[i]].push_back(VY[i]);
                     dirs[comp_id[i]].push_back(VZ[i]);
-                    ++plist_count[comp_id[i]];
+                    ids[comp_id[i]].push_back(m_id[i]);
                 }
 
                 // calc circumsphere
@@ -205,9 +216,20 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
                 mix.resize(num_plists);
                 dirs.clear();
                 dirs.resize(num_plists);
+                ids.clear();
+                ids.resize(num_plists);
                 list_radii.clear();
                 list_radii.reserve(num_plists);
                 plist_count.resize(num_plists, 0);
+
+                for (uint64_t pl_idx = 0; pl_idx < num_plists; ++pl_idx) {
+                    auto const count = std::count(comp_id.begin(), comp_id.end(), pl_idx);
+                    plist_count[pl_idx] = count;
+
+                    mix[pl_idx].reserve(count * 3);
+                    dirs[pl_idx].reserve(count * 3);
+                    ids[pl_idx].reserve(count);
+                }
 
                 for (int j = 0; j < comp_sigmas.size(); ++j) {
                     for (int k = 0; k < comp_sigmas[j].size(); ++k) {
@@ -233,7 +255,7 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
                         dirs[component_offset[comp_id[i]] + j].push_back(VX[i]);
                         dirs[component_offset[comp_id[i]] + j].push_back(VY[i]);
                         dirs[component_offset[comp_id[i]] + j].push_back(VZ[i]);
-                        ++plist_count[component_offset[comp_id[i]] + j];
+                        ids[component_offset[comp_id[i]] + j].push_back(m_id[i]);
                     }
                 }
             }
@@ -241,7 +263,9 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
             megamol::core::utility::log::Log::DefaultLog.WriteError(
                 "[ls1ParticleFormat]: exception while trying to use data: %s", ex.what());
         }
-        version++;
+        if (datahashChanged || representationDirty)
+            version++;
+        representationDirty = false;
     }
 
     // set number of particle lists
@@ -296,6 +320,12 @@ bool ls1ParticleFormat::getDataCallback(core::Call& call) {
             parts.SetDirData(geocalls::SimpleSphericalParticles::DIRDATA_NONE, nullptr);
         } else {
             parts.SetDirData(geocalls::SimpleSphericalParticles::DIRDATA_FLOAT_XYZ, dirs[k].data());
+        }
+
+        if (ids[k].data() == nullptr) {
+            parts.SetIDData(geocalls::SimpleSphericalParticles::IDDATA_NONE, nullptr);
+        } else {
+            parts.SetIDData(geocalls::SimpleSphericalParticles::IDDATA_UINT64, ids[k].data());
         }
         parts.SetGlobalRadius(list_radii[k]);
 

--- a/plugins/mmadios/src/ls1ParticleFormat.h
+++ b/plugins/mmadios/src/ls1ParticleFormat.h
@@ -87,6 +87,7 @@ private:
 
     std::vector<std::vector<float>> mix;
     std::vector<std::vector<float>> dirs;
+    std::vector<std::vector<uint64_t>> ids;
     std::vector<uint64_t> plist_count;
     std::vector<float> bbox;
     int num_plists;


### PR DESCRIPTION
Now, if no IDs exist, the ID accessor returns particle index in stream.
Added ID output to ls1ParticleFormat.
