### PR TITLE
Fix connecting to external transfer function editor for multiple tf parameters

### DIFF
--- a/frontend/services/gui/src/graph/Parameter.cpp
+++ b/frontend/services/gui/src/graph/Parameter.cpp
@@ -2025,7 +2025,7 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
 
     if (this->tf_use_external_editor) {
         if (this->tf_editor_external_ptr != nullptr) {
-            param_externally_connected = this->tf_editor_external_ptr->IsParameterConnected();
+            param_externally_connected = this->tf_editor_external_ptr->IsSpecificParameterConnected(this);
         }
     }
 
@@ -2059,6 +2059,7 @@ bool megamol::gui::Parameter::widget_transfer_function_editor(megamol::gui::Para
             this->tf_show_editor = false;
         }
         gui_utils::PopReadOnly((this->tf_editor_external_ptr == nullptr));
+
         if (this->tf_use_external_editor && (this->tf_editor_external_ptr != nullptr)) {
             ImGui::SameLine();
             gui_utils::PushReadOnly(param_externally_connected);

--- a/frontend/services/gui/src/windows/TransferFunctionEditor.cpp
+++ b/frontend/services/gui/src/windows/TransferFunctionEditor.cpp
@@ -333,7 +333,7 @@ bool TransferFunctionEditor::TransferFunctionEditor::Draw() {
     ImGui::BeginGroup();
     ImGui::PushID("TransferFunctionEditor");
 
-    if (this->windowed_mode && (!this->IsParameterConnected())) {
+    if (this->windowed_mode && (!this->IsAnyParameterConnected())) {
         const char* message = "Changes have no effect.\n"
                               "No transfer function parameter connected for edit.\n";
         ImGui::TextColored(GUI_COLOR_TEXT_ERROR, message);
@@ -632,7 +632,7 @@ bool TransferFunctionEditor::TransferFunctionEditor::Draw() {
 
         if (this->windowed_mode) {
             if (apply_changes) {
-                if (this->IsParameterConnected()) {
+                if (this->IsAnyParameterConnected()) {
                     std::string tf;
                     if (this->GetTransferFunction(tf)) {
                         if (this->connected_parameter_ptr->Type() == ParamType_t::TRANSFERFUNCTION) {

--- a/frontend/services/gui/src/windows/TransferFunctionEditor.h
+++ b/frontend/services/gui/src/windows/TransferFunctionEditor.h
@@ -86,7 +86,11 @@ public:
         this->flip_legend = vertical;
     }
 
-    bool IsParameterConnected() const {
+    bool IsSpecificParameterConnected(Parameter* calling_param) const {
+        return (this->connected_parameter_ptr == calling_param);
+    }
+
+    bool IsAnyParameterConnected() const {
         return (this->connected_parameter_ptr != nullptr);
     }
 


### PR DESCRIPTION
Fix 'Connect' button for switching to external transfer function editor when **multiple** tf parameters/modules are used.

## Summary of Changes
<!--
  A list of changes that will be copied into the merge commit message and changelog.
-->

## References and Context
<!--
  Optional. A list of references of this PR, for instance related PRs or scientific papers,
  or any other context about this PR relevant for the devs.
-->

## Test Instructions
Open example infovis-spheres.lua and open transfer function editor window. Switch between both TF parameters by using the "Connect" button.
