### PR TITLE
Unified saving of parameter values

### DIFF
--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -1251,16 +1251,18 @@ void megamol::gui::GUIManager::draw_popups() {
         this->gui_state.open_popup_save |= this->win_configurator_ptr->ConsumeTriggeredGlobalProjectSave();
 
         auto filename = graph_ptr->GetFilename();
-        auto save_gui_state = vislib::math::Ternary(vislib::math::Ternary::TRI_FALSE);
+        bool save_all_param_values = false;
+        bool save_gui_state = false;
         bool popup_failed = false;
         if (this->file_browser.PopUp_Save("Save Running Project", filename, this->gui_state.open_popup_save, {"lua"},
-                megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state)) {
+                megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,
+                save_all_param_values)) {
             std::string state_str;
-            if (save_gui_state.IsTrue()) {
+            if (save_gui_state) {
                 state_str = this->project_to_lua_string(true);
             }
             popup_failed = !this->win_configurator_ptr->GetGraphCollection().SaveProjectToFile(
-                graph_ptr->UID(), filename, state_str);
+                graph_ptr->UID(), filename, state_str, save_all_param_values);
         }
         PopUps::Minimal(
             "Failed to Save Project", popup_failed, "See console log output for more information.", "Cancel");
@@ -1279,10 +1281,10 @@ void megamol::gui::GUIManager::draw_popups() {
     this->gui_hotkeys[HOTKEY_GUI_LOAD_PROJECT].is_pressed = false;
 
     // File name for screenshot pop-up
-    auto tmp_flag = vislib::math::Ternary(vislib::math::Ternary::TRI_UNKNOWN);
+    auto dummy = false;
     if (this->file_browser.PopUp_Save("File Name for Screenshot", this->gui_state.screenshot_filepath,
             this->gui_state.open_popup_screenshot, {"png"},
-            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, tmp_flag)) {
+            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, dummy, dummy)) {
         this->gui_state.screenshot_filepath_id = 0;
     }
 

