### PR TITLE
fix cli params

### DIFF
--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -1,6 +1,7 @@
 
 #include "CLIConfigParsing.h"
 
+#define CXXOPTS_VECTOR_DELIMITER '\0'
 #include <cxxopts.hpp>
 
 #include <filesystem>
@@ -277,10 +278,6 @@ static void echolevel_handler(
 static void project_handler(
     std::string const& option_name, cxxopts::ParseResult const& parsed_options, RuntimeConfig& config) {
     auto v = parsed_options[option_name].as<std::vector<std::string>>();
-    while (v.size() > 1) {
-        v.front() += "," + v[1];
-        v.pop_back();
-    }
     files_exist(v, "Project file");
 
     config.project_files.insert(config.project_files.end(), v.begin(), v.end());


### PR DESCRIPTION
## Summary of Changes
Revert the comma separator fix from #1172.
Merging all project params with a comma, does also concat different file names. Instead we now remove the comma delimiter from cxxopts. This will allow string values containing commas (i.e. filenames), but on the other hand will not allow to provide vector cli parameters at all. Is probably not a optimal solution, but maybe a better hotfix.

This will not work anymore with this hotfix: `--param param1=value1,param2=value2`
Use this instead: `--param param1=value1 --param param2=value2`