### PR TITLE
Graph Subscription Sync in Remote Service

### DIFF
--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -659,7 +659,9 @@ std::vector<std::string> megamol::frontend::extract_config_file_paths(const int 
         }
 
         // remove empty files: enables to start megamol without config file
-        std::remove_if(config_files.begin(), config_files.end(), [](auto const& file) { return file.empty(); });
+        config_files.erase(
+            std::remove_if(config_files.begin(), config_files.end(), [](auto const& file) { return file.empty(); }),
+            config_files.end());
 
         // check remaining files exist
         files_exist(config_files, "Config file");

--- a/frontend/services/remote_service/Remote_Service.hpp
+++ b/frontend/services/remote_service/Remote_Service.hpp
@@ -101,6 +101,8 @@ private:
             CloseHeadNode,
             ClearGraph,
             SendGraph,
+            SyncGraphChanges,
+            DontSyncGraphChanges,
             KeepSendingParams,
             DontSendParams,
             SetParamSendingModules,
@@ -111,6 +113,12 @@ private:
         std::string modules_to_send_params_of = "all";
         std::string lua_command = "";
 
+        std::function<std::string()> sync_graph_subscription = [this]() {
+            this->subscription_graph_commands.clear();
+            return std::string{};
+        };
+        std::string subscription_graph_commands;
+
         std::vector<Command> commands_queue;
     };
     HeadNodeRemoteControl m_headnode_remote_control;
@@ -118,6 +126,8 @@ private:
     void remote_control_window();
 
     bool start_headnode(bool start_or_shutdown = true);
+
+    void subscribe_megamol_graph(void* registry);
 };
 
 std::string handle_remote_session_config(


### PR DESCRIPTION
Add option to sync graph subscription events in remote service headnode mode. 

## Summary of Changes
* Subscribe remote service to graph events
* Headnode sends graph events to render nodes, if enabled

## Test Instructions
* Start headnode: `./megamol.exe --headnode`
* Start rendernode: `./megamol.exe --rendernode`
* In Headnode GUI menu, start headnode server and activate sync graph subscription
* Load megamol project in headnode. It should sync to the rendernode.

[Remote Graph Sync Demo](https://github.com/UniStuttgart-VISUS/megamol/assets/44215465/dd05a573-4295-4f14-89e1-b9d870e9b9aa)