--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -1251,9 +1251,10 @@ void megamol::gui::GUIManager::draw_popups() {
         this->gui_state.open_popup_save |= this->win_configurator_ptr->ConsumeTriggeredGlobalProjectSave();
 
         auto filename = graph_ptr->GetFilename();
-        bool save_all_param_values = false;
-        bool save_gui_state = false;
         bool popup_failed = false;
+        // Default for saving gui state and parameter values
+        bool save_all_param_values = true;
+        bool save_gui_state = false;
         if (this->file_browser.PopUp_Save("Save Running Project", filename, this->gui_state.open_popup_save, {"lua"},
                 megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,
                 save_all_param_values)) {

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -1848,8 +1848,8 @@ bool megamol::gui::GraphCollection::save_graph_dialog(ImGuiID graph_uid, bool& o
             project_filename = graph_ptr->GetFilename();
         }
     }
-    // Default for option asking for saving gui state
-    bool save_all_param_values = false;
+    // Default for saving gui state and parameter values
+    bool save_all_param_values = true;
     bool save_gui_state = false;
     if (this->gui_file_browser.PopUp_Save("Save Configurator Project", project_filename, open_dialog, {"lua"},
             megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -837,8 +837,8 @@ bool megamol::gui::GraphCollection::LoadOrAddProjectFromFile(
 }
 
 
-bool megamol::gui::GraphCollection::SaveProjectToFile(
-    ImGuiID in_graph_uid, const std::string& project_filename, const std::string& state_json, bool write_all_param_values) {
+bool megamol::gui::GraphCollection::SaveProjectToFile(ImGuiID in_graph_uid, const std::string& project_filename,
+    const std::string& state_json, bool write_all_param_values) {
 
     /// Should be same as: megamol::core::MegaMolGraph_Convenience::SerializeGraph()
     try {

--- a/frontend/services/gui/src/graph/GraphCollection.cpp
+++ b/frontend/services/gui/src/graph/GraphCollection.cpp
@@ -838,7 +838,7 @@ bool megamol::gui::GraphCollection::LoadOrAddProjectFromFile(
 
 
 bool megamol::gui::GraphCollection::SaveProjectToFile(
-    ImGuiID in_graph_uid, const std::string& project_filename, const std::string& state_json) {
+    ImGuiID in_graph_uid, const std::string& project_filename, const std::string& state_json, bool write_all_param_values) {
 
     /// Should be same as: megamol::core::MegaMolGraph_Convenience::SerializeGraph()
     try {
@@ -873,10 +873,9 @@ bool megamol::gui::GraphCollection::SaveProjectToFile(
                     }
 
                     for (auto& parameter : module_ptr->Parameters()) {
-                        // - Write all parameters for running graph (default value is not available)
-                        // - For other graphs only write parameters with other values than the default
-                        // - Ignore button parameters
-                        if ((graph_ptr->IsRunning() || parameter.DefaultValueMismatch()) &&
+                        // Either write_all_param_values or only write parameters with values deviating from the default
+                        // Button parameters are always ignored
+                        if ((write_all_param_values || parameter.DefaultValueMismatch()) &&
                             (parameter.Type() != ParamType_t::BUTTON)) {
                             confParams << "mmSetParamValue(\"" << parameter.FullNameProject() << "\",[=["
                                        << parameter.GetValueString() << "]=])\n";
@@ -1506,8 +1505,9 @@ bool megamol::gui::GraphCollection::NotifyRunningGraph_AddModule(core::ModuleIns
                 if (param_slot != nullptr) {
                     std::string param_full_name(param_slot->FullName().PeekBuffer());
                     std::shared_ptr<Parameter> param_ptr;
+                    // This is the default value of the parameter since changed values are propagated separately via parameter subscription
                     megamol::gui::Parameter::ReadNewCoreParameterToNewParameter(
-                        (*param_slot), param_ptr, false, false, true, gui_module_ptr->FullName());
+                        (*param_slot), param_ptr, true, false, true, gui_module_ptr->FullName());
                     gui_module_ptr->Parameters().emplace_back((*param_ptr));
                 }
 
@@ -1849,16 +1849,18 @@ bool megamol::gui::GraphCollection::save_graph_dialog(ImGuiID graph_uid, bool& o
         }
     }
     // Default for option asking for saving gui state
-    auto save_gui_state = vislib::math::Ternary(vislib::math::Ternary::TRI_FALSE);
+    bool save_all_param_values = false;
+    bool save_gui_state = false;
     if (this->gui_file_browser.PopUp_Save("Save Configurator Project", project_filename, open_dialog, {"lua"},
-            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state)) {
+            megamol::core::param::FilePathParam::Flag_File_ToBeCreatedWithRestrExts, save_gui_state,
+            save_all_param_values)) {
 
         std::string gui_state;
-        if (save_gui_state.IsTrue()) {
+        if (save_gui_state) {
             gui_state = this->get_state(graph_uid, project_filename);
         }
 
-        popup_failed = !this->SaveProjectToFile(graph_uid, project_filename, gui_state);
+        popup_failed = !this->SaveProjectToFile(graph_uid, project_filename, gui_state, save_all_param_values);
     }
     PopUps::Minimal("Failed to Save Project", popup_failed, "See console log output for more information.", "Cancel");
 

--- a/frontend/services/gui/src/graph/GraphCollection.h
+++ b/frontend/services/gui/src/graph/GraphCollection.h
@@ -70,7 +70,8 @@ public:
 
     bool LoadOrAddProjectFromFile(ImGuiID in_graph_uid, const std::string& project_filename);
 
-    bool SaveProjectToFile(ImGuiID in_graph_uid, const std::string& project_filename, const std::string& state_json);
+    bool SaveProjectToFile(ImGuiID in_graph_uid, const std::string& project_filename, const std::string& state_json,
+        bool write_all_param_values);
 
     void Draw(GraphState_t& state);
 

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
@@ -161,9 +161,8 @@ bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, 
             // File browser selectables ---------------------------------------
             auto select_flags = ImGuiSelectableFlags_DontClosePopups;
             // Footer Height: 1x save gui state line + 2x line for button + 2x max log lines
-            float footer_height =
-                ImGui::GetFrameHeightWithSpacing() * ((mode != DIALOGMODE_SAVE) ? (2.0f) : (3.0f)) +
-                (ImGui::GetTextLineHeightWithSpacing() * 2.0f);
+            float footer_height = ImGui::GetFrameHeightWithSpacing() * ((mode != DIALOGMODE_SAVE) ? (2.0f) : (3.0f)) +
+                                  (ImGui::GetTextLineHeightWithSpacing() * 2.0f);
             float child_select_height = (ImGui::GetContentRegionAvail().y - footer_height);
             ImGui::BeginChild(
                 "files_list_child_window", ImVec2(0.0f, child_select_height), true, ImGuiWindowFlags_None);

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.cpp
@@ -29,7 +29,8 @@ megamol::gui::FileBrowserWidget::FileBrowserWidget()
         , file_errors()
         , file_warnings()
         , child_directories()
-        , save_gui_state(vislib::math::Ternary::TRI_UNKNOWN)
+        , save_gui_state(false)
+        , save_all_param_values(false)
         , label_uid_map()
         , search_widget()
         , tooltip() {
@@ -84,7 +85,7 @@ bool megamol::gui::FileBrowserWidget::Button_Select(
 
 bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, const std::string& label,
     std::string& inout_filename, bool& inout_open_popup, const FilePathParam::Extensions_t& extensions,
-    FilePathParam::Flags_t flags, vislib::math::Ternary& inout_save_gui_state) {
+    FilePathParam::Flags_t flags, bool& inout_save_gui_state, bool& inout_save_all_param_values) {
 
     bool retval = false;
 
@@ -119,7 +120,9 @@ bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, 
             inout_open_popup = false;
 
             this->search_widget.ClearSearchString();
+
             this->save_gui_state = inout_save_gui_state;
+            this->save_all_param_values = inout_save_all_param_values;
         }
 
         bool open = true;
@@ -159,7 +162,7 @@ bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, 
             auto select_flags = ImGuiSelectableFlags_DontClosePopups;
             // Footer Height: 1x save gui state line + 2x line for button + 2x max log lines
             float footer_height =
-                ImGui::GetFrameHeightWithSpacing() * ((inout_save_gui_state.IsUnknown()) ? (2.0f) : (3.0f)) +
+                ImGui::GetFrameHeightWithSpacing() * ((mode != DIALOGMODE_SAVE) ? (2.0f) : (3.0f)) +
                 (ImGui::GetTextLineHeightWithSpacing() * 2.0f);
             float child_select_height = (ImGui::GetContentRegionAvail().y - footer_height);
             ImGui::BeginChild(
@@ -298,12 +301,12 @@ bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, 
             }
 
             // Optional save GUI state option ------------
-            if (!inout_save_gui_state.IsUnknown()) {
-                bool check = this->save_gui_state.IsTrue();
-                megamol::gui::ButtonWidgets::ToggleButton("Save GUI state", check);
-                this->save_gui_state =
-                    ((check) ? (vislib::math::Ternary::TRI_TRUE) : (vislib::math::Ternary::TRI_FALSE));
+            if (mode == DIALOGMODE_SAVE) {
+                megamol::gui::ButtonWidgets::ToggleButton("Save GUI state", this->save_gui_state);
                 this->tooltip.Marker("Check this option to also save all settings affecting the GUI.");
+                ImGui::SameLine();
+                megamol::gui::ButtonWidgets::ToggleButton("Save all parameter values", this->save_all_param_values);
+                this->tooltip.Marker("Check this option to save all paramter values, not only the changed.");
             }
 
             // Buttons --------------------------
@@ -351,6 +354,7 @@ bool megamol::gui::FileBrowserWidget::popup(FileBrowserWidget::DialogMode mode, 
                 }
                 inout_filename = tmp_path.generic_u8string();
                 inout_save_gui_state = this->save_gui_state;
+                inout_save_all_param_values = this->save_all_param_values;
                 ImGui::CloseCurrentPopup();
                 retval = true;
             }

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.h
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.h
@@ -41,19 +41,19 @@ public:
      */
     bool PopUp_Save(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
         const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags,
-        vislib::math::Ternary& inout_save_gui_state) {
-        return this->popup(
-            DIALOGMODE_SAVE, label, inout_filename, inout_open_popup, extensions, flags, inout_save_gui_state);
+        bool& inout_save_gui_state, bool& inout_save_all_param_values) {
+        return this->popup(DIALOGMODE_SAVE, label, inout_filename, inout_open_popup, extensions, flags,
+            inout_save_gui_state, inout_save_all_param_values);
     }
     bool PopUp_Load(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
         const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags) {
-        auto tmp = vislib::math::Ternary(vislib::math::Ternary::TRI_UNKNOWN);
-        return this->popup(DIALOGMODE_LOAD, label, inout_filename, inout_open_popup, extensions, flags, tmp);
+        bool dummy = false;
+        return this->popup(DIALOGMODE_LOAD, label, inout_filename, inout_open_popup, extensions, flags, dummy, dummy);
     }
     bool PopUp_Select(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
         const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags) {
-        auto tmp = vislib::math::Ternary(vislib::math::Ternary::TRI_UNKNOWN);
-        return this->popup(DIALOGMODE_SELECT, label, inout_filename, inout_open_popup, extensions, flags, tmp);
+        bool dummy = false;
+        return this->popup(DIALOGMODE_SELECT, label, inout_filename, inout_open_popup, extensions, flags, dummy, dummy);
     }
 
     /**
@@ -90,7 +90,8 @@ private:
 
     // Keeps child paths and flag whether child is directors or not
     std::vector<ChildData_t> child_directories;
-    vislib::math::Ternary save_gui_state;
+    bool save_gui_state;
+    bool save_all_param_values;
     std::map<std::string, std::string> label_uid_map;
 
     StringSearchWidget search_widget;
@@ -100,7 +101,7 @@ private:
 
     bool popup(DialogMode mode, const std::string& label, std::string& inout_filename, bool& inout_open_popup,
         const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags,
-        vislib::math::Ternary& inout_save_gui_state);
+        bool& inout_save_gui_state, bool& inout_save_all_param_values);
 
     bool validate_split_path(
         const std::string& in_path, FilePathParam::Flags_t flags, std::string& out_dir, std::string& out_file) const;

--- a/frontend/services/gui/src/widgets/FileBrowserWidget.h
+++ b/frontend/services/gui/src/widgets/FileBrowserWidget.h
@@ -40,8 +40,8 @@ public:
      * @return True on success, false otherwise.
      */
     bool PopUp_Save(const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags,
-        bool& inout_save_gui_state, bool& inout_save_all_param_values) {
+        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags, bool& inout_save_gui_state,
+        bool& inout_save_all_param_values) {
         return this->popup(DIALOGMODE_SAVE, label, inout_filename, inout_open_popup, extensions, flags,
             inout_save_gui_state, inout_save_all_param_values);
     }
@@ -100,8 +100,8 @@ private:
     // FUNCTIONS --------------------------------------------------------------
 
     bool popup(DialogMode mode, const std::string& label, std::string& inout_filename, bool& inout_open_popup,
-        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags,
-        bool& inout_save_gui_state, bool& inout_save_all_param_values);
+        const FilePathParam::Extensions_t& extensions, FilePathParam::Flags_t flags, bool& inout_save_gui_state,
+        bool& inout_save_all_param_values);
 
     bool validate_split_path(
         const std::string& in_path, FilePathParam::Flags_t flags, std::string& out_dir, std::string& out_file) const;


### PR DESCRIPTION
Added option to either save all parameter values to the project file or to only save the parameters with values deviating from the default. Option works for the running graph and "configurator only" graphs the same way. 

Fixes #1183

## Summary of Changes


## References and Context
<!--
  Optional. A list of references of this PR, for instance related PRs or scientific papers,
  or any other context about this PR relevant for the devs.
-->

## Test Instructions
<!--
  Optional. For large feature PRs, test instructions are required for the devs to review the PR.
  Include, if possible, the expected behavior.
-->
