### PR TITLE
Configurator: Fix additional "ghost" module when adding new module to group

### DIFF
--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -290,7 +290,7 @@ bool megamol::gui::Graph::DeleteModule(ImGuiID module_uid, bool use_queue) {
                 if (module_group_ptr != nullptr) {
                     module_group_ptr->RestoreInterfaceslots();
                 }
-                
+
 
 #ifdef GUI_VERBOSE
                 megamol::core::utility::log::Log::DefaultLog.WriteInfo(
@@ -885,8 +885,9 @@ ImGuiID megamol::gui::Graph::AddGroupModule(
         for (auto& group_ptr : this->groups) {
             if (group_ptr->Name() == group_name) {
                 if (existing_group_uid != GUI_INVALID_ID) {
-                megamol::core::utility::log::Log::DefaultLog.WriteWarn(
-                    "[GUI] Warning: Found groups with same name. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);
+                    megamol::core::utility::log::Log::DefaultLog.WriteWarn(
+                        "[GUI] Warning: Found groups with same name. [%s, %s, line %d]\n", __FILE__, __FUNCTION__,
+                        __LINE__);
                 }
                 existing_group_uid = group_ptr->UID();
             }
@@ -903,11 +904,9 @@ ImGuiID megamol::gui::Graph::AddGroupModule(
                 }
             }
         }
-
     }
     return GUI_INVALID_ID;
 }
-
 
 
 ImGuiID megamol::gui::Graph::AddGroupModule(ImGuiID group_uid, const ModulePtr_t& module_ptr, bool use_queue) {
@@ -915,16 +914,16 @@ ImGuiID megamol::gui::Graph::AddGroupModule(ImGuiID group_uid, const ModulePtr_t
     try {
         // Add module to group
         for (auto& group_ptr : this->groups) {
-                if (group_ptr->UID() == group_uid) {
+            if (group_ptr->UID() == group_uid) {
                 Graph::QueueData queue_data;
                 queue_data.name_id = module_ptr->FullName();
                 if (group_ptr->AddModule(module_ptr)) {
-                queue_data.rename_id = module_ptr->FullName();
-                if (use_queue) {
-                    this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
-                }
-                this->ForceSetDirty();
-                return group_uid;
+                    queue_data.rename_id = module_ptr->FullName();
+                    if (use_queue) {
+                        this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
+                    }
+                    this->ForceSetDirty();
+                    return group_uid;
                 }
             }
         }
@@ -946,7 +945,7 @@ ImGuiID megamol::gui::Graph::AddGroupModule(ImGuiID group_uid, const ModulePtr_t
 ImGuiID megamol::gui::Graph::RemoveGroupModule(
     ImGuiID group_uid, ImGuiID module_uid, bool use_queue, bool reset_interface) {
 
-     try {
+    try {
         // Remove module to group
         for (auto& group_ptr : this->groups) {
             if (group_ptr->UID() == group_uid) {

--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -263,14 +263,8 @@ bool megamol::gui::Graph::DeleteModule(ImGuiID module_uid, bool use_queue) {
                 GroupPtr_t module_group_ptr = nullptr;
                 for (auto& group_ptr : this->groups) {
                     if (group_ptr->ContainsModule(module_uid)) {
-                        group_ptr->RemoveModule(module_uid);
                         module_group_ptr = group_ptr;
-
-                        queue_data.name_id = current_full_name;
-                        queue_data.rename_id = (*iter)->FullName();
-                        if (use_queue) {
-                            this->PushSyncQueue(QueueAction::RENAME_MODULE, queue_data);
-                        }
+                        this->RemoveGroupModule(group_ptr->UID(), module_uid, use_queue, false);
                     }
                 }
 
@@ -296,6 +290,7 @@ bool megamol::gui::Graph::DeleteModule(ImGuiID module_uid, bool use_queue) {
                 if (module_group_ptr != nullptr) {
                     module_group_ptr->RestoreInterfaceslots();
                 }
+                
 
 #ifdef GUI_VERBOSE
                 megamol::core::utility::log::Log::DefaultLog.WriteInfo(
@@ -803,12 +798,13 @@ ImGuiID megamol::gui::Graph::AddGroup(const std::string& group_name) {
         auto group_ptr = std::make_shared<Group>(group_id);
         group_ptr->SetName((group_name.empty()) ? (this->generate_unique_group_name()) : (group_name));
         this->groups.emplace_back(group_ptr);
-        this->ForceSetDirty();
 
 #ifdef GUI_VERBOSE
         megamol::core::utility::log::Log::DefaultLog.WriteInfo("[GUI] Added group '%s' (uid %i) to project '%s'.\n",
             group_ptr->Name().c_str(), group_ptr->UID(), this->name.c_str());
 #endif // GUI_VERBOSE
+
+        this->ForceSetDirty();
         return group_id;
 
     } catch (std::exception& e) {
@@ -840,7 +836,6 @@ megamol::gui::GroupPtr_t megamol::gui::Graph::GetGroup(ImGuiID group_uid) {
 
 bool megamol::gui::Graph::DeleteGroup(ImGuiID group_uid) {
 
-    // ! No syncronisation of module renaming considered
     try {
         for (auto iter = this->groups.begin(); iter != this->groups.end(); iter++) {
             if ((*iter)->UID() == group_uid) {
@@ -861,8 +856,6 @@ bool megamol::gui::Graph::DeleteGroup(ImGuiID group_uid) {
                 this->groups.erase(iter);
 
                 this->ForceSetDirty();
-
-                this->ForceUpdate();
                 return true;
             }
         }
@@ -885,32 +878,90 @@ bool megamol::gui::Graph::DeleteGroup(ImGuiID group_uid) {
 ImGuiID megamol::gui::Graph::AddGroupModule(
     const std::string& group_name, const ModulePtr_t& module_ptr, bool use_queue) {
 
-    try {
-        // Only create new group if given name is not empty
-        if (!group_name.empty()) {
-            // Check if group with given name already exists
-            ImGuiID existing_group_uid = GUI_INVALID_ID;
-            for (auto& group_ptr : this->groups) {
-                if (group_ptr->Name() == group_name) {
-                    existing_group_uid = group_ptr->UID();
+    // Only create new group if given name is not empty
+    if (!group_name.empty()) {
+        // Check if group with given name already exists
+        ImGuiID existing_group_uid = GUI_INVALID_ID;
+        for (auto& group_ptr : this->groups) {
+            if (group_ptr->Name() == group_name) {
+                if (existing_group_uid != GUI_INVALID_ID) {
+                megamol::core::utility::log::Log::DefaultLog.WriteWarn(
+                    "[GUI] Warning: Found groups with same name. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);
+                }
+                existing_group_uid = group_ptr->UID();
+            }
+        }
+        // Create new group if there is no one with given name
+        if (existing_group_uid == GUI_INVALID_ID) {
+            existing_group_uid = this->AddGroup(group_name);
+        }
+        // Add module to group
+        for (auto& group_ptr : this->groups) {
+            if (group_ptr->UID() == existing_group_uid) {
+                if (this->AddGroupModule(existing_group_uid, module_ptr, use_queue) != GUI_INVALID_ID) {
+                    return existing_group_uid;
                 }
             }
-            // Create new group if there is no one with given name
-            if (existing_group_uid == GUI_INVALID_ID) {
-                existing_group_uid = this->AddGroup(group_name);
+        }
+
+    }
+    return GUI_INVALID_ID;
+}
+
+
+
+ImGuiID megamol::gui::Graph::AddGroupModule(ImGuiID group_uid, const ModulePtr_t& module_ptr, bool use_queue) {
+
+    try {
+        // Add module to group
+        for (auto& group_ptr : this->groups) {
+                if (group_ptr->UID() == group_uid) {
+                Graph::QueueData queue_data;
+                queue_data.name_id = module_ptr->FullName();
+                if (group_ptr->AddModule(module_ptr)) {
+                queue_data.rename_id = module_ptr->FullName();
+                if (use_queue) {
+                    this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
+                }
+                this->ForceSetDirty();
+                return group_uid;
+                }
             }
-            // Add module to group
-            for (auto& group_ptr : this->groups) {
-                if (group_ptr->UID() == existing_group_uid) {
-                    Graph::QueueData queue_data;
-                    queue_data.name_id = module_ptr->FullName();
-                    if (group_ptr->AddModule(module_ptr)) {
-                        queue_data.rename_id = module_ptr->FullName();
-                        if (use_queue) {
-                            this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
+        }
+
+    } catch (std::exception& e) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError(
+            "[GUI] Error: %s [%s, %s, line %d]\n", e.what(), __FILE__, __FUNCTION__, __LINE__);
+        return GUI_INVALID_ID;
+    } catch (...) {
+        megamol::core::utility::log::Log::DefaultLog.WriteError(
+            "[GUI] Unknown Error. [%s, %s, line %d]\n", __FILE__, __FUNCTION__, __LINE__);
+        return GUI_INVALID_ID;
+    }
+
+    return GUI_INVALID_ID;
+}
+
+
+ImGuiID megamol::gui::Graph::RemoveGroupModule(
+    ImGuiID group_uid, ImGuiID module_uid, bool use_queue, bool reset_interface) {
+
+     try {
+        // Remove module to group
+        for (auto& group_ptr : this->groups) {
+            if (group_ptr->UID() == group_uid) {
+                for (auto module_ptr : this->modules) {
+                    if (module_ptr->UID() == module_uid) {
+                        Graph::QueueData queue_data;
+                        queue_data.name_id = module_ptr->FullName();
+                        if (group_ptr->RemoveModule(module_ptr->UID(), reset_interface)) {
+                            queue_data.rename_id = module_ptr->FullName();
+                            if (use_queue) {
+                                this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
+                            }
+                            this->ForceSetDirty();
+                            return group_uid;
                         }
-                        this->ForceSetDirty();
-                        return existing_group_uid;
                     }
                 }
             }
@@ -972,8 +1023,6 @@ bool megamol::gui::Graph::UniqueModuleRename(const std::string& module_full_name
             queue_data.name_id = module_full_name;
             queue_data.rename_id = mod->FullName();
             this->PushSyncQueue(QueueAction::RENAME_MODULE, queue_data);
-
-            this->ForceUpdate();
 
             megamol::core::utility::log::Log::DefaultLog.WriteWarn(
                 "[GUI] Renamed existing module '%s' while adding module with same name. "
@@ -1726,8 +1775,6 @@ void megamol::gui::Graph::Draw(GraphState_t& state) {
                         }
                     }
                     if (module_ptr != nullptr) {
-                        std::string current_module_fullname = module_ptr->FullName();
-
                         // Add module to new or already existing group
                         // Create new group for multiple selected modules only once!
                         ImGuiID group_uid = GUI_INVALID_ID;
@@ -1740,25 +1787,12 @@ void megamol::gui::Graph::Draw(GraphState_t& state) {
                             group_uid = uid_pair.second;
                         }
 
-                        if (auto add_group_ptr = this->GetGroup(group_uid)) {
-                            Graph::QueueData queue_data;
-                            queue_data.name_id = module_ptr->FullName();
-
-                            // Remove module from previous associated group
-                            ImGuiID module_group_uid = module_ptr->GroupUID();
-                            if (auto remove_group_ptr = this->GetGroup(module_group_uid)) {
-                                if (remove_group_ptr->UID() != add_group_ptr->UID()) {
-                                    remove_group_ptr->RemoveModule(module_ptr->UID());
-                                    remove_group_ptr->RestoreInterfaceslots();
-                                }
-                            }
-
-                            // Add module to group
-                            add_group_ptr->AddModule(module_ptr);
-                            queue_data.rename_id = module_ptr->FullName();
-                            this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
-                            this->ForceSetDirty();
-                        }
+                        /// Without intermediate renaming via queue!
+                        /// Would trigger megamol::gui::GraphCollection::NotifyRunningGraph_RenameModule for already renamed module!
+                        std::string current_module_groupname = module_ptr->GroupName();
+                        this->RemoveGroupModule(module_ptr->GroupUID(), module_ptr->UID(), false);
+                        module_ptr->SetGroupName(current_module_groupname);
+                        this->AddGroupModule(group_uid, module_ptr, true);
                     }
                 }
                 reset_state = true;
@@ -1766,21 +1800,9 @@ void megamol::gui::Graph::Draw(GraphState_t& state) {
             // Remove module from group -------------------------------------------
             if (!this->gui_graph_state.interact.modules_remove_group_uids.empty()) {
                 for (auto& module_uid : this->gui_graph_state.interact.modules_remove_group_uids) {
-                    ModulePtr_t module_ptr;
-                    for (auto& mod : this->Modules()) {
-                        if (mod->UID() == module_uid) {
-                            module_ptr = mod;
-                        }
-                    }
                     for (auto& remove_group_ptr : this->GetGroups()) {
                         if (remove_group_ptr->ContainsModule(module_uid)) {
-                            Graph::QueueData queue_data;
-                            queue_data.name_id = module_ptr->FullName();
-                            remove_group_ptr->RemoveModule(module_ptr->UID());
-                            remove_group_ptr->RestoreInterfaceslots();
-                            queue_data.rename_id = module_ptr->FullName();
-                            this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
-                            this->ForceSetDirty();
+                            this->RemoveGroupModule(remove_group_ptr->UID(), module_uid, true);
                         }
                     }
                 }
@@ -1866,26 +1888,7 @@ void megamol::gui::Graph::Draw(GraphState_t& state) {
                     this->DeleteCall(this->gui_graph_state.interact.call_selected_uid);
                 }
                 if (this->gui_graph_state.interact.group_selected_uid != GUI_INVALID_ID) {
-                    // Save old name of modules
-                    std::vector<std::pair<ImGuiID, std::string>> module_uid_name_pair;
-                    if (auto group_ptr = this->GetGroup(this->gui_graph_state.interact.group_selected_uid)) {
-                        for (auto& module_ptr : group_ptr->Modules()) {
-                            module_uid_name_pair.push_back({module_ptr->UID(), module_ptr->FullName()});
-                        }
-                    }
-                    // Delete group
                     this->DeleteGroup(this->gui_graph_state.interact.group_selected_uid);
-                    // Push module renaming to sync queue
-                    for (auto& module_ptr : this->Modules()) {
-                        for (auto& module_pair : module_uid_name_pair) {
-                            if (module_ptr->UID() == module_pair.first) {
-                                Graph::QueueData queue_data;
-                                queue_data.name_id = module_pair.second;
-                                queue_data.rename_id = module_ptr->FullName();
-                                this->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
-                            }
-                        }
-                    }
                 }
                 if (this->gui_graph_state.interact.interfaceslot_selected_uid != GUI_INVALID_ID) {
                     for (auto& group_ptr : this->GetGroups()) {

--- a/frontend/services/gui/src/graph/Graph.h
+++ b/frontend/services/gui/src/graph/Graph.h
@@ -88,6 +88,8 @@ public:
     }
     GroupPtr_t GetGroup(ImGuiID group_uid);
     ImGuiID AddGroupModule(const std::string& group_name, const ModulePtr_t& module_ptr, bool use_queue = true);
+    ImGuiID AddGroupModule(ImGuiID group_uid, const ModulePtr_t& module_ptr, bool use_queue = true);
+    ImGuiID RemoveGroupModule(ImGuiID group_uid, ImGuiID module_uid, bool use_queue = true, bool reset_interface = true);
 
     void Clear();
 
@@ -135,10 +137,6 @@ public:
 
     inline std::string Name() const {
         return this->name;
-    }
-
-    void ForceUpdate() {
-        this->gui_update = true;
     }
 
     void ResetStatePointers() {

--- a/frontend/services/gui/src/graph/Graph.h
+++ b/frontend/services/gui/src/graph/Graph.h
@@ -89,7 +89,8 @@ public:
     GroupPtr_t GetGroup(ImGuiID group_uid);
     ImGuiID AddGroupModule(const std::string& group_name, const ModulePtr_t& module_ptr, bool use_queue = true);
     ImGuiID AddGroupModule(ImGuiID group_uid, const ModulePtr_t& module_ptr, bool use_queue = true);
-    ImGuiID RemoveGroupModule(ImGuiID group_uid, ImGuiID module_uid, bool use_queue = true, bool reset_interface = true);
+    ImGuiID RemoveGroupModule(
+        ImGuiID group_uid, ImGuiID module_uid, bool use_queue = true, bool reset_interface = true);
 
     void Clear();
 

--- a/frontend/services/gui/src/graph/Group.h
+++ b/frontend/services/gui/src/graph/Group.h
@@ -34,7 +34,7 @@ public:
     ~Group();
 
     bool AddModule(const ModulePtr_t& module_ptr);
-    bool RemoveModule(ImGuiID module_uid);
+    bool RemoveModule(ImGuiID module_uid, bool retore_interface = true);
     bool ContainsModule(ImGuiID module_uid);
     inline bool Empty() {
         return (this->modules.empty());
@@ -69,10 +69,6 @@ public:
     inline ImVec2 Size() const {
         return this->gui_size;
     }
-    inline void ForceUpdate() {
-        this->gui_update = true;
-    }
-
     inline void SetName(const std::string& group_name) {
         this->name = group_name;
     }

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -477,35 +477,32 @@ void megamol::gui::Configurator::draw_window_module_list(float width, float heig
 
             if (add_module) {
                 if (auto selected_graph_ptr = this->graph_collection.GetGraph(this->graph_state.graph_selected_uid)) {
-                    if (auto module_ptr = selected_graph_ptr->AddModule(
-                            this->graph_collection.GetModulesStock(), mod.class_name, "", "")) {
 
-                        // If there is a call slot selected, create call to compatible call slot of new module
-                        bool add_call = compat_filter && (selected_callslot_ptr != nullptr);
+                    // If there is a call slot selected, create call to compatible call slot of new module
+                    bool add_call = compat_filter && (selected_callslot_ptr != nullptr);
 
-                        // If there is a group selected or hovered or the new call is connected to module which is part
-                        // of group, add module to this group
-                        if (!interfaceslot_selected) {
-                            ImGuiID connected_group = GUI_INVALID_ID;
-                            if (add_call && selected_callslot_ptr->IsParentModuleConnected()) {
-                                connected_group = selected_callslot_ptr->GetParentModule()->GroupUID();
-                            }
-                            ImGuiID selected_group_uid = selected_graph_ptr->GetSelectedGroup();
-                            ImGuiID group_uid = (connected_group != GUI_INVALID_ID)
-                                                    ? (connected_group)
-                                                    : ((selected_group_uid != GUI_INVALID_ID)
-                                                              ? (selected_group_uid)
-                                                              : (this->module_list_popup_hovered_group_uid));
-
-                            if (auto group_ptr = selected_graph_ptr->GetGroup(group_uid)) {
-                                Graph::QueueData queue_data;
-                                queue_data.name_id = module_ptr->FullName();
-                                selected_graph_ptr->ResetStatePointers();
-                                group_ptr->AddModule(module_ptr);
-                                queue_data.rename_id = module_ptr->FullName();
-                                selected_graph_ptr->PushSyncQueue(Graph::QueueAction::RENAME_MODULE, queue_data);
-                            }
+                    // If there is a group selected or hovered or the new call is connected to module which is part
+                    // of group, add module to this group
+                    std::string group_name = "";
+                    if (!interfaceslot_selected) {
+                        ImGuiID connected_group = GUI_INVALID_ID;
+                        if (add_call && selected_callslot_ptr->IsParentModuleConnected()) {
+                            connected_group = selected_callslot_ptr->GetParentModule()->GroupUID();
                         }
+                        ImGuiID selected_group_uid = selected_graph_ptr->GetSelectedGroup();
+                        ImGuiID group_uid = (connected_group != GUI_INVALID_ID)
+                                                ? (connected_group)
+                                                : ((selected_group_uid != GUI_INVALID_ID)
+                                                          ? (selected_group_uid)
+                                                          : (this->module_list_popup_hovered_group_uid));
+                        if (auto group_ptr = selected_graph_ptr->GetGroup(group_uid)) {
+                            group_name = group_ptr->Name();
+                        }
+                    }
+
+                    // Add new module
+                    if (auto module_ptr = selected_graph_ptr->AddModule(
+                            this->graph_collection.GetModulesStock(), mod.class_name, "", group_name)) {
 
                         // Add new call after module is created and after possible renaming due to group joining of module!
                         if (add_call) {


### PR DESCRIPTION
If a new module is created inside a group in the Configurator, the looped back notification from the MegaMol graph for adding the new module can not be discarded by the GUI and a new "ghost" module was added. The reason is that in the GUI graph the module is already renamed and added to a group and therefore has a different name.

**Since the origin of the notifications from the MegaMol graph can not be detected, the GUI graph should only add ONE queue event per module per frame!**

## Summary of Changes
- Adapted code that group name of newly added module is known before the module is added. Therefore, the subsequent renaming can be prevented.
- Cleaned up redundant code for adding and removing modules to a group.

## References and Context
<!--
  Optional. A list of references of this PR, for instance related PRs or scientific papers,
  or any other context about this PR relevant for the devs.
-->

## Test Instructions
<!--
  Optional. For large feature PRs, test instructions are required for the devs to review the PR.
  Include, if possible, the expected behavior.
-->
