### PR TITLE
Adaptive sampling for isovalue volume renderer

### DIFF
--- a/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-Iso.comp.glsl
+++ b/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-Iso.comp.glsl
@@ -7,6 +7,8 @@
 
 /* isovalue used for isosurface reconstruction */
 uniform float isoValue;
+uniform float minStepFactor;
+uniform float minRefinementRatio;
 
 /* opacity */
 uniform float opacity;
@@ -94,10 +96,10 @@ void compute(float t, const float tfar, const Ray ray, const float rayStep, cons
         old_value = vol_sample;
 
         // Adaptive step size
-        if (vol_sample / isoValue < 0.5f) {
+        if (vol_sample / isoValue < minRefinementRatio) {
             t += rayStep;
         } else {
-            t += rayStep * (1.0f + (rayStep / 10.0f) - vol_sample / isoValue);
+            t += rayStep * max(1.0f - vol_sample / isoValue, minStepFactor);
         }
     }
 

--- a/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-Iso.comp.glsl
+++ b/plugins/volume_gl/shaders/volume_gl/RaycastVolumeRenderer-Iso.comp.glsl
@@ -7,6 +7,7 @@
 
 /* isovalue used for isosurface reconstruction */
 uniform float isoValue;
+uniform bool adaptiveSampling;
 uniform float minStepFactor;
 uniform float minRefinementRatio;
 
@@ -96,7 +97,7 @@ void compute(float t, const float tfar, const Ray ray, const float rayStep, cons
         old_value = vol_sample;
 
         // Adaptive step size
-        if (vol_sample / isoValue < minRefinementRatio) {
+        if (!adaptiveSampling || isoValue < 0.00001f || vol_sample / isoValue < minRefinementRatio) {
             t += rayStep;
         } else {
             t += rayStep * max(1.0f - vol_sample / isoValue, minStepFactor);

--- a/plugins/volume_gl/src/RaycastVolumeRenderer.cpp
+++ b/plugins/volume_gl/src/RaycastVolumeRenderer.cpp
@@ -75,25 +75,27 @@ RaycastVolumeRenderer::RaycastVolumeRenderer()
     this->m_mode.Param<core::param::EnumParam>()->SetTypePair(2, "Aggregate");
     this->MakeSlotAvailable(&this->m_mode);
 
-    this->m_ray_step_ratio_param << new megamol::core::param::FloatParam(1.0f, std::numeric_limits<float>::min());
+    this->m_ray_step_ratio_param << new megamol::core::param::FloatParam(
+        1.0f, std::numeric_limits<float>::min(), std::numeric_limits<float>::max(), 0.1f);
     this->MakeSlotAvailable(&this->m_ray_step_ratio_param);
 
-    this->m_opacity_threshold << new megamol::core::param::FloatParam(1.0f, 0.0f, 1.0f);
+    this->m_opacity_threshold << new megamol::core::param::FloatParam(1.0f, 0.0f, 1.0f, 0.1f);
     this->MakeSlotAvailable(&this->m_opacity_threshold);
 
-    this->m_iso_value << new megamol::core::param::FloatParam(0.5f, std::numeric_limits<float>::min());
+    this->m_iso_value << new megamol::core::param::FloatParam(0.5f, 0.0f, 1.0f, 0.1f);
     this->MakeSlotAvailable(&this->m_iso_value);
 
     this->m_adaptive_sampling << new megamol::core::param::BoolParam(false);
     this->MakeSlotAvailable(&this->m_adaptive_sampling);
 
-    this->m_min_step_factor << new megamol::core::param::FloatParam(0.01f, std::numeric_limits<float>::min(), 1.0f);
+    this->m_min_step_factor << new megamol::core::param::FloatParam(
+        0.01f, std::numeric_limits<float>::min(), 1.0f, 0.01f);
     this->MakeSlotAvailable(&this->m_min_step_factor);
 
-    this->m_min_refinement_ratio << new megamol::core::param::FloatParam(0.5f, 0.0f, 1.0f);
+    this->m_min_refinement_ratio << new megamol::core::param::FloatParam(0.5f, 0.0f, 1.0f, 0.1f);
     this->MakeSlotAvailable(&this->m_min_refinement_ratio);
 
-    this->m_opacity << new megamol::core::param::FloatParam(1.0f, 0.0f, 1.0f);
+    this->m_opacity << new megamol::core::param::FloatParam(1.0f, 0.0f, 1.0f, 0.1f);
     this->MakeSlotAvailable(&this->m_opacity);
 
     this->m_use_lighting_slot << new core::param::BoolParam(false);
@@ -378,17 +380,11 @@ bool RaycastVolumeRenderer::Render(mmstd_gl::CallRender3DGL& cr) {
             "opacityThreshold", this->m_opacity_threshold.Param<core::param::FloatParam>()->Value());
     } else if (this->m_mode.Param<core::param::EnumParam>()->Value() == 1) {
         compute_shdr->setUniform("isoValue", this->m_iso_value.Param<core::param::FloatParam>()->Value());
-
-        if (this->m_adaptive_sampling.Param<core::param::BoolParam>()->Value()) {
-            compute_shdr->setUniform(
-                "minStepFactor", this->m_min_step_factor.Param<core::param::FloatParam>()->Value());
-            compute_shdr->setUniform(
-                "minRefinementRatio", this->m_min_refinement_ratio.Param<core::param::FloatParam>()->Value());
-        } else {
-            compute_shdr->setUniform("minRefinementRatio", 1.1f); // a value >1 ensures that adaptive sampling
-                                                                  // is effectively turned off
-        }
-
+        compute_shdr->setUniform(
+            "adaptiveSampling", static_cast<int>(this->m_adaptive_sampling.Param<core::param::BoolParam>()->Value()));
+        compute_shdr->setUniform("minStepFactor", this->m_min_step_factor.Param<core::param::FloatParam>()->Value());
+        compute_shdr->setUniform(
+            "minRefinementRatio", this->m_min_refinement_ratio.Param<core::param::FloatParam>()->Value());
         compute_shdr->setUniform("opacity", this->m_opacity.Param<core::param::FloatParam>()->Value());
     }
 

--- a/plugins/volume_gl/src/RaycastVolumeRenderer.cpp
+++ b/plugins/volume_gl/src/RaycastVolumeRenderer.cpp
@@ -82,7 +82,7 @@ RaycastVolumeRenderer::RaycastVolumeRenderer()
     this->m_opacity_threshold << new megamol::core::param::FloatParam(1.0f, 0.0f, 1.0f, 0.1f);
     this->MakeSlotAvailable(&this->m_opacity_threshold);
 
-    this->m_iso_value << new megamol::core::param::FloatParam(0.5f, 0.0f, 1.0f, 0.1f);
+    this->m_iso_value << new megamol::core::param::FloatParam(0.5f, 0.0f, std::numeric_limits<float>::max(), 0.1f);
     this->MakeSlotAvailable(&this->m_iso_value);
 
     this->m_adaptive_sampling << new megamol::core::param::BoolParam(false);

--- a/plugins/volume_gl/src/RaycastVolumeRenderer.h
+++ b/plugins/volume_gl/src/RaycastVolumeRenderer.h
@@ -128,6 +128,9 @@ private:
     core::param::ParamSlot m_ray_step_ratio_param;
     core::param::ParamSlot m_opacity_threshold;
     core::param::ParamSlot m_iso_value;
+    core::param::ParamSlot m_adaptive_sampling;
+    core::param::ParamSlot m_min_step_factor;
+    core::param::ParamSlot m_min_refinement_ratio;
     core::param::ParamSlot m_opacity;
 
     core::param::ParamSlot m_use_lighting_slot;


### PR DESCRIPTION
- Fixed how adaptive resampling enforces a minimum step size
- Added parameters to steer adaptive resampling:
  - Turn it on/off
  - Enforce a minimum step size
  - Customize range in which refinement is active

Argument for adaptive resampling, based on observation in the veiled chameleon dataset:
Speed up of a factor of around 20 before noticing visible changes by increasing the base step size ratio and activating adaptive resampling with default parameters.

This solves #1226.