### PR TITLE
fix autocomplete pop-up in gui log console

### DIFF
--- a/frontend/services/gui/src/windows/LogConsole.cpp
+++ b/frontend/services/gui/src/windows/LogConsole.cpp
@@ -467,8 +467,7 @@ bool megamol::gui::LogConsole::Draw() {
             /// Re-implementing behaviour because of globally disabled ImGuiConfigFlags_NavEnableKeyboard
             bool selected_candidate =
                 ImGui::Selectable(this->input_shared_data->autocomplete_candidates[i].first.c_str(),
-                    (i == this->selected_candidate_index),
-                    ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SelectOnNav);
+                    (i == this->selected_candidate_index), ImGuiSelectableFlags_AllowDoubleClick);
             if (selected_candidate || ((i == this->selected_candidate_index) && ImGui::IsKeyPressed(ImGuiKey_Enter))) {
                 this->input_buffer = this->input_shared_data->autocomplete_candidates[i].first;
                 this->input_buffer.append("()");


### PR DESCRIPTION
<!--
  Add a description here.
  Include a list of issues it fixes in the "Fixes #[]" format if applicable.
-->

## Summary of Changes
<!--
  A list of changes that will be copied into the merge commit message and changelog.
-->

## References and Context
<!--
  Optional. A list of references of this PR, for instance related PRs or scientific papers,
  or any other context about this PR relevant for the devs.
-->

## Test Instructions
If "tab" is pressed in LogConsole input field, the pop-up with all suitable autocompletion candidates should be shown.
