### PR TITLE
Fixed bug for unwanted call curve hovering in configurator

### DIFF
--- a/frontend/services/gui/src/graph/Call.cpp
+++ b/frontend/services/gui/src/graph/Call.cpp
@@ -302,10 +302,11 @@ void megamol::gui::Call::Draw(megamol::gui::PresentPhase phase, megamol::gui::Gr
                         } else {
                             diff_vec -= ImBezierCubicClosestPoint(bez_p1, bez_p2, bez_p3, bez_p4, mouse_pos, 10.0f);
                         }
-                        auto curve_hovered = (fabs(diff_vec.x) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
-                                             (fabs(diff_vec.y) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
-                                            !ImGui::IsPopupOpen(ImGuiID(0), ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
-                                            /// Prevent curve hovering when pop up is open and might occlude call curve
+                        auto curve_hovered =
+                            (fabs(diff_vec.x) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
+                            (fabs(diff_vec.y) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
+                            !ImGui::IsPopupOpen(ImGuiID(0), ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
+                        /// Prevent curve hovering when pop up is open and might occlude call curve
 
                         if (this->gui_set_active || ImGui::IsItemActivated() ||
                             (curve_hovered && ImGui::IsMouseReleased(ImGuiMouseButton_Left))) {

--- a/frontend/services/gui/src/graph/Call.cpp
+++ b/frontend/services/gui/src/graph/Call.cpp
@@ -303,7 +303,9 @@ void megamol::gui::Call::Draw(megamol::gui::PresentPhase phase, megamol::gui::Gr
                             diff_vec -= ImBezierCubicClosestPoint(bez_p1, bez_p2, bez_p3, bez_p4, mouse_pos, 10.0f);
                         }
                         auto curve_hovered = (fabs(diff_vec.x) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
-                                             (fabs(diff_vec.y) <= std::max(1.0f, bez_linewidth / 2.0f));
+                                             (fabs(diff_vec.y) <= std::max(1.0f, bez_linewidth / 2.0f)) &&
+                                            !ImGui::IsPopupOpen(ImGuiID(0), ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
+                                            /// Prevent curve hovering when pop up is open and might occlude call curve
 
                         if (this->gui_set_active || ImGui::IsItemActivated() ||
                             (curve_hovered && ImGui::IsMouseReleased(ImGuiMouseButton_Left))) {

--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -2404,14 +2404,14 @@ void megamol::gui::Graph::draw_canvas(ImVec2 position, ImVec2 size, GraphState_t
         for (auto& group_ptr : this->GetGroups()) {
             group_ptr->Draw(phase, this->gui_graph_state);
 
-            // 3] MODULES and CALL SLOTS (of group) ---------------------------
+            // 2] MODULES and CALL SLOTS (of group) ---------------------------
             for (auto& module_ptr : this->Modules()) {
                 if (module_ptr->GroupUID() == group_ptr->UID()) {
                     module_ptr->Draw(phase, this->gui_graph_state);
                 }
             }
 
-            // 2] CALLS (of group) --------------------------------------------
+            // 3] CALLS (of group) --------------------------------------------
             for (auto& module_ptr : this->Modules()) {
                 if (module_ptr->GroupUID() == group_ptr->UID()) {
                     /// Check only for calls of caller slots for considering each call only once

--- a/frontend/services/gui/src/graph/Module.cpp
+++ b/frontend/services/gui/src/graph/Module.cpp
@@ -525,7 +525,9 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
 #ifdef MEGAMOL_USE_PROFILING
                     // Profiling Button
                     if (profiling_button) {
-                        ImGui::SameLine(0.0f, style.ItemSpacing.x * state.canvas.zooming);
+                        if (parameter_button || graph_entry_button) {
+                            ImGui::SameLine(0.0f, style.ItemSpacing.x * state.canvas.zooming);
+                        }
 
                         // Lazy loading of performance button texture
                         if (!this->gui_profiling_button.IsLoaded()) {

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -24,7 +24,6 @@ megamol::gui::Configurator::Configurator(
         , module_list_popup_hovered_group_uid(GUI_INVALID_ID)
         , show_module_list_sidebar(false)
         , show_module_list_popup(false)
-        , module_list_popup_pos()
         , last_selected_callslot_uid(GUI_INVALID_ID)
         , open_popup_load(false)
         , file_browser()
@@ -200,9 +199,11 @@ void megamol::gui::Configurator::PopUps() {
             this->module_list_popup_hovered_group_uid = selected_graph_ptr->GetHoveredGroup();
         }
     }
+
+    ImVec2 module_list_popup_pos;
     if (this->graph_state.hotkeys[HOTKEY_CONFIGURATOR_MODULE_SEARCH].is_pressed) {
         this->show_module_list_popup = true;
-        this->module_list_popup_pos = ImGui::GetMousePos();
+        module_list_popup_pos = ImGui::GetMousePos();
     }
     if (this->show_module_list_popup) {
 
@@ -216,31 +217,33 @@ void megamol::gui::Configurator::PopUps() {
             ImGui::OpenPopup(pop_up_id.c_str(), ImGuiPopupFlags_None);
             this->search_widget.SetSearchFocus();
 
-            float diff_width = (this->win_config.position.x + this->win_config.size.x - this->module_list_popup_pos.x);
-            float diff_height = (this->win_config.position.y + this->win_config.size.y - this->module_list_popup_pos.y);
+            float diff_width = (this->win_config.position.x + this->win_config.size.x - module_list_popup_pos.x);
+            float diff_height = (this->win_config.position.y + this->win_config.size.y - module_list_popup_pos.y);
             if (diff_width < popup_width) {
-                this->module_list_popup_pos.x -= ((popup_width - diff_width) + offset_x);
+                module_list_popup_pos.x -= ((popup_width - diff_width) + offset_x);
             }
-            this->module_list_popup_pos.x = std::max(this->module_list_popup_pos.x, this->win_config.position.x);
+            module_list_popup_pos.x = std::max(module_list_popup_pos.x, this->win_config.position.x);
             if (diff_height < popup_height) {
-                this->module_list_popup_pos.y -= ((popup_height - diff_height) + offset_y);
+                module_list_popup_pos.y -= ((popup_height - diff_height) + offset_y);
             }
-            this->module_list_popup_pos.y = std::max(this->module_list_popup_pos.y, this->win_config.position.y);
-            ImGui::SetNextWindowPos(this->module_list_popup_pos);
+            module_list_popup_pos.y = std::max(module_list_popup_pos.y, this->win_config.position.y);
+            ImGui::SetNextWindowPos(module_list_popup_pos);
             ImGui::SetNextWindowSize(ImVec2(10.0f, 10.0f));
         }
         auto popup_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar |
-                           ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove;
+                           ImGuiWindowFlags_NoCollapse;
         if (ImGui::BeginPopup(pop_up_id.c_str(), popup_flags)) {
+
+            ImVec2 popup_position = ImGui::GetWindowPos();
 
             this->draw_window_module_list(
                 std::max(0.0f, (popup_width - offset_x)), std::max(0.0f, (popup_height - offset_y)), false);
 
             bool module_list_popup_hovered = false;
-            if ((ImGui::GetMousePos().x >= this->module_list_popup_pos.x) &&
-                (ImGui::GetMousePos().x <= (this->module_list_popup_pos.x + popup_width)) &&
-                (ImGui::GetMousePos().y >= this->module_list_popup_pos.y) &&
-                (ImGui::GetMousePos().y <= (this->module_list_popup_pos.y + popup_height))) {
+            if ((ImGui::GetMousePos().x >= popup_position.x) &&
+                (ImGui::GetMousePos().x <= (popup_position.x + popup_width)) &&
+                (ImGui::GetMousePos().y >= popup_position.y) &&
+                (ImGui::GetMousePos().y <= (popup_position.y + popup_height))) {
                 module_list_popup_hovered = true;
             }
             if (((ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !module_list_popup_hovered)) ||

--- a/frontend/services/gui/src/windows/Configurator.h
+++ b/frontend/services/gui/src/windows/Configurator.h
@@ -72,7 +72,6 @@ private:
     ImGuiID module_list_popup_hovered_group_uid;
     bool show_module_list_sidebar;
     bool show_module_list_popup;
-    ImVec2 module_list_popup_pos;
     ImGuiID last_selected_callslot_uid;
     bool open_popup_load;
 


### PR DESCRIPTION

<!--
  Add a description here.
  Include a list of issues it fixes in the "Fixes #[]" format if applicable.
-->

## Summary of Changes
- prevent call curve hovering when a pop-up is open
- fixed profiling button position of modules
- allow moving module pop-up

## References and Context
<!--
  Optional. A list of references of this PR, for instance related PRs or scientific papers,
  or any other context about this PR relevant for the devs.
-->

## Test Instructions
<!--
  Optional. For large feature PRs, test instructions are required for the devs to review the PR.
  Include, if possible, the expected behavior.
-->
