### PR TITLE
Update clang-format

### DIFF
--- a/.ci/check_format.sh
+++ b/.ci/check_format.sh
@@ -79,17 +79,17 @@ while read -r file; do
   if [[ "$is_cpp" == true ]]; then
     # ClangFormat
     if [[ "$_fix" == true ]]; then
-      clang-format-14 -i "$file"
+      clang-format-16 -i "$file"
     else
       # Workaround "set -e" and store exit code
       format_exit_code=0
-      output="$(clang-format-14 --dry-run --Werror "$file" 2>&1)" || format_exit_code=$?
+      output="$(clang-format-16 --dry-run --Werror "$file" 2>&1)" || format_exit_code=$?
       if [[ $format_exit_code -ne 0 ]]; then
         EXIT_CODE=1
         echo "::error::ClangFormat found issues in: $file"
         #echo "$output"
         # Show detailed diff. Requires ClangFormat to run again, but should mostly affect only a few files.
-        clang-format-14 "$file" | diff --color=always -u "$file" - || true
+        clang-format-16 "$file" | diff --color=always -u "$file" - || true
       fi
     fi
 

--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,6 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignEscapedNewlines: Left
 AllowAllArgumentsOnNextLine: true # 'false' has different behavior between clang-format 11 and 12, therefore use 'true'.
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: Empty
@@ -22,13 +21,13 @@ AlwaysBreakTemplateDeclarations: Yes
 BreakBeforeBraces: Attach
 BreakConstructorInitializers: BeforeComma
 CommentPragmas: '^.*'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true # Replace with "PackConstructorInitializers: Never", when switching to clang-format 14.
 ConstructorInitializerIndentWidth: 8
 DerivePointerAlignment: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
+PackConstructorInitializers: CurrentLine
 PointerAlignment: Left
-SpaceAfterCStyleCast: false # want true, but has issues with clang-format-12
+SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: false
 Standard: c++17
 # TODO Does not work reliable, yet. Do not use in automatic CI pipeline!

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -11,6 +11,11 @@ jobs:
     name: Style-Check
     runs-on: ubuntu-22.04
     steps:
+      - name: Install clang-format
+        run: |
+          wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository --yes "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+          sudo apt-get install -y clang-format-16
       - uses: actions/checkout@v3
       - name: Run format check
         run: .ci/check_format.sh

--- a/core/include/mmcore/utility/log/Log.inl
+++ b/core/include/mmcore/utility/log/Log.inl
@@ -25,16 +25,16 @@ void Log::writeMessage(log_level level, std::string const& msg, Args&&... args) 
     switch (level) {
     case log_level::error: {
         logger->error(fmsg);
-        (echo_logger ? echo_logger->error(fmsg) : (void)(0));
+        (echo_logger ? echo_logger->error(fmsg) : (void) (0));
     } break;
     case log_level::warn: {
         logger->warn(fmsg);
-        (echo_logger ? echo_logger->warn(fmsg) : (void)(0));
+        (echo_logger ? echo_logger->warn(fmsg) : (void) (0));
     } break;
     case log_level::info:
     default: {
         logger->info(fmsg);
-        (echo_logger ? echo_logger->info(fmsg) : (void)(0));
+        (echo_logger ? echo_logger->info(fmsg) : (void) (0));
     }
     }
 }

--- a/core/include/mmcore/view/CameraControllers.h
+++ b/core/include/mmcore/view/CameraControllers.h
@@ -556,8 +556,8 @@ public:
      * This event handler can be reimplemented to receive mouse move events.
      */
     virtual void OnMouseMove(double x, double y, int wndWidth, int wndHeight) {
-        this->_mouseX = (float)static_cast<int>(x);
-        this->_mouseY = (float)static_cast<int>(y);
+        this->_mouseX = (float) static_cast<int>(x);
+        this->_mouseY = (float) static_cast<int>(y);
 
         glm::vec3 newPos;
 

--- a/core/src/param/TransferFunctionParam.cpp
+++ b/core/src/param/TransferFunctionParam.cpp
@@ -265,7 +265,7 @@ bool TransferFunctionParam::CheckTransferFunctionString(const std::string& tfs) 
 
             // Check transfer function node data
             if (json.at("Nodes").is_array()) {
-                unsigned int tmp_size = (unsigned int)json.at("Nodes").size();
+                unsigned int tmp_size = (unsigned int) json.at("Nodes").size();
                 for (unsigned int i = 0; i < tmp_size; ++i) {
                     if (!json.at("Nodes")[i].is_array()) {
                         megamol::core::utility::log::Log::DefaultLog.WriteError(
@@ -298,7 +298,7 @@ bool TransferFunctionParam::CheckTransferFunctionString(const std::string& tfs) 
 
             // Check value range
             if (json.at("ValueRange").is_array()) {
-                unsigned int tmp_size = (unsigned int)json.at("ValueRange").size();
+                unsigned int tmp_size = (unsigned int) json.at("ValueRange").size();
                 if (tmp_size != 2) {
                     megamol::core::utility::log::Log::DefaultLog.WriteError(
                         "There should be at two entries in 'ValueRange' array. [%s, %s, line %d]\n", __FILE__,

--- a/core_gl/src/utility/SDFFont.cpp
+++ b/core_gl/src/utility/SDFFont.cpp
@@ -297,13 +297,13 @@ void SDFFont::BatchDrawString(const glm::mat4& mvm, const glm::mat4& pm, const f
         return;
 
     // Bind glyph data in batch cache
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glBindBuffer(GL_ARRAY_BUFFER, this->vbos[i].handle);
-        if (this->vbos[i].index == (GLuint)VBOAttrib::POSITION) {
-            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)this->posBatchCache.size() * sizeof(GLfloat),
+        if (this->vbos[i].index == (GLuint) VBOAttrib::POSITION) {
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) this->posBatchCache.size() * sizeof(GLfloat),
                 &this->posBatchCache.front(), GL_STATIC_DRAW);
-        } else if (this->vbos[i].index == (GLuint)VBOAttrib::TEXTURE) {
-            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)this->texBatchCache.size() * sizeof(GLfloat),
+        } else if (this->vbos[i].index == (GLuint) VBOAttrib::TEXTURE) {
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) this->texBatchCache.size() * sizeof(GLfloat),
                 &this->texBatchCache.front(), GL_STATIC_DRAW);
         }
         glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -311,7 +311,7 @@ void SDFFont::BatchDrawString(const glm::mat4& mvm, const glm::mat4& pm, const f
 
     // Draw batch cache
     unsigned int glyphCnt =
-        ((unsigned int)this->posBatchCache.size() / 18); // 18 = 2 Triangles * 3 Vertices * 3 Coordinates
+        ((unsigned int) this->posBatchCache.size() / 18); // 18 = 2 Triangles * 3 Vertices * 3 Coordinates
     this->render(mvm, pm, glyphCnt, &col);
 }
 
@@ -322,16 +322,16 @@ void SDFFont::BatchDrawString(const glm::mat4& mvm, const glm::mat4& pm) const {
         return;
 
     // Bind glyph data in batch cache
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glBindBuffer(GL_ARRAY_BUFFER, this->vbos[i].handle);
-        if (this->vbos[i].index == (GLuint)VBOAttrib::POSITION) {
-            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)this->posBatchCache.size() * sizeof(GLfloat),
+        if (this->vbos[i].index == (GLuint) VBOAttrib::POSITION) {
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) this->posBatchCache.size() * sizeof(GLfloat),
                 &this->posBatchCache.front(), GL_STATIC_DRAW);
-        } else if (this->vbos[i].index == (GLuint)VBOAttrib::TEXTURE) {
-            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)this->texBatchCache.size() * sizeof(GLfloat),
+        } else if (this->vbos[i].index == (GLuint) VBOAttrib::TEXTURE) {
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) this->texBatchCache.size() * sizeof(GLfloat),
                 &this->texBatchCache.front(), GL_STATIC_DRAW);
-        } else if (this->vbos[i].index == (GLuint)VBOAttrib::COLOR) {
-            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)this->colBatchCache.size() * sizeof(GLfloat),
+        } else if (this->vbos[i].index == (GLuint) VBOAttrib::COLOR) {
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) this->colBatchCache.size() * sizeof(GLfloat),
                 &this->colBatchCache.front(), GL_STATIC_DRAW);
         }
         glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -339,7 +339,7 @@ void SDFFont::BatchDrawString(const glm::mat4& mvm, const glm::mat4& pm) const {
 
     // Draw batch cache
     unsigned int glyphCnt =
-        ((unsigned int)this->posBatchCache.size() / 18); // 18 = 2 Triangles * 3 Vertices * 3 Coordinates
+        ((unsigned int) this->posBatchCache.size() / 18); // 18 = 2 Triangles * 3 Vertices * 3 Coordinates
     this->render(mvm, pm, glyphCnt, nullptr);
 }
 
@@ -352,7 +352,7 @@ void SDFFont::Deinitialise() {
     this->shadervertcol.reset();
 
     // VBOs
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glDeleteBuffers(1, &this->vbos[i].handle);
     }
     this->vbos.clear();
@@ -454,20 +454,21 @@ int* SDFFont::buildGlyphRun(const char* txt, float maxWidth) const {
             idx = static_cast<unsigned int>(byte);
         } else { // ... else if byte >= 128 => UTF8-Byte: 1XXXXXXX
             // Supporting UTF8 for up to 3 bytes:
-            if (byte >= (unsigned char)(0b11100000)) { // => >224 - 1110XXXX -> start 3-Byte UTF8, 2 bytes are following
+            if (byte >=
+                (unsigned char) (0b11100000)) { // => >224 - 1110XXXX -> start 3-Byte UTF8, 2 bytes are following
                 folBytes = 2;
-                idx = (unsigned int)(byte & (unsigned char)(0b00001111)); // => consider only last 4 bits
-                idx = (idx << 12);                                        // => 2*6 Bits are following
+                idx = (unsigned int) (byte & (unsigned char) (0b00001111)); // => consider only last 4 bits
+                idx = (idx << 12);                                          // => 2*6 Bits are following
                 continue;
             } else if (byte >=
-                       (unsigned char)(0b11000000)) { // => >192 - 110XXXXX -> start 2-Byte UTF8, 1 byte is following
+                       (unsigned char) (0b11000000)) { // => >192 - 110XXXXX -> start 2-Byte UTF8, 1 byte is following
                 folBytes = 1;
-                idx = (unsigned int)(byte & (unsigned char)(0b00011111)); // => consider only last 5 bits
-                idx = (idx << 6);                                         // => 1*6 Bits are following
+                idx = (unsigned int) (byte & (unsigned char) (0b00011111)); // => consider only last 5 bits
+                idx = (idx << 6);                                           // => 1*6 Bits are following
                 continue;
-            } else if (byte >= (unsigned char)(0b10000000)) { // => >128 - 10XXXXXX -> "following" 1-2 bytes
+            } else if (byte >= (unsigned char) (0b10000000)) { // => >128 - 10XXXXXX -> "following" 1-2 bytes
                 folBytes--;
-                tmpIdx = (unsigned int)(byte & (unsigned char)(0b00111111)); // => consider only last 6 bits
+                tmpIdx = (unsigned int) (byte & (unsigned char) (0b00111111)); // => consider only last 6 bits
                 idx = (idx | (tmpIdx << (folBytes *
                                          6))); // => shift tmpIdx depending on following byte and 'merge' (|) with idx
                 if (folBytes > 0)
@@ -475,7 +476,7 @@ int* SDFFont::buildGlyphRun(const char* txt, float maxWidth) const {
             }
         }
         // Check if glyph info is available
-        if (idx > (unsigned int)this->glyphIdcs.size()) {
+        if (idx > (unsigned int) this->glyphIdcs.size()) {
             /// megamol::core::utility::log::Log::DefaultLog.WriteWarn("[SDFFont] Glyph index greater than available: \"%i\" > max. Index = \"%i\".\n", idx, this->idxCnt);
             continue;
         }
@@ -739,12 +740,12 @@ void SDFFont::drawGlyphs(const glm::mat4& mvm, const glm::mat4& pm, const float 
         }
     } else {
         // ... or draw glyphs instantly.
-        for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+        for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
             glBindBuffer(GL_ARRAY_BUFFER, this->vbos[i].handle);
-            if (this->vbos[i].index == (GLuint)VBOAttrib::POSITION) {
-                glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)posCnt * sizeof(GLfloat), posData, GL_STATIC_DRAW);
-            } else if (this->vbos[i].index == (GLuint)VBOAttrib::TEXTURE) {
-                glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)texCnt * sizeof(GLfloat), texData, GL_STATIC_DRAW);
+            if (this->vbos[i].index == (GLuint) VBOAttrib::POSITION) {
+                glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) posCnt * sizeof(GLfloat), posData, GL_STATIC_DRAW);
+            } else if (this->vbos[i].index == (GLuint) VBOAttrib::TEXTURE) {
+                glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) texCnt * sizeof(GLfloat), texData, GL_STATIC_DRAW);
             }
             glBindBuffer(GL_ARRAY_BUFFER, 0);
         }
@@ -817,7 +818,7 @@ void SDFFont::render(
     }
     usedShader->setUniform("smoothMode", static_cast<int>(this->smoothMode));
 
-    glDrawArrays(GL_TRIANGLES, 0, (GLsizei)glyph_count * 6); // 2 triangles per glyph -> 6 vertices
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) glyph_count * 6); // 2 triangles per glyph -> 6 vertices
 
     glUseProgram(0); // instead of usedShader->Disable() => because draw() is CONST
     glBindVertexArray(0);
@@ -904,7 +905,7 @@ bool SDFFont::loadFontBuffers() {
     if (glIsVertexArray(this->vaoHandle)) {
         glDeleteVertexArrays(1, &this->vaoHandle);
     }
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glDeleteBuffers(1, &this->vbos[i].handle);
     }
     this->vbos.clear();
@@ -917,19 +918,19 @@ bool SDFFont::loadFontBuffers() {
 
     // VBO for position data
     newVBO.name = "inPos";
-    newVBO.index = (GLuint)VBOAttrib::POSITION;
+    newVBO.index = (GLuint) VBOAttrib::POSITION;
     newVBO.dim = 3;
     this->vbos.push_back(newVBO);
 
     // VBO for texture data
     newVBO.name = "inTexCoord";
-    newVBO.index = (GLuint)VBOAttrib::TEXTURE;
+    newVBO.index = (GLuint) VBOAttrib::TEXTURE;
     newVBO.dim = 2;
     this->vbos.push_back(newVBO);
 
     // VBO for texture data
     newVBO.name = "inColor";
-    newVBO.index = (GLuint)VBOAttrib::COLOR;
+    newVBO.index = (GLuint) VBOAttrib::COLOR;
     newVBO.dim = 4;
     this->vbos.push_back(newVBO);
 
@@ -939,20 +940,20 @@ bool SDFFont::loadFontBuffers() {
     glGenVertexArrays(1, &this->vaoHandle);
     glBindVertexArray(this->vaoHandle);
 
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glGenBuffers(1, &this->vbos[i].handle);
         glBindBuffer(GL_ARRAY_BUFFER, this->vbos[i].handle);
         // Create empty buffer
         glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_STATIC_DRAW);
         // Bind buffer to vertex attribute
         glEnableVertexAttribArray(this->vbos[i].index);
-        glVertexAttribPointer(this->vbos[i].index, this->vbos[i].dim, GL_FLOAT, GL_FALSE, 0, (GLubyte*)nullptr);
+        glVertexAttribPointer(this->vbos[i].index, this->vbos[i].dim, GL_FLOAT, GL_FALSE, 0, (GLubyte*) nullptr);
     }
 
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    for (unsigned int i = 0; i < (unsigned int)this->vbos.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->vbos.size(); i++) {
         glDisableVertexAttribArray(this->vbos[i].index);
     }
 
@@ -1001,48 +1002,48 @@ bool SDFFont::loadFontInfo(std::filesystem::path filepath) {
         if (line.rfind("common ", 0) == 0) { // starts with
 
             idx = line.find("scaleW=", 0);
-            texWidth = (float)std::atof(line.substr(idx + 7, 4).c_str());
+            texWidth = (float) std::atof(line.substr(idx + 7, 4).c_str());
 
             idx = line.find("scaleH=", 0);
-            texHeight = (float)std::atof(line.substr(idx + 7, 4).c_str());
+            texHeight = (float) std::atof(line.substr(idx + 7, 4).c_str());
 
             idx = line.find("lineHeight=", 0);
-            lineHeight = (float)std::atof(line.substr(idx + 11, 4).c_str());
+            lineHeight = (float) std::atof(line.substr(idx + 11, 4).c_str());
         }
         // (2) Parse character info
         else if (line.rfind("char ", 0) == 0) {
             SDFGlyphInfo newChar;
 
             idx = line.find("id=", 0);
-            newChar.id = (unsigned int)std::atoi(line.substr(idx + 3, 5).c_str());
+            newChar.id = (unsigned int) std::atoi(line.substr(idx + 3, 5).c_str());
 
             if (maxId < newChar.id) {
                 maxId = newChar.id;
             }
 
             idx = line.find("x=", 0);
-            newChar.texX0 = (float)std::atof(line.substr(idx + 2, 4).c_str()) / texWidth;
+            newChar.texX0 = (float) std::atof(line.substr(idx + 2, 4).c_str()) / texWidth;
 
             idx = line.find("y=", 0);
-            newChar.texY0 = (float)std::atof(line.substr(idx + 2, 4).c_str()) / texHeight;
+            newChar.texY0 = (float) std::atof(line.substr(idx + 2, 4).c_str()) / texHeight;
 
             idx = line.find("width=", 0);
-            width = (float)std::atof(line.substr(idx + 6, 4).c_str());
+            width = (float) std::atof(line.substr(idx + 6, 4).c_str());
 
             idx = line.find("height=", 0);
-            height = (float)std::atof(line.substr(idx + 7, 4).c_str());
+            height = (float) std::atof(line.substr(idx + 7, 4).c_str());
 
             newChar.width = width / lineHeight;
             newChar.height = height / lineHeight;
 
             idx = line.find("xoffset=", 0);
-            newChar.xoffset = (float)std::atof(line.substr(idx + 8, 4).c_str()) / lineHeight;
+            newChar.xoffset = (float) std::atof(line.substr(idx + 8, 4).c_str()) / lineHeight;
 
             idx = line.find("yoffset=", 0);
-            newChar.yoffset = (float)std::atof(line.substr(idx + 8, 4).c_str()) / lineHeight;
+            newChar.yoffset = (float) std::atof(line.substr(idx + 8, 4).c_str()) / lineHeight;
 
             idx = line.find("xadvance=", 0);
-            newChar.xadvance = (float)std::atof(line.substr(idx + 9, 4).c_str()) / lineHeight;
+            newChar.xadvance = (float) std::atof(line.substr(idx + 9, 4).c_str()) / lineHeight;
 
             newChar.kernCnt = 0;
             newChar.kerns = nullptr;
@@ -1058,13 +1059,13 @@ bool SDFFont::loadFontInfo(std::filesystem::path filepath) {
             SDFGlyphKerning newKern;
 
             idx = line.find("first=", 0);
-            newKern.previous = (unsigned int)std::atoi(line.substr(idx + 6, 4).c_str());
+            newKern.previous = (unsigned int) std::atoi(line.substr(idx + 6, 4).c_str());
 
             idx = line.find("second=", 0);
-            newKern.current = (unsigned int)std::atoi(line.substr(idx + 7, 4).c_str());
+            newKern.current = (unsigned int) std::atoi(line.substr(idx + 7, 4).c_str());
 
             idx = line.find("amount=", 0);
-            newKern.xamount = (float)std::atof(line.substr(idx + 7, 4).c_str()) / lineHeight;
+            newKern.xamount = (float) std::atof(line.substr(idx + 7, 4).c_str()) / lineHeight;
 
             tmpKerns.push_back(newKern);
         }
@@ -1078,9 +1079,9 @@ bool SDFFont::loadFontInfo(std::filesystem::path filepath) {
         this->glyphIdcs.push_back(nullptr);
     }
     // Set pointers to available glyph info
-    for (unsigned int i = 0; i < (unsigned int)this->glyphs.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int) this->glyphs.size(); i++) {
         // Filling character index array --------------------------------------
-        if (this->glyphs[i].id > (unsigned int)this->glyphIdcs.size()) {
+        if (this->glyphs[i].id > (unsigned int) this->glyphIdcs.size()) {
             megamol::core::utility::log::Log::DefaultLog.WriteError(
                 "[SDFFont] Character is out of range: \"%i\". [%s, %s, line %d]\n", this->glyphs[i].id, __FILE__,
                 __FUNCTION__, __LINE__);
@@ -1089,14 +1090,14 @@ bool SDFFont::loadFontInfo(std::filesystem::path filepath) {
         this->glyphIdcs[this->glyphs[i].id] = &this->glyphs[i];
         // Assigning glyphKrns -------------------------------------------------
         // Get count of glyphKrns for current glyph
-        for (unsigned int j = 0; j < (unsigned int)tmpKerns.size(); j++) {
+        for (unsigned int j = 0; j < (unsigned int) tmpKerns.size(); j++) {
             if (this->glyphs[i].id == tmpKerns[j].current) {
                 this->glyphs[i].kernCnt++;
             }
         }
         unsigned int c = 0;
         this->glyphs[i].kerns = new SDFGlyphKerning[this->glyphs[i].kernCnt];
-        for (unsigned int j = 0; j < (unsigned int)tmpKerns.size(); j++) {
+        for (unsigned int j = 0; j < (unsigned int) tmpKerns.size(); j++) {
             if (this->glyphs[i].id == tmpKerns[j].current) {
                 this->glyphs[i].kerns[c] = tmpKerns[j];
                 c++;

--- a/core_gl/src/utility/SSBOStreamer.cpp
+++ b/core_gl/src/utility/SSBOStreamer.cpp
@@ -66,7 +66,7 @@ GLuint SSBOStreamer::SetDataWithSize(
 GLuint SSBOStreamer::GetNumItemsPerChunkAligned(GLuint numItemsPerChunk, bool up) const {
     // Lazy initialisation of offset alignment because OGl context must be available.
     if (this->offsetAlignment == 0) {
-        glGetIntegerv(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT, (GLint*)&this->offsetAlignment);
+        glGetIntegerv(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT, (GLint*) &this->offsetAlignment);
     }
     // Rounding the number of items per chunk is important for alignment and thus performance.
     // That means, if we synchronize with another buffer that has tiny items, we have to make

--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -469,7 +469,7 @@ bool GUIManager::OnChar(unsigned int codePoint) {
     ImGuiIO& io = ImGui::GetIO();
     io.ClearInputCharacters();
     if (codePoint > 0 && codePoint < 0x10000) {
-        io.AddInputCharacter((unsigned short)codePoint);
+        io.AddInputCharacter((unsigned short) codePoint);
     }
 
     return false;

--- a/frontend/services/gui/src/graph/CallSlot.cpp
+++ b/frontend/services/gui/src/graph/CallSlot.cpp
@@ -361,7 +361,7 @@ void megamol::gui::CallSlot::Draw(PresentPhase phase, megamol::gui::GraphItemsSt
             // Drag & Drop
             if (ImGui::BeginDragDropTarget()) {
                 if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(GUI_DND_CALLSLOT_UID_TYPE)) {
-                    auto* dragged_slot_uid_ptr = (ImGuiID*)payload->Data;
+                    auto* dragged_slot_uid_ptr = (ImGuiID*) payload->Data;
                     state.interact.slot_drag_drop_uids.first = (*dragged_slot_uid_ptr);
                     state.interact.slot_drag_drop_uids.second = this->uid;
                 }
@@ -519,6 +519,6 @@ void megamol::gui::CallSlot::Update(const GraphItemsState_t& state) {
         module_size.y -= line_height;
         ImVec2 size = module_size * state.canvas.zooming;
         this->gui_position = ImVec2(pos.x + ((this->type == CallSlotType::CALLER) ? (size.x) : (0.0f)),
-            pos.y + size.y * ((float)slot_idx + 1) / ((float)slot_count + 1));
+            pos.y + size.y * ((float) slot_idx + 1) / ((float) slot_count + 1));
     }
 }

--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -2688,7 +2688,7 @@ void megamol::gui::Graph::draw_canvas_dragged_call() {
 
     if (const ImGuiPayload* payload = ImGui::GetDragDropPayload()) {
         if (payload->IsDataType(GUI_DND_CALLSLOT_UID_TYPE)) {
-            auto* selected_slot_uid_ptr = (ImGuiID*)payload->Data;
+            auto* selected_slot_uid_ptr = (ImGuiID*) payload->Data;
             if (selected_slot_uid_ptr == nullptr) {
                 megamol::core::utility::log::Log::DefaultLog.WriteError(
                     "[GUI] Pointer to drag and drop payload data is nullptr. [%s, %s, line %d]\n", __FILE__,
@@ -3504,7 +3504,7 @@ void megamol::gui::Graph::draw_profiling(ImVec2 position, ImVec2 size) {
         if (ImGui::BeginDragDropTarget()) {
             if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("DND_COPY_PROFILING_DATA")) {
                 assert(payload->DataSize == (dnd_size * sizeof(char)));
-                std::string payload_id = (const char*)payload->Data;
+                std::string payload_id = (const char*) payload->Data;
                 try {
                     auto uid_payload = static_cast<ImGuiID>(std::strtol(payload_id.c_str(), nullptr, 10));
                     if (errno == ERANGE) {

--- a/frontend/services/gui/src/graph/InterfaceSlot.cpp
+++ b/frontend/services/gui/src/graph/InterfaceSlot.cpp
@@ -313,7 +313,7 @@ void megamol::gui::InterfaceSlot::Draw(PresentPhase phase, megamol::gui::GraphIt
             // Drag & Drop
             if (ImGui::BeginDragDropTarget()) {
                 if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(GUI_DND_CALLSLOT_UID_TYPE)) {
-                    auto* dragged_slot_uid_ptr = (ImGuiID*)payload->Data;
+                    auto* dragged_slot_uid_ptr = (ImGuiID*) payload->Data;
                     state.interact.slot_drag_drop_uids.first = (*dragged_slot_uid_ptr);
                     state.interact.slot_drag_drop_uids.second = this->uid;
                 }

--- a/frontend/services/gui/src/imgui_backends/imgui_impl_generic.cpp
+++ b/frontend/services/gui/src/imgui_backends/imgui_impl_generic.cpp
@@ -13,7 +13,7 @@ struct ImGui_ImplGeneric_Data {
 };
 
 static ImGui_ImplGeneric_Data* ImGui_ImplGeneric_GetBackendData() {
-    return ImGui::GetCurrentContext() ? (ImGui_ImplGeneric_Data*)ImGui::GetIO().BackendPlatformUserData : NULL;
+    return ImGui::GetCurrentContext() ? (ImGui_ImplGeneric_Data*) ImGui::GetIO().BackendPlatformUserData : NULL;
 }
 
 bool ImGui_ImplGeneric_Init(GenericWindow* window) {
@@ -22,7 +22,7 @@ bool ImGui_ImplGeneric_Init(GenericWindow* window) {
 
     // Setup backend capabilities flags
     ImGui_ImplGeneric_Data* bd = IM_NEW(ImGui_ImplGeneric_Data)();
-    io.BackendPlatformUserData = (void*)bd;
+    io.BackendPlatformUserData = (void*) bd;
     io.BackendPlatformName = "imgui_impl_generic";
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
     io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
@@ -54,7 +54,7 @@ void ImGui_ImplGeneric_NewFrame(GenericWindow* window, GenericMonitor* monitor) 
     int display_w = monitor->res_x;
     int display_h = monitor->res_y;
 
-    io.DisplaySize = ImVec2((float)w, (float)h);
+    io.DisplaySize = ImVec2((float) w, (float) h);
     if (w > 0 && h > 0)
-        io.DisplayFramebufferScale = ImVec2((float)display_w / w, (float)display_h / h);
+        io.DisplayFramebufferScale = ImVec2((float) display_w / w, (float) display_h / h);
 }

--- a/frontend/services/gui/src/windows/LogConsole.cpp
+++ b/frontend/services/gui/src/windows/LogConsole.cpp
@@ -70,7 +70,7 @@ int Input_Text_Callback(ImGuiInputTextCallbackData* data) {
         }
 
         // Build a list of candidates
-        const std::string input = std::string(word_start, (int)(word_end - word_start));
+        const std::string input = std::string(word_start, (int) (word_end - word_start));
         user_data->autocomplete_candidates.clear();
         for (int i = 0; i < user_data->commands.size(); i++) {
             if (gui_utils::CaseInsensitiveStringContain(user_data->commands[i].first, input)) {
@@ -89,7 +89,7 @@ int Input_Text_Callback(ImGuiInputTextCallbackData* data) {
         } else {
             // Multiple matches. Complete as much as we can..
             // So inputing "C"+Tab will complete to "CL" then display "CLEAR" and "CLASSIFY" as matches.
-            int match_len = (int)(word_end - word_start);
+            int match_len = (int) (word_end - word_start);
             for (;;) {
                 int c = 0;
                 bool all_candidates_matches = true;
@@ -104,7 +104,7 @@ int Input_Text_Callback(ImGuiInputTextCallbackData* data) {
             }
 
             if (match_len > 0) {
-                data->DeleteChars((int)(word_start - data->Buf), (int)(word_end - word_start));
+                data->DeleteChars((int) (word_start - data->Buf), (int) (word_end - word_start));
                 data->InsertChars(data->CursorPos, user_data->autocomplete_candidates[0].first.data(),
                     user_data->autocomplete_candidates[0].first.data() + match_len);
             }
@@ -420,7 +420,7 @@ bool megamol::gui::LogConsole::Draw() {
                                            ImGuiInputTextFlags_CallbackCompletion |
                                            ImGuiInputTextFlags_CallbackHistory | ImGuiInputTextFlags_CallbackAlways;
     if (ImGui::InputText("###console_input", &this->input_buffer, input_text_flags, Input_Text_Callback,
-            (void*)this->input_shared_data.get())) {
+            (void*) this->input_shared_data.get())) {
         std::string command = this->input_buffer;
         auto result = (*this->input_lua_func)(command);
         if (std::get<0>(result)) {

--- a/frontend/services/gui/src/windows/ParameterList.cpp
+++ b/frontend/services/gui/src/windows/ParameterList.cpp
@@ -218,7 +218,7 @@ bool ParameterList::Draw() {
     if (ImGui::BeginDragDropTarget()) {
         if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("DND_COPY_MODULE_PARAMETERS")) {
             assert(payload->DataSize == (dnd_size * sizeof(char)));
-            std::string payload_id = (const char*)payload->Data;
+            std::string payload_id = (const char*) payload->Data;
             try {
                 auto module_uid_payload = static_cast<ImGuiID>(std::strtol(payload_id.c_str(), nullptr, 10));
                 if (errno == ERANGE) {

--- a/frontend/services/gui/src/windows/TransferFunctionEditor.cpp
+++ b/frontend/services/gui/src/windows/TransferFunctionEditor.cpp
@@ -537,9 +537,9 @@ bool TransferFunctionEditor::TransferFunctionEditor::Draw() {
         const size_t opts_cnt = opts.size();
         if (ImGui::BeginCombo("Interpolation", opts[this->interpolation_mode].c_str())) {
             for (size_t i = 0; i < opts_cnt; ++i) {
-                if (ImGui::Selectable(opts[(TransferFunctionParam::InterpolationMode)i].c_str(),
-                        (this->interpolation_mode == (TransferFunctionParam::InterpolationMode)i))) {
-                    this->interpolation_mode = (TransferFunctionParam::InterpolationMode)i;
+                if (ImGui::Selectable(opts[(TransferFunctionParam::InterpolationMode) i].c_str(),
+                        (this->interpolation_mode == (TransferFunctionParam::InterpolationMode) i))) {
+                    this->interpolation_mode = (TransferFunctionParam::InterpolationMode) i;
                     this->reload_texture = true;
                 }
             }
@@ -951,8 +951,8 @@ void TransferFunctionEditor::drawFunctionPlot(const ImVec2& size) {
                 float x, g;
                 ImVec2 pos;
 
-                for (int p = 0; p < (int)canvas_size.x + step; p += step) {
-                    x = (float)(p) / canvas_size.x;
+                for (int p = 0; p < (int) canvas_size.x + step; p += step) {
+                    x = (float) (p) / canvas_size.x;
                     g = TransferFunctionParam::gauss(x, ga, gb, gc);
                     pos =
                         ImVec2(canvas_pos.x + (x * canvas_size.x), canvas_pos.y + canvas_size.y - (g * canvas_size.y));

--- a/frontend/services/opengl_glfw/gl/OpenGL_GLFW_Service.cpp
+++ b/frontend/services/opengl_glfw/gl/OpenGL_GLFW_Service.cpp
@@ -502,7 +502,7 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
     XCloseDisplay(display);
 #endif
     if (m_opengl_context.major_ < 3) {
-        auto ext = std::string((char const*)glGetString(GL_EXTENSIONS));
+        auto ext = std::string((char const*) glGetString(GL_EXTENSIONS));
         std::istringstream iss(ext);
         std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
             std::back_inserter(m_opengl_context.ext_));
@@ -512,7 +512,7 @@ bool OpenGL_GLFW_Service::init(const Config& config) {
 
         m_opengl_context.ext_.resize(num_ext);
         for (GLint i = 0; i < num_ext; ++i) {
-            m_opengl_context.ext_[i] = std::string((char const*)glGetStringi(GL_EXTENSIONS, i));
+            m_opengl_context.ext_[i] = std::string((char const*) glGetStringi(GL_EXTENSIONS, i));
         }
     }
 

--- a/frontend/services/remote_service/comm/FBOCommFabric.cpp
+++ b/frontend/services/remote_service/comm/FBOCommFabric.cpp
@@ -36,7 +36,7 @@ bool megamol::remote::MPICommFabric::Bind(std::string const& address) {
 bool megamol::remote::MPICommFabric::Send(std::vector<char> const& buf, send_type const type) {
 #ifdef MEGAMOL_USE_MPI
     // TODO this is wrong. mpiprovider gives you the correct comm
-    auto status = MPI_Send((void*)buf.data(), buf.size(), MPI_CHAR, target_rank_, 0, MPI_COMM_WORLD);
+    auto status = MPI_Send((void*) buf.data(), buf.size(), MPI_CHAR, target_rank_, 0, MPI_COMM_WORLD);
     return status == MPI_SUCCESS;
 #else
     return false;

--- a/frontend/services/vr_service/VR_Service.cpp
+++ b/frontend/services/vr_service/VR_Service.cpp
@@ -167,9 +167,7 @@ void VR_Service::setRequestedResources(std::vector<FrontendResource> resources) 
     m_entry_points_registry.rename_entry_point = [&](auto const& name, auto const& newname) -> bool { return true; };
     m_entry_points_registry.clear_entry_points = [&]() -> void { vr_device(clear_entry_points()); };
     m_entry_points_registry.subscribe_to_entry_point_changes = [&](auto const& func) -> void {};
-    m_entry_points_registry.get_entry_point = [&](std::string const& name) -> auto{
-        return std::nullopt;
-    };
+    m_entry_points_registry.get_entry_point = [&](std::string const& name) -> auto { return std::nullopt; };
 
     auto& megamol_graph = m_requestedResourceReferences[1].getResource<core::MegaMolGraph>();
 #ifdef MEGAMOL_USE_VR_INTEROP

--- a/plugins/cinematic/src/KeyframeKeeper.cpp
+++ b/plugins/cinematic/src/KeyframeKeeper.cpp
@@ -731,14 +731,14 @@ bool KeyframeKeeper::addUndoAction(KeyframeKeeper::Undo::Action act, Keyframe kf
 
     // Remove all already undone actions in list
     if (!this->undoQueue.empty() && (this->undoQueueIndex >= -1)) {
-        if (this->undoQueueIndex < (int)(this->undoQueue.size() - 1)) {
+        if (this->undoQueueIndex < (int) (this->undoQueue.size() - 1)) {
             this->undoQueue.erase(this->undoQueue.begin() + (this->undoQueueIndex + 1), this->undoQueue.end());
         }
     }
 
     this->undoQueue.emplace_back(Undo(act, kf, prev_kf, first_controlpoint, last_controlpoint,
         previous_first_controlpoint, previous_last_controlpoint));
-    this->undoQueueIndex = (int)(this->undoQueue.size()) - 1;
+    this->undoQueueIndex = (int) (this->undoQueue.size()) - 1;
     retVal = true;
 
     if (!retVal) {
@@ -808,7 +808,7 @@ bool KeyframeKeeper::redoAction() {
 
     bool retVal = false;
 
-    if (!this->undoQueue.empty() && (this->undoQueueIndex < (int)(this->undoQueue.size() - 1))) {
+    if (!this->undoQueue.empty() && (this->undoQueueIndex < (int) (this->undoQueue.size() - 1))) {
 
         this->undoQueueIndex++;
         if (this->undoQueueIndex < 0) {
@@ -910,7 +910,7 @@ void KeyframeKeeper::snapKeyframe2AnimFrame(Keyframe& inout_kf) {
         return;
     }
 
-    float fpsFrac = 1.0f / (float)(this->fps);
+    float fpsFrac = 1.0f / (float) (this->fps);
     float t = std::round(inout_kf.GetAnimTime() / fpsFrac) * fpsFrac;
     if (std::abs(t - std::round(t)) < (fpsFrac / 2.0)) {
         t = std::round(t);
@@ -964,7 +964,7 @@ void KeyframeKeeper::setSameSpeed() {
                                0)) { // skip checking for first keyframe (last keyframe is skipped by prior loop)
                 kfTime = kfDist / totalVelocity;
 
-                unsigned int index = static_cast<unsigned int>(floorf(((float)i / (float)this->interpolSteps)));
+                unsigned int index = static_cast<unsigned int>(floorf(((float) i / (float) this->interpolSteps)));
                 float t = this->keyframes[index - 1].GetAnimTime() + kfTime;
                 t = (t < 0.0f) ? (0.0f) : (t);
                 t = (t > this->totalAnimTime) ? (this->totalAnimTime) : (t);
@@ -1005,10 +1005,10 @@ void KeyframeKeeper::refreshInterpolCamPos(unsigned int s) {
     if (this->keyframes.size() > 1) {
         for (unsigned int i = 0; i < this->keyframes.size() - 1; i++) {
             startTime = this->keyframes[i].GetAnimTime();
-            deltaTimeStep = (this->keyframes[i + 1].GetAnimTime() - startTime) / (float)s;
+            deltaTimeStep = (this->keyframes[i + 1].GetAnimTime() - startTime) / (float) s;
 
             for (unsigned int j = 0; j < s; j++) {
-                kf = this->interpolateKeyframe(startTime + deltaTimeStep * (float)j);
+                kf = this->interpolateKeyframe(startTime + deltaTimeStep * (float) j);
                 auto p = kf.GetCamera().get<view::Camera::Pose>().position;
                 this->interpolCamPos.emplace_back(glm::vec3(p[0], p[1], p[2]));
             }
@@ -1220,7 +1220,7 @@ Keyframe KeyframeKeeper::interpolateKeyframe(float time) {
         int i1 = 0;
         int i2 = 0;
         int i3 = 0;
-        int kfIdxCnt = (int)this->keyframes.size() - 1;
+        int kfIdxCnt = (int) this->keyframes.size() - 1;
         float iT = 0.0f;
         for (int i = 0; i < kfIdxCnt; i++) {
             float tMin = this->keyframes[i].GetAnimTime();

--- a/plugins/cinematic_gl/src/CinematicView.cpp
+++ b/plugins/cinematic_gl/src/CinematicView.cpp
@@ -561,7 +561,7 @@ bool CinematicView::render_to_file_setup() {
     unsigned int firstFrame = static_cast<unsigned int>(this->firstRenderFrameParam.Param<param::IntParam>()->Value());
     unsigned int lastFrame = static_cast<unsigned int>(this->lastRenderFrameParam.Param<param::IntParam>()->Value());
 
-    unsigned int maxFrame = (unsigned int)(ccc->GetTotalAnimTime() * (float)this->fps);
+    unsigned int maxFrame = (unsigned int) (ccc->GetTotalAnimTime() * (float) this->fps);
     if (firstFrame > maxFrame) {
         megamol::core::utility::log::Log::DefaultLog.WriteWarn(
             "[CINEMATIC VIEW] [render_to_file_setup] Max frame count exceeded. Limiting first frame to maximum frame "
@@ -578,11 +578,11 @@ bool CinematicView::render_to_file_setup() {
     }
 
     this->png_data.cnt = firstFrame;
-    this->png_data.animTime = (float)this->png_data.cnt / (float)this->fps;
+    this->png_data.animTime = (float) this->png_data.cnt / (float) this->fps;
 
     // Calculate pre-decimal point positions for frame counter in filename
     this->png_data.exp_frame_cnt = 1;
-    float frameCnt = (float)(this->fps) * ccc->GetTotalAnimTime();
+    float frameCnt = (float) (this->fps) * ccc->GetTotalAnimTime();
     while (frameCnt > 1.0f) {
         frameCnt /= 10.0f;
         this->png_data.exp_frame_cnt++;
@@ -750,7 +750,7 @@ bool CinematicView::render_to_file_write() {
 
         // Next frame/time step
         this->png_data.cnt++;
-        this->png_data.animTime = (float)this->png_data.cnt / (float)this->fps;
+        this->png_data.animTime = (float) this->png_data.cnt / (float) this->fps;
         float fpsFrac = (1.0f / static_cast<float>(this->fps));
         // Fit animTime to exact full seconds (removing rounding error)
         if (std::abs(this->png_data.animTime - std::round(this->png_data.animTime)) < (fpsFrac / 2.0)) {

--- a/plugins/cinematic_gl/src/TimeLineRenderer.cpp
+++ b/plugins/cinematic_gl/src/TimeLineRenderer.cpp
@@ -225,7 +225,7 @@ bool TimeLineRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         this->moveRightFrameParam.ResetDirty();
         // Set selected animation time to right animation time frame
         float at = ccc->GetSelectedKeyframe().GetAnimTime();
-        float fpsFrac = 1.0f / (float)(this->fps);
+        float fpsFrac = 1.0f / (float) (this->fps);
         float t = std::round(at / fpsFrac) * fpsFrac;
         t += fpsFrac;
         if (std::abs(t - std::round(t)) < (fpsFrac / 2.0)) {
@@ -240,7 +240,7 @@ bool TimeLineRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         this->moveLeftFrameParam.ResetDirty();
         // Set selected animation time to left animation time frame
         float at = ccc->GetSelectedKeyframe().GetAnimTime();
-        float fpsFrac = 1.0f / (float)(this->fps);
+        float fpsFrac = 1.0f / (float) (this->fps);
         float t = std::round(at / fpsFrac) * fpsFrac;
         t -= fpsFrac;
         if (std::abs(t - std::round(t)) < (fpsFrac / 2.0)) {
@@ -358,7 +358,7 @@ bool TimeLineRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     }
 
     // Push frame marker lines ------------------------------------------------
-    float frameFrac = this->axes[Axis::X].length / ((float)(this->fps) * (this->axes[Axis::X].maxValue)) *
+    float frameFrac = this->axes[Axis::X].length / ((float) (this->fps) * (this->axes[Axis::X].maxValue)) *
                       this->axes[Axis::X].scaleFactor;
     loop_max = this->axes[Axis::X].length + (frameFrac / 2.0f);
     for (float f = this->axes[Axis::X].scaleOffset; f <= loop_max; f = (f + frameFrac)) {
@@ -830,8 +830,8 @@ bool TimeLineRenderer::OnMouseMove(double x, double y) {
     float yAxisValue;
 
     // Store current mouse position
-    this->mouseX = (float)static_cast<int>(x);
-    this->mouseY = this->viewport.y - (float)static_cast<int>(y);
+    this->mouseX = (float) static_cast<int>(x);
+    this->mouseY = this->viewport.y - (float) static_cast<int>(y);
 
     // LEFT-CLICK --- keyframe selection
     if (this->mouseButton == MouseButton::BUTTON_LEFT) {

--- a/plugins/cinematic_gl/src/TrackingShotRenderer.cpp
+++ b/plugins/cinematic_gl/src/TrackingShotRenderer.cpp
@@ -46,7 +46,7 @@ TrackingShotRenderer::TrackingShotRenderer()
     this->MakeSlotAvailable(&this->keyframeKeeperSlot);
 
     // init parameters
-    this->stepsParam.SetParameter(new param::IntParam((int)this->interpolSteps, 1));
+    this->stepsParam.SetParameter(new param::IntParam((int) this->interpolSteps, 1));
     this->MakeSlotAvailable(&this->stepsParam);
 
     this->toggleHelpTextParam.SetParameter(new param::ButtonParam(core::view::Key::KEY_H, core::view::Modifier::SHIFT));
@@ -333,8 +333,8 @@ bool TrackingShotRenderer::OnMouseMove(double x, double y) {
     }
 
     // Just store current mouse position
-    this->mouseX = (float)static_cast<int>(x);
-    this->mouseY = (float)static_cast<int>(y);
+    this->mouseX = (float) static_cast<int>(x);
+    this->mouseY = (float) static_cast<int>(y);
 
     // Check for grabbed or hit manipulator
     if (this->manipulatorGrabbed && this->manipulators.ProcessHitManipulator(this->mouseX, this->mouseY)) {

--- a/plugins/compositing_gl/src/AntiAliasing.cpp
+++ b/plugins/compositing_gl/src/AntiAliasing.cpp
@@ -612,7 +612,7 @@ bool megamol::compositing_gl::AntiAliasing::getDataCallback(core::Call& caller) 
             if (smaa_constants_.Rt_metrics[2] != input_width || smaa_constants_.Rt_metrics[3] != input_height ||
                 settings_have_changed_) {
                 smaa_constants_.Rt_metrics = glm::vec4(
-                    1.f / (float)input_width, 1.f / (float)input_height, (float)input_width, (float)input_height);
+                    1.f / (float) input_width, 1.f / (float) input_height, (float) input_width, (float) input_height);
                 ssbo_constants_->rebuffer(&smaa_constants_, sizeof(smaa_constants_));
             }
 
@@ -660,7 +660,7 @@ bool megamol::compositing_gl::AntiAliasing::getDataCallback(core::Call& caller) 
             break;
         }
 
-        tex_inspector_.SetTexture((void*)(intptr_t)tex_to_show, tex_dim.x, tex_dim.y);
+        tex_inspector_.SetTexture((void*) (intptr_t) tex_to_show, tex_dim.x, tex_dim.y);
         tex_inspector_.ShowWindow();
     }
 

--- a/plugins/compositing_gl/src/DepthDarkening.cpp
+++ b/plugins/compositing_gl/src/DepthDarkening.cpp
@@ -188,7 +188,7 @@ void megamol::compositing_gl::DepthDarkening::fitTextures(std::shared_ptr<glowl:
     std::vector<std::shared_ptr<glowl::Texture2D>> texVec = {outputTex_, intermediateTex_, intermediateTex2_};
     for (auto& tex : texVec) {
         if (tex->getWidth() != resolution.first || tex->getHeight() != resolution.second) {
-            glowl::TextureLayout tx_layout{(GLint)outFormatHandler_.getInternalFormat(), resolution.first,
+            glowl::TextureLayout tx_layout{(GLint) outFormatHandler_.getInternalFormat(), resolution.first,
                 resolution.second, 1, outFormatHandler_.getFormat(), outFormatHandler_.getType(), 1};
             tex->reload(tx_layout, nullptr);
         }
@@ -252,12 +252,12 @@ bool megamol::compositing_gl::DepthDarkening::textureFormatUpdate() {
 
     //checks if slot is connected
     if (inputDepthSlot_.GetStatus() == 2) {
-        tx_layout = glowl::TextureLayout{(GLint)outFormatHandler_.getInternalFormat(),
+        tx_layout = glowl::TextureLayout{(GLint) outFormatHandler_.getInternalFormat(),
             static_cast<int>(inputDepthSlot_.CallAs<CallTexture2D>()->getData()->getWidth()),
             static_cast<int>(inputDepthSlot_.CallAs<CallTexture2D>()->getData()->getHeight()), 1,
             outFormatHandler_.getFormat(), outFormatHandler_.getType(), 1};
     } else {
-        tx_layout = glowl::TextureLayout{(GLint)outFormatHandler_.getInternalFormat(), 1, 1, 1,
+        tx_layout = glowl::TextureLayout{(GLint) outFormatHandler_.getInternalFormat(), 1, 1, 1,
             outFormatHandler_.getFormat(), outFormatHandler_.getType(), 1};
     }
     outputTex_ = std::make_shared<glowl::Texture2D>("depth_darkening_output", tx_layout, nullptr);

--- a/plugins/compositing_gl/src/SSAO.cpp
+++ b/plugins/compositing_gl/src/SSAO.cpp
@@ -448,7 +448,7 @@ bool megamol::compositing_gl::SSAO::create() {
             randomFloats(generator) * 2.0 - 1.0, randomFloats(generator) * 2.0 - 1.0, randomFloats(generator));
         sample = glm::normalize(sample);
         sample *= randomFloats(generator);
-        float scale = (float)i / 64.0;
+        float scale = (float) i / 64.0;
         ssaoKernel.push_back(sample.x);
         ssaoKernel.push_back(sample.y);
         ssaoKernel.push_back(sample.z);
@@ -593,11 +593,11 @@ bool megamol::compositing_gl::SSAO::getDataCallback(core::Call& caller) {
             std::array<int, 2> txResNormal;
             if (!generateNormals) {
                 normals_ = callNormal->getData();
-                txResNormal = {(int)normals_->getWidth(), (int)normals_->getHeight()};
+                txResNormal = {(int) normals_->getWidth(), (int) normals_->getHeight()};
             }
 
             auto depthTx2D = callDepth->getData();
-            std::array<int, 2> txResDepth = {(int)depthTx2D->getWidth(), (int)depthTx2D->getHeight()};
+            std::array<int, 2> txResDepth = {(int) depthTx2D->getWidth(), (int) depthTx2D->getHeight()};
 
             setupOutputTexture(depthTx2D, final_output_);
 
@@ -997,8 +997,8 @@ void megamol::compositing_gl::SSAO::updateConstants(
 
     const glm::mat4& proj = inputs->ProjectionMatrix;
 
-    consts.ViewportPixelSize = glm::vec2(1.0f / (float)size_.x, 1.0f / (float)size_.y);
-    consts.HalfViewportPixelSize = glm::vec2(1.0f / (float)half_size_.x, 1.0f / (float)half_size_.y);
+    consts.ViewportPixelSize = glm::vec2(1.0f / (float) size_.x, 1.0f / (float) size_.y);
+    consts.HalfViewportPixelSize = glm::vec2(1.0f / (float) half_size_.x, 1.0f / (float) half_size_.y);
 
     consts.Viewport2xPixelSize = glm::vec2(consts.ViewportPixelSize.x * 2.0f, consts.ViewportPixelSize.y * 2.0f);
     consts.Viewport2xPixelSize_x_025 =
@@ -1048,7 +1048,7 @@ void megamol::compositing_gl::SSAO::updateConstants(
 
     // used to get average load per pixel; 9.0 is there to compensate for only doing every 9th InterlockedAdd in
     // PSPostprocessImportanceMapB for performance reasons
-    consts.LoadCounterAvgDiv = 9.0f / (float)(quarter_size_.x * quarter_size_.y * 255.0);
+    consts.LoadCounterAvgDiv = 9.0f / (float) (quarter_size_.x * quarter_size_.y * 255.0);
 
     // Special settings for lowest quality level - just nerf the effect a tiny bit
     if (settings.QualityLevel <= 0) {
@@ -1071,7 +1071,7 @@ void megamol::compositing_gl::SSAO::updateConstants(
 
     consts.InvSharpness = std::clamp(1.0f - settings.Sharpness, 0.0f, 1.0f);
     consts.PassIndex = pass;
-    consts.QuarterResPixelSize = glm::vec2(1.0f / (float)quarter_size_.x, 1.0f / (float)quarter_size_.y);
+    consts.QuarterResPixelSize = glm::vec2(1.0f / (float) quarter_size_.x, 1.0f / (float) quarter_size_.y);
 
     float additionalAngleOffset =
         settings.TemporalSupersamplingAngleOffset; // if using temporal supersampling approach (like "Progressive
@@ -1088,13 +1088,13 @@ void megamol::compositing_gl::SSAO::updateConstants(
         b = spmap[subPass];
 
         float ca, sa;
-        float angle0 = ((float)a + (float)b / (float)subPassCount) * (3.1415926535897932384626433832795f) * 0.5f;
+        float angle0 = ((float) a + (float) b / (float) subPassCount) * (3.1415926535897932384626433832795f) * 0.5f;
         angle0 += additionalAngleOffset;
 
         ca = ::cosf(angle0);
         sa = ::sinf(angle0);
 
-        float scale = 1.0f + (a - 1.5f + (b - (subPassCount - 1.0f) * 0.5f) / (float)subPassCount) * 0.07f;
+        float scale = 1.0f + (a - 1.5f + (b - (subPassCount - 1.0f) * 0.5f) / (float) subPassCount) * 0.07f;
         scale *= additionalRadiusScale;
 
         // all values are within [-1, 1]

--- a/plugins/compositing_gl/src/TexInspectModule.cpp
+++ b/plugins/compositing_gl/src/TexInspectModule.cpp
@@ -55,7 +55,7 @@ bool TexInspectModule::getDataCallback(core::Call& caller) {
         auto tex_width = tex->getWidth();
         auto tex_height = tex->getHeight();
 
-        tex_inspector_.SetTexture((void*)(intptr_t)tex_handle, tex_width, tex_height);
+        tex_inspector_.SetTexture((void*) (intptr_t) tex_handle, tex_width, tex_height);
         tex_inspector_.ShowWindow();
     }
 

--- a/plugins/datatools/src/OverrideParticleBBox.cpp
+++ b/plugins/datatools/src/OverrideParticleBBox.cpp
@@ -126,7 +126,7 @@ bool datatools::OverrideParticleBBox::manipulateExtent(
     //    }
     //}
 
-    if (!(inData)(0))
+    if (!(inData) (0))
         return false;
     outData = inData; // also transfers the unlocker to 'outData'
 

--- a/plugins/datatools/src/ParticleNeighborhoodGraph.cpp
+++ b/plugins/datatools/src/ParticleNeighborhoodGraph.cpp
@@ -245,7 +245,7 @@ void ParticleNeighborhoodGraph::calcData(geocalls::MultiParticleDataCall* data) 
     float bboxCentY = bboxCent.Y();
     float bboxCentZ = bboxCent.Z();
 
-#define _COORD(x, y, z) ((x) + ((y) + ((z)*y_size)) * x_size)
+#define _COORD(x, y, z) ((x) + ((y) + ((z) *y_size)) * x_size)
 
     std::vector<size_t> grid(d.get_count());
     std::vector<size_t*> gridCell(x_size * y_size * z_size);

--- a/plugins/datatools/src/table/TableSort.cpp
+++ b/plugins/datatools/src/table/TableSort.cpp
@@ -62,7 +62,7 @@ bool megamol::datatools::table::TableSort::prepareData(TableDataCall& src, const
 
     /* Request the source data. */
     src.SetFrameID(frameID);
-    if (!(src)(0)) {
+    if (!(src) (0)) {
         Log::DefaultLog.WriteError(
             _T("The call to %hs failed in %hs."), TableDataCall::FunctionName(0), TableDataCall::ClassName());
         return false;

--- a/plugins/datatools/src/table/TableToLines.cpp
+++ b/plugins/datatools/src/table/TableToLines.cpp
@@ -615,7 +615,7 @@ void TableToLines::colorTransferGray(std::vector<float>& grayArray, float const*
         } else {
             float exact_tf = (tableSize - 1) * scaled_gray;
             int floor = std::floor(exact_tf);
-            float tail = exact_tf - (float)floor;
+            float tail = exact_tf - (float) floor;
             floor *= 4;
             for (int i = 0; i < target_length; i++) {
                 float colorFloor = transferTable[floor + i];

--- a/plugins/datatools/src/table/TableWhere.cpp
+++ b/plugins/datatools/src/table/TableWhere.cpp
@@ -113,7 +113,7 @@ bool megamol::datatools::table::TableWhere::prepareData(TableDataCall& src, cons
 
     /* Request the source data. */
     src.SetFrameID(frameID);
-    if (!(src)(0)) {
+    if (!(src) (0)) {
         Log::DefaultLog.WriteError(
             _T("The call to %hs failed in %hs."), TableDataCall::FunctionName(0), TableDataCall::ClassName());
         return false;

--- a/plugins/datatools_gl/src/misc/AddClusterColours.cpp
+++ b/plugins/datatools_gl/src/misc/AddClusterColours.cpp
@@ -195,7 +195,7 @@ bool AddClusterColours::getDataCallback(core::Call& caller) {
                     for (UINT64 j = 0; j < parts.GetCount(); j++) {
                         //                        float v = (values[j] - parts.GetMinColourIndexValue()) /
                         //                            (parts.GetMaxColourIndexValue() - parts.GetMinColourIndexValue());
-                        unsigned int clusterId = (unsigned int)(values[j] / 100000000.0);
+                        unsigned int clusterId = (unsigned int) (values[j] / 100000000.0);
                         unsigned int colorIdx = (clusterId % 13);
                         float v = static_cast<float>(colorIdx) / 13.0f;
                         if (v < 0.0f)

--- a/plugins/datatools_gl/src/misc/ParticleWorker.cpp
+++ b/plugins/datatools_gl/src/misc/ParticleWorker.cpp
@@ -258,8 +258,8 @@ bool ParticleWorker::getDataCallback(Call& call) {
         } else if (partsIn.GetVertexDataStride() == 3 * sizeof(float) + 4 * sizeof(float)) {
             // highly specific, because we know:
             partsOut.SetVertexData(partsIn.GetVertexDataType(), NULL, partsIn.GetVertexDataStride());
-            partsOut.SetColourData(MultiParticleDataCall::Particles::COLDATA_FLOAT_I, (void*)(NULL + 3 * sizeof(float)),
-                partsIn.GetVertexDataStride());
+            partsOut.SetColourData(MultiParticleDataCall::Particles::COLDATA_FLOAT_I,
+                (void*) (NULL + 3 * sizeof(float)), partsIn.GetVertexDataStride());
 
             partsOut.SetVAOs(glVAO[i], glVB[i], glVB[i]);
             glBindVertexArray(vao);

--- a/plugins/doc_megamol101_gl/src/SimplestSphereRenderer.cpp
+++ b/plugins/doc_megamol101_gl/src/SimplestSphereRenderer.cpp
@@ -169,7 +169,7 @@ bool SimplestSphereRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                 colVec.data()); // write colors to the gpu
         }
         glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(float) * 4, 0);
-        glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (GLvoid*)(sizeof(float) * 4 * sphereCount));
+        glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (GLvoid*) (sizeof(float) * 4 * sphereCount));
 
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glBindVertexArray(0);

--- a/plugins/imageseries/src/filter/GenericFilter.cpp
+++ b/plugins/imageseries/src/filter/GenericFilter.cpp
@@ -134,7 +134,7 @@ GenericFilter::ImagePtr GenericFilter::operator()() {
 ImageMetadata GenericFilter::getMetadata() const {
     if (input.image1) {
         ImageMetadata metadata = input.image1->getMetadata();
-        metadata.hash = util::computeHash(input.image1, input.image2, (int)input.operation);
+        metadata.hash = util::computeHash(input.image1, input.image2, (int) input.operation);
         return metadata;
     } else {
         return {};

--- a/plugins/infovis/src/MDSProjection.cpp
+++ b/plugins/infovis/src/MDSProjection.cpp
@@ -198,7 +198,7 @@ Eigen::MatrixXd megamol::infovis::MDSProjection::classicMds(
     assert(squaredDissimilarityMatrix.rows() == squaredDissimilarityMatrix.cols());
 
     Eigen::MatrixXd J = Eigen::MatrixXd::Identity(rowsCount, rowsCount) -
-                        (1.0 / (double)rowsCount) * Eigen::MatrixXd::Ones(rowsCount, rowsCount);
+                        (1.0 / (double) rowsCount) * Eigen::MatrixXd::Ones(rowsCount, rowsCount);
 
     // Apply double centering
     Eigen::MatrixXd B = -0.5 * J * squaredDissimilarityMatrix * J;
@@ -317,7 +317,7 @@ Eigen::MatrixXd megamol::infovis::MDSProjection::smacofMds(Eigen::MatrixXd dissi
     for (k = 0; k < countSteps; k++) {
         if (weightsAllOne) {
             Eigen::MatrixXd B = bMatrix(X, weightsMatrix, dissimilarityMatrix);
-            X = ((B * X).array()) / (float)nPoints;
+            X = ((B * X).array()) / (float) nPoints;
 
         } else {
             X = Vp * bMatrix(X, weightsMatrix, dissimilarityMatrix) * X;
@@ -427,7 +427,7 @@ Eigen::MatrixXd megamol::infovis::MDSProjection::ordinalMds(Eigen::MatrixXd diss
                         for (int i : notMonotoncols) {
                             avg += distances(row, i);
                         }
-                        avg /= (double)notMonotoncols.size();
+                        avg /= (double) notMonotoncols.size();
 
                         for (int i : notMonotoncols)
                             newDistances(row, i) = avg;

--- a/plugins/infovis/src/PCAProjection.cpp
+++ b/plugins/infovis/src/PCAProjection.cpp
@@ -191,7 +191,7 @@ bool megamol::infovis::PCAProjection::project(megamol::datatools::table::TableDa
 
 
     covarianceMatrix = covarianceMatrix.transpose() * covarianceMatrix;
-    covarianceMatrix = covarianceMatrix / (float)(rowsCount - 1);
+    covarianceMatrix = covarianceMatrix / (float) (rowsCount - 1);
 
 
     // calculate Eigenvalues and Eigenvectors

--- a/plugins/infovis/src/TSNEProjection.cpp
+++ b/plugins/infovis/src/TSNEProjection.cpp
@@ -153,7 +153,7 @@ bool megamol::infovis::TSNEProjection::project(megamol::datatools::table::TableD
     }
 
     // Load data in a double Array
-    double* inputData = (double*)malloc(columnCount * rowsCount * sizeof(double));
+    double* inputData = (double*) malloc(columnCount * rowsCount * sizeof(double));
     for (int col = 0; col < columnCount; col++) {
         for (int row = 0; row < rowsCount; row++) {
             inputData[row * columnCount + col] = inData[row * columnCount + col];
@@ -161,7 +161,7 @@ bool megamol::infovis::TSNEProjection::project(megamol::datatools::table::TableD
         }
     }
 
-    double* result = (double*)malloc(rowsCount * outputColumnCount * sizeof(double));
+    double* result = (double*) malloc(rowsCount * outputColumnCount * sizeof(double));
     TSNE::run(inputData, rowsCount, columnCount, result, outputColumnCount, perplexity, theta, randomSeed, false,
         maxIter, 250, 250);
 

--- a/plugins/mesh_gl/src/GPURenderTaskCollection.cpp
+++ b/plugins/mesh_gl/src/GPURenderTaskCollection.cpp
@@ -41,7 +41,7 @@ void processGPURenderTasks(
         }
 
         glMultiDrawElementsIndirect(render_task->mesh->getPrimitiveType(), render_task->mesh->getIndexType(),
-            (GLvoid*)0, render_task->draw_cnt, 0);
+            (GLvoid*) 0, render_task->draw_cnt, 0);
 
         // Reset previously set GLStates
         render_task->reset_states();

--- a/plugins/mmospray/src/AbstractOSPRayRenderer.cpp
+++ b/plugins/mmospray/src/AbstractOSPRayRenderer.cpp
@@ -188,7 +188,7 @@ void AbstractOSPRayRenderer::setupOSPRay(const char* renderer_name) {
             peekchar = getc(file);
             while (peekchar == '#') {
                 auto tmp = fgets(lineBuf, LINESZ, file);
-                (void)tmp;
+                (void) tmp;
                 peekchar = getc(file);
             }
             ungetc(peekchar, file);
@@ -203,7 +203,7 @@ void AbstractOSPRayRenderer::setupOSPRay(const char* renderer_name) {
             peekchar = getc(file);
             while (peekchar == '#') {
                 auto tmp = fgets(lineBuf, LINESZ, file);
-                (void)tmp;
+                (void) tmp;
                 peekchar = getc(file);
             }
             ungetc(peekchar, file);
@@ -217,7 +217,7 @@ void AbstractOSPRayRenderer::setupOSPRay(const char* renderer_name) {
             data = new unsigned char[width * height * 3];
             rc = fread(data, width * height * 3, 1, file);
             // flip in y, because OSPRay's textures have the origin at the lower left corner
-            unsigned char* texels = (unsigned char*)data;
+            unsigned char* texels = (unsigned char*) data;
             for (int y = 0; y < height / 2; y++)
                 for (int x = 0; x < width * 3; x++)
                     std::swap(texels[y * width * 3 + x], texels[(height - 1 - y) * width * 3 + x]);
@@ -484,9 +484,9 @@ void AbstractOSPRayRenderer::writePPM(std::string fileName, const std::array<int
     // file << "P6\n" << size.x << " " << size.y << "\n255\n";
     FILE* file = fopen(fileName.c_str(), "wb");
     fprintf(file, "P6\n%i %i\n255\n", size[0], size[1]);
-    unsigned char* out = (unsigned char*)alloca(3 * size[0]);
+    unsigned char* out = (unsigned char*) alloca(3 * size[0]);
     for (int y = 0; y < size[1]; y++) {
-        const unsigned char* in = (const unsigned char*)&pixel[(size[1] - 1 - y) * size[1]];
+        const unsigned char* in = (const unsigned char*) &pixel[(size[1] - 1 - y) * size[1]];
         for (int x = 0; x < size[0]; x++) {
             out[3 * x + 0] = in[4 * x + 0];
             out[3 * x + 1] = in[4 * x + 1];

--- a/plugins/mmospray/src/OSPRayStructuredVolume.cpp
+++ b/plugins/mmospray/src/OSPRayStructuredVolume.cpp
@@ -213,7 +213,7 @@ bool OSPRayStructuredVolume::readData(core::Call& call) {
     this->structureContainer.volumeType = volumeTypeEnum::STRUCTUREDVOLUME;
     structuredVolumeStructure svs;
 
-    svs.volRepType = (volumeRepresentationType)this->repType.Param<core::param::EnumParam>()->Value();
+    svs.volRepType = (volumeRepresentationType) this->repType.Param<core::param::EnumParam>()->Value();
     svs.voxels = cd->GetData();
     svs.gridOrigin = gridOrigin;
     svs.gridSpacing = gridSpacing;

--- a/plugins/mmospray/src/Pkd.cpp
+++ b/plugins/mmospray/src/Pkd.cpp
@@ -75,8 +75,8 @@ void ospray::Pkd::setDim(size_t ID, int dim) const {
 #if DIM_FROM_DEPTH
     return;
 #else
-    rkcommon::math::vec3f& particle = (rkcommon::math::vec3f&)this->model->position[ID];
-    int& pxAsInt = (int&)particle.x;
+    rkcommon::math::vec3f& particle = (rkcommon::math::vec3f&) this->model->position[ID];
+    int& pxAsInt = (int&) particle.x;
     pxAsInt = (pxAsInt & ~3) | dim;
 #endif
 }
@@ -167,8 +167,8 @@ void ospray::Pkd::buildRec(const size_t nodeID, const rkcommon::math::box3f& bou
         SubtreeIterator l0(leftChildOf(nodeID));
         SubtreeIterator r0(rightChildOf(nodeID));
 
-        SubtreeIterator l((size_t)l0); //(leftChildOf(nodeID));
-        SubtreeIterator r((size_t)r0); //(rightChildOf(nodeID));
+        SubtreeIterator l((size_t) l0); //(leftChildOf(nodeID));
+        SubtreeIterator r((size_t) r0); //(rightChildOf(nodeID));
 
         // size_t numSwaps = 0, numComps = 0;
         float rootPos = POS(nodeID, dim);

--- a/plugins/mmospray/src/Pkd.h
+++ b/plugins/mmospray/src/Pkd.h
@@ -145,7 +145,7 @@ struct PKDBuildJob {
 };
 
 static void pkdBuildThread(void* arg) {
-    PKDBuildJob* job = (PKDBuildJob*)arg;
+    PKDBuildJob* job = (PKDBuildJob*) arg;
     job->pkd->buildRec(job->nodeID, job->bounds, job->depth);
     delete job;
 }

--- a/plugins/mmospray/src/VecField3f.cpp
+++ b/plugins/mmospray/src/VecField3f.cpp
@@ -259,7 +259,7 @@ void VecField3f::SearchCritPointsCUDA(unsigned int maxItNewton, float stepNewton
 
     // TODO What happens if a double pointer is beeing cast to a float pointer?
     // Call CUDA function
-    SearchNullPoints((const float*)this->data, make_uint3(this->dimX, this->dimY, this->dimZ),
+    SearchNullPoints((const float*) this->data, make_uint3(this->dimX, this->dimY, this->dimZ),
         make_float3(this->orgX, this->orgY, this->orgZ), make_float3(this->spacingX, this->spacingY, this->spacingZ),
         cellCoords, 0);
 

--- a/plugins/mmospray_gl/src/OSPRayMeshGLGeometry.cpp
+++ b/plugins/mmospray_gl/src/OSPRayMeshGLGeometry.cpp
@@ -130,7 +130,7 @@ bool OSPRayMeshGLGeometry::readData(megamol::core::Call& call) {
                 case geocalls_gl::CallTriMeshDataGL::Mesh::DT_BYTE:
                     _color.reserve(vertexCount * 4);
                     for (unsigned int i = 0; i < 3 * obj.GetVertexCount(); i++) {
-                        _color.push_back((float)obj.GetColourPointerByte()[i] / 255.0f);
+                        _color.push_back((float) obj.GetColourPointerByte()[i] / 255.0f);
                         if ((i + 1) % 3 == 0) {
                             _color.push_back(1.0f);
                         }

--- a/plugins/mmospray_gl/src/OSPRayToGL.h
+++ b/plugins/mmospray_gl/src/OSPRayToGL.h
@@ -19,7 +19,7 @@ inline constexpr auto ospray_to_gl_init_func = [](std::shared_ptr<glowl::Framebu
     fbo->width = width;
     fbo->height = height;
 
-    glGenTextures(1, (GLuint*)&fbo->data.col_tex);
+    glGenTextures(1, (GLuint*) &fbo->data.col_tex);
     glBindTexture(GL_TEXTURE_2D, fbo->data.col_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
@@ -28,7 +28,7 @@ inline constexpr auto ospray_to_gl_init_func = [](std::shared_ptr<glowl::Framebu
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    glGenTextures(1, (GLuint*)&fbo->data.depth_tex);
+    glGenTextures(1, (GLuint*) &fbo->data.depth_tex);
     glBindTexture(GL_TEXTURE_2D, fbo->data.depth_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);

--- a/plugins/mmstd_gl/src/renderer/AnimationRenderer.cpp
+++ b/plugins/mmstd_gl/src/renderer/AnimationRenderer.cpp
@@ -341,7 +341,7 @@ bool megamol::mmstd_gl::AnimationRenderer::Render(mmstd_gl::CallRender3DGL& call
             break;
         }
 
-        tex_inspector_.SetTexture((void*)(intptr_t)tex_to_show, xres, yres);
+        tex_inspector_.SetTexture((void*) (intptr_t) tex_to_show, xres, yres);
         tex_inspector_.ShowWindow();
     }
 

--- a/plugins/mmstd_gl/src/renderer/TransferFunctionGL.cpp
+++ b/plugins/mmstd_gl/src/renderer/TransferFunctionGL.cpp
@@ -120,7 +120,7 @@ bool TransferFunctionGL::requestTF(core::Call& call) {
 
         GLint otid = 0;
         glGetIntegerv(GL_TEXTURE_BINDING_1D, &otid);
-        glBindTexture(GL_TEXTURE_1D, (GLuint)this->texID);
+        glBindTexture(GL_TEXTURE_1D, (GLuint) this->texID);
         const auto tex_format =
             this->texFormat == core::view::AbstractCallGetTransferFunction::TEXTURE_FORMAT_RGBA ? GL_RGBA : GL_RGB;
 

--- a/plugins/mmstd_gl/src/special/ScreenShooter.cpp
+++ b/plugins/mmstd_gl/src/special/ScreenShooter.cpp
@@ -383,8 +383,8 @@ void special::ScreenShooter::BeforeRender(core::view::AbstractView* view) {
 
                 if (this->animAddTime2FrameSlot.Param<core::param::BoolParam>()->Value()) {
                     int intPart = static_cast<int>(floor(this->animLastFrameTime));
-                    float fractPart = this->animLastFrameTime - (float)intPart;
-                    ext.Format(_T(".%.5d.%03d.png"), intPart, (int)(fractPart * 1000.0f));
+                    float fractPart = this->animLastFrameTime - (float) intPart;
+                    ext.Format(_T(".%.5d.%03d.png"), intPart, (int) (fractPart * 1000.0f));
                 } else {
                     ext.Format(_T(".%.5u.png"), this->outputCounter);
                 }
@@ -872,7 +872,7 @@ void special::ScreenShooter::BeforeRender(core::view::AbstractView* view) {
         if (data.pngInfoPtr != NULL) {
             png_destroy_write_struct(&data.pngPtr, &data.pngInfoPtr);
         } else {
-            png_destroy_write_struct(&data.pngPtr, (png_infopp)NULL);
+            png_destroy_write_struct(&data.pngPtr, (png_infopp) NULL);
         }
     }
     try {

--- a/plugins/mmstd_gl/src/special/TextureInspector.cpp
+++ b/plugins/mmstd_gl/src/special/TextureInspector.cpp
@@ -83,9 +83,9 @@ void TextureInspector::ShowWindow() {
         ImGui::Spacing();
 
         //Custom color values to example-select buttons to make them stand out
-        ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(0.59f, 0.7f, 0.8f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0.59f, 0.8f, 0.8f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0.59f, 0.9f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4) ImColor::HSV(0.59f, 0.7f, 0.8f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4) ImColor::HSV(0.59f, 0.8f, 0.8f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4) ImColor::HSV(0.59f, 0.9f, 1.0f));
 
         // Draw row of buttons, one for each scene
         static int selected_scene = 0;

--- a/plugins/mmvtkm/src/mmvtkmDataSource.cpp
+++ b/plugins/mmvtkm/src/mmvtkmDataSource.cpp
@@ -223,7 +223,7 @@ bool mmvtkmDataSource::getDataCallback(core::Call& caller) {
 
 
             for (int i = 0; i < numElements; ++i) {
-                std::vector<int> labels = {(int)nodeA[i], (int)nodeB[i], (int)nodeC[i], (int)nodeD[i]};
+                std::vector<int> labels = {(int) nodeA[i], (int) nodeB[i], (int) nodeC[i], (int) nodeD[i]};
                 std::vector<vtkm::Id> indexBuffer(4);
 
                 bool notFound = false;

--- a/plugins/mmvtkm/src/mmvtkmStreamLines.cpp
+++ b/plugins/mmvtkm/src/mmvtkmStreamLines.cpp
@@ -857,7 +857,7 @@ void mmvtkmStreamLines::orderPolygonVertices(std::vector<glm::vec3>& vertices) {
     }
 
 
-    float numVertices = (float)vertices.size();
+    float numVertices = (float) vertices.size();
     std::vector<std::pair<float, glm::vec3>> angles;
     glm::vec3 center = vertices[0] + 0.5f * (vertices[1] - vertices[0]);
 
@@ -922,7 +922,7 @@ void mmvtkmStreamLines::orderPolygonVertices(std::vector<glm::vec3>& vertices) {
         });
 
 
-    for (int i = 0; i < (int)numVertices; ++i) {
+    for (int i = 0; i < (int) numVertices; ++i) {
         vertices[i] = angles[i].second;
     }
 
@@ -1032,7 +1032,7 @@ bool mmvtkmStreamLines::createAndAddMeshDataToCall(std::string const& identifier
 
     mesh::MeshDataAccessCollection::VertexAttribute va;
     va.data = reinterpret_cast<uint8_t*>(data.data());
-    va.byte_size = 3 * (size_t)numPoints * sizeof(float);
+    va.byte_size = 3 * (size_t) numPoints * sizeof(float);
     va.component_cnt = 3;
     va.component_type = mesh::MeshDataAccessCollection::ValueType::FLOAT;
     va.stride = 3 * sizeof(float);
@@ -1041,7 +1041,7 @@ bool mmvtkmStreamLines::createAndAddMeshDataToCall(std::string const& identifier
 
     mesh::MeshDataAccessCollection::VertexAttribute vColor;
     vColor.data = reinterpret_cast<uint8_t*>(color.data());
-    vColor.byte_size = 4 * (size_t)numPoints * sizeof(float);
+    vColor.byte_size = 4 * (size_t) numPoints * sizeof(float);
     vColor.component_cnt = 4;
     vColor.component_type = mesh::MeshDataAccessCollection::ValueType::FLOAT;
     vColor.stride = 4 * sizeof(float);
@@ -1120,8 +1120,8 @@ bool mmvtkmStreamLines::getDataCallback(core::Call& caller) {
             }
 
             dataSetBounds_ = rhsVtkmDc->getMetaData().minMaxBounds;
-            visVec3f low = {(float)dataSetBounds_.X.Min, (float)dataSetBounds_.Y.Min, (float)dataSetBounds_.Z.Min};
-            visVec3f up = {(float)dataSetBounds_.X.Max, (float)dataSetBounds_.Y.Max, (float)dataSetBounds_.Z.Max};
+            visVec3f low = {(float) dataSetBounds_.X.Min, (float) dataSetBounds_.Y.Min, (float) dataSetBounds_.Z.Min};
+            visVec3f up = {(float) dataSetBounds_.X.Max, (float) dataSetBounds_.Y.Max, (float) dataSetBounds_.Z.Max};
             this->psLowerStreamlineSeedBound_.Param<core::param::Vector3fParam>()->SetValue(low, false);
             this->psUpperStreamlineSeedBound_.Param<core::param::Vector3fParam>()->SetValue(up, false);
         }
@@ -1174,14 +1174,14 @@ bool mmvtkmStreamLines::getDataCallback(core::Call& caller) {
         // sample points in triangles and combine each triangles' samples
         seedStrategy_ = psSeedStrategy_.Param<core::param::EnumParam>()->Value();
         for (const auto& tri : seedPlaneTriangles_) {
-            unsigned int numTriSeeds = (unsigned int)floor(numSeeds_ * tri.weight);
+            unsigned int numTriSeeds = (unsigned int) floor(numSeeds_ * tri.weight);
 
             int cnt = 0;
             for (int i = 0; i < numTriSeeds; ++i) {
                 float s = 0, t = 0;
                 if (seedStrategy_ == 0) {
-                    s = (float)rand() / (float)RAND_MAX;
-                    t = (float)rand() / (float)RAND_MAX;
+                    s = (float) rand() / (float) RAND_MAX;
+                    t = (float) rand() / (float) RAND_MAX;
                 } else if (seedStrategy_ == 1) {
                     s = sobol::sample(cnt, 0);
                     t = sobol::sample(cnt, 1);
@@ -1290,7 +1290,7 @@ bool mmvtkmStreamLines::getDataCallback(core::Call& caller) {
 
                 streamlineData_[i][j] = glm::vec3(crnt[0], crnt[1], crnt[2]);
 
-                streamlineColor_[i][j] = glm::vec4(glm::vec3((float)j / (float)numPoints * 0.9f + 0.1f), 1.f);
+                streamlineColor_[i][j] = glm::vec4(glm::vec3((float) j / (float) numPoints * 0.9f + 0.1f), 1.f);
             }
 
 

--- a/plugins/mmvtkm_gl/src/mmvtkmStreamlineRenderer.cpp
+++ b/plugins/mmvtkm_gl/src/mmvtkmStreamlineRenderer.cpp
@@ -86,7 +86,7 @@ void megamol::mmvtkm_gl::mmvtkmStreamlineRenderer::updateRenderTaskCollection(
         for (int i = 0; i < batch_meshes.size(); ++i) {
             auto const& shader = material_collection_->getMaterials().begin()->second.shader_program;
 
-            std::string ghostIdentifier = (std::string)this->FullName() + "ghostplane";
+            std::string ghostIdentifier = (std::string) this->FullName() + "ghostplane";
             std::vector<std::string>::iterator it =
                 std::find(identifiers[i].begin(), identifiers[i].end(), ghostIdentifier.c_str());
 

--- a/plugins/moldyn/src/io/MMPLDDataSource.cpp
+++ b/plugins/moldyn/src/io/MMPLDDataSource.cpp
@@ -207,7 +207,7 @@ void MMPLDDataSource::Frame::SetData(
             p += sizeof(unsigned int);
             ci->sizeofPlainData = *this->dat.AsAt<size_t>(p);
             p += sizeof(size_t);
-            ci->plainData = (unsigned int*)malloc(ci->sizeofPlainData);
+            ci->plainData = (unsigned int*) malloc(ci->sizeofPlainData);
             memcpy(ci->plainData, this->dat.At(p), ci->sizeofPlainData);
             p += ci->sizeofPlainData;
             pts.SetClusterInfos(ci);
@@ -408,8 +408,8 @@ bool MMPLDDataSource::filenameChanged(core::param::ParamSlot& slot) {
 
     UINT64 mem = vislib::sys::SystemInformation::AvailableMemorySize();
     if (this->limitMemorySlot.Param<core::param::BoolParam>()->Value()) {
-        mem = vislib::math::Min(
-            mem, (UINT64)(this->limitMemorySizeSlot.Param<core::param::IntParam>()->Value()) * (UINT64)(1024u * 1024u));
+        mem = vislib::math::Min(mem,
+            (UINT64) (this->limitMemorySizeSlot.Param<core::param::IntParam>()->Value()) * (UINT64) (1024u * 1024u));
     }
     unsigned int cacheSize = static_cast<unsigned int>(mem / size);
 

--- a/plugins/moldyn/src/io/VTFDataSource.cpp
+++ b/plugins/moldyn/src/io/VTFDataSource.cpp
@@ -121,12 +121,12 @@ bool io::VTFDataSource::Frame::LoadFrame(vislib::sys::File* file, unsigned int i
             break;
         }
 
-        int clusterId = (int)vislib::CharTraitsA::ParseInt(shreds[1]);
+        int clusterId = (int) vislib::CharTraitsA::ParseInt(shreds[1]);
         this->clusterInfos.data[clusterId].Append(id);
 
         vislib::math::Vector<float, 3> pos;
-        pos.Set((float)vislib::CharTraitsA::ParseDouble(shreds[2]), (float)vislib::CharTraitsA::ParseDouble(shreds[3]),
-            (float)vislib::CharTraitsA::ParseDouble(shreds[4]));
+        pos.Set((float) vislib::CharTraitsA::ParseDouble(shreds[2]),
+            (float) vislib::CharTraitsA::ParseDouble(shreds[3]), (float) vislib::CharTraitsA::ParseDouble(shreds[4]));
 
         vislib::math::Vector<float, 4> col;
         col.Set(0.0f, // type
@@ -144,7 +144,7 @@ bool io::VTFDataSource::Frame::LoadFrame(vislib::sys::File* file, unsigned int i
     // count + start + data
     this->clusterInfos.sizeofPlainData =
         2 * this->clusterInfos.data.Count() * sizeof(int) + this->partCnt[0] * sizeof(int);
-    this->clusterInfos.plainData = (unsigned int*)malloc(this->clusterInfos.sizeofPlainData);
+    this->clusterInfos.plainData = (unsigned int*) malloc(this->clusterInfos.sizeofPlainData);
     this->clusterInfos.numClusters = static_cast<unsigned int>(this->clusterInfos.data.Count());
     unsigned int ptr = 0;
     unsigned int summedSizesSoFar = static_cast<unsigned int>(2 * this->clusterInfos.data.Count());
@@ -237,8 +237,8 @@ const io::VTFDataSource::Frame* io::VTFDataSource::Frame::MakeInterpolationFrame
 
     for (unsigned int t = 0; t < a.typeCnt; t++) {
         for (unsigned int i = 0; i < this->partCnt[t]; i++) {
-            vislib::math::ShallowPoint<float, 3> av((float*)a.pos[t].As<float>() + i * 3);
-            vislib::math::ShallowPoint<float, 3> bv((float*)b.pos[t].As<float>() + i * 3);
+            vislib::math::ShallowPoint<float, 3> av((float*) a.pos[t].As<float>() + i * 3);
+            vislib::math::ShallowPoint<float, 3> bv((float*) b.pos[t].As<float>() + i * 3);
             vislib::math::ShallowPoint<float, 3> tv(this->pos[t].As<float>() + i * 3);
 
             if (av.SquareDistance(bv) > 0.01) {
@@ -350,7 +350,7 @@ io::VTFDataSource::~VTFDataSource() {
  */
 view::AnimDataModule::Frame* io::VTFDataSource::constructFrame() const {
     Frame* f = new Frame(*const_cast<io::VTFDataSource*>(this));
-    f->SetTypeCount((unsigned int)this->types.Count());
+    f->SetTypeCount((unsigned int) this->types.Count());
     return f;
 }
 
@@ -393,11 +393,11 @@ void io::VTFDataSource::preprocessFrame(Frame& frame) {
         const float* v = frame.PartPoss(t);
         for (unsigned int p = 0; p < frame.PartCnt(t); ++p) {
             // HAZARD: This cast brackets might be wrong
-            unsigned int x = static_cast<unsigned int>(floorf((float)N * v[3 * p + 0])) /
+            unsigned int x = static_cast<unsigned int>(floorf((float) N * v[3 * p + 0])) /
                              static_cast<unsigned int>(this->extents.GetX());
-            unsigned int y = static_cast<unsigned int>(floorf((float)N * v[3 * p + 1])) /
+            unsigned int y = static_cast<unsigned int>(floorf((float) N * v[3 * p + 1])) /
                              static_cast<unsigned int>(this->extents.GetY());
-            unsigned int z = static_cast<unsigned int>(floorf((float)N * v[3 * p + 2])) /
+            unsigned int z = static_cast<unsigned int>(floorf((float) N * v[3 * p + 2])) /
                              static_cast<unsigned int>(this->extents.GetZ());
             vislib::Array<int>& cell = frame.particleGridCell(x, y, z);
             cell.Add(p);
@@ -412,11 +412,11 @@ void io::VTFDataSource::preprocessFrame(Frame& frame) {
         for (unsigned int p = 0; p < frame.PartCnt(t); ++p) {
             vislib::math::ShallowVector<float, 3> pos(const_cast<float*>(&v[3 * p]));
 
-            unsigned int x = static_cast<unsigned int>(floorf((float)N * pos.GetX())) /
+            unsigned int x = static_cast<unsigned int>(floorf((float) N * pos.GetX())) /
                              static_cast<unsigned int>(this->extents.GetX());
-            unsigned int y = static_cast<unsigned int>(floorf((float)N * pos.GetY())) /
+            unsigned int y = static_cast<unsigned int>(floorf((float) N * pos.GetY())) /
                              static_cast<unsigned int>(this->extents.GetY());
-            unsigned int z = static_cast<unsigned int>(floorf((float)N * pos.GetZ())) /
+            unsigned int z = static_cast<unsigned int>(floorf((float) N * pos.GetZ())) /
                              static_cast<unsigned int>(this->extents.GetZ());
 
             // over each neighboring cell
@@ -502,7 +502,7 @@ bool io::VTFDataSource::filenameChanged(param::ParamSlot& slot) {
     }
 
     Frame tmpFrame(*this);
-    tmpFrame.SetTypeCount((unsigned int)this->types.Count());
+    tmpFrame.SetTypeCount((unsigned int) this->types.Count());
     // use frame zero to estimate the frame size in memory to calculate the
     // frame cache size
     this->loadFrame(&tmpFrame, 0);
@@ -574,9 +574,9 @@ bool io::VTFDataSource::parseHeaderAndFrameIndices(const vislib::TString& filena
 
         if (!haveBoundingBox) {
             if (shreds[0].Compare("pbc", false)) {
-                extents.Set((float)vislib::CharTraitsA::ParseDouble(shreds[1]),
-                    (float)vislib::CharTraitsA::ParseDouble(shreds[2]),
-                    (float)vislib::CharTraitsA::ParseDouble(shreds[3]));
+                extents.Set((float) vislib::CharTraitsA::ParseDouble(shreds[1]),
+                    (float) vislib::CharTraitsA::ParseDouble(shreds[2]),
+                    (float) vislib::CharTraitsA::ParseDouble(shreds[3]));
 
                 haveBoundingBox = true;
                 continue;
@@ -588,7 +588,7 @@ bool io::VTFDataSource::parseHeaderAndFrameIndices(const vislib::TString& filena
 
                 SimpleType type;
                 type.SetID(vislib::CharTraitsA::ParseInt(shreds[7]));
-                type.SetRadius((float)vislib::CharTraitsA::ParseDouble(shreds[3]));
+                type.SetRadius((float) vislib::CharTraitsA::ParseDouble(shreds[3]));
                 type.SetCount(vislib::CharTraitsA::ParseInt(counts[1]) - vislib::CharTraitsA::ParseInt(counts[0]) + 1);
                 this->types.Append(type);
                 haveAtomType = true;
@@ -664,7 +664,7 @@ if (line.IsEmpty()) {
 }
         */
     }
-    this->setFrameCount((unsigned int)this->frameIdx.Count());
+    this->setFrameCount((unsigned int) this->frameIdx.Count());
     //this->initFrameCache(1);
 
     return true;
@@ -685,7 +685,7 @@ bool io::VTFDataSource::getDataCallback(Call& caller) {
             return false;
         c2->SetDataHash((this->file == NULL) ? 0 : this->datahash);
         c2->SetUnlocker(new Unlocker(*f));
-        c2->SetParticleListCount((unsigned int)this->types.Count());
+        c2->SetParticleListCount((unsigned int) this->types.Count());
         for (unsigned int i = 0; i < this->types.Count(); i++) {
             c2->AccessParticles(i).SetGlobalRadius(this->types[i].Radius() /* / this->boxScaling*/);
             c2->AccessParticles(i).SetGlobalColour(this->types[i].Red(), this->types[i].Green(), this->types[i].Blue());

--- a/plugins/moldyn/src/io/VTFResDataSource.cpp
+++ b/plugins/moldyn/src/io/VTFResDataSource.cpp
@@ -166,8 +166,9 @@ bool io::VTFResDataSource::Frame::LoadFrame(
         }
         case PARTICLES: {
             vislib::math::Vector<float, 3> pos;
-            pos.Set((float)vislib::CharTraitsA::ParseDouble(shreds[1]),
-                (float)vislib::CharTraitsA::ParseDouble(shreds[2]), (float)vislib::CharTraitsA::ParseDouble(shreds[3]));
+            pos.Set((float) vislib::CharTraitsA::ParseDouble(shreds[1]),
+                (float) vislib::CharTraitsA::ParseDouble(shreds[2]),
+                (float) vislib::CharTraitsA::ParseDouble(shreds[3]));
 
             vislib::math::Vector<float, 4> col;
             col.Set(0, // type
@@ -210,8 +211,8 @@ bool io::VTFResDataSource::Frame::LoadFrame(
                 // NOTE TODO Changed for SFB_DEMO
                 float* particleData = col[0].AsAt<float>(4 * sizeof(float) * particleId);
                 particleData[1] = static_cast<float>(parsedClusters);
-                float soa = (float)vislib::CharTraitsA::ParseDouble(shreds[shreds.Count() - 4]);
-                float ld = (float)vislib::CharTraitsA::ParseDouble(shreds[shreds.Count() - 3]);
+                float soa = (float) vislib::CharTraitsA::ParseDouble(shreds[shreds.Count() - 4]);
+                float ld = (float) vislib::CharTraitsA::ParseDouble(shreds[shreds.Count() - 3]);
                 //particleData[0] = (float)vislib::CharTraitsA::ParseDouble(shreds[shreds.Count() - 1]);
                 particleData[0] = ld / std::pow(soa * 0.25f, 1.0f / 3.0f);
 
@@ -233,7 +234,7 @@ bool io::VTFResDataSource::Frame::LoadFrame(
     // count + start + data
     this->clusterInfos.sizeofPlainData =
         2 * this->clusterInfos.data.Count() * sizeof(int) + this->partCnt[0] * sizeof(int);
-    this->clusterInfos.plainData = (unsigned int*)malloc(this->clusterInfos.sizeofPlainData);
+    this->clusterInfos.plainData = (unsigned int*) malloc(this->clusterInfos.sizeofPlainData);
     this->clusterInfos.numClusters = static_cast<unsigned int>(this->clusterInfos.data.Count());
     unsigned int ptr = 0;
     unsigned int summedSizesSoFar = static_cast<unsigned int>(2 * this->clusterInfos.data.Count());
@@ -393,8 +394,8 @@ const io::VTFResDataSource::Frame* io::VTFResDataSource::Frame::MakeInterpolatio
 
     for (unsigned int t = 0; t < a.typeCnt; t++) {
         for (unsigned int i = 0; i < this->partCnt[t]; i++) {
-            vislib::math::ShallowPoint<float, 3> av((float*)a.pos[t].As<float>() + i * 3);
-            vislib::math::ShallowPoint<float, 3> bv((float*)b.pos[t].As<float>() + i * 3);
+            vislib::math::ShallowPoint<float, 3> av((float*) a.pos[t].As<float>() + i * 3);
+            vislib::math::ShallowPoint<float, 3> bv((float*) b.pos[t].As<float>() + i * 3);
             vislib::math::ShallowPoint<float, 3> tv(this->pos[t].As<float>() + i * 3);
 
             if (av.SquareDistance(bv) > 0.01) {
@@ -508,7 +509,7 @@ io::VTFResDataSource::~VTFResDataSource() {
  */
 view::AnimDataModule::Frame* io::VTFResDataSource::constructFrame() const {
     Frame* f = new Frame(*const_cast<io::VTFResDataSource*>(this));
-    f->SetTypeCount((unsigned int)this->types.Count());
+    f->SetTypeCount((unsigned int) this->types.Count());
     return f;
 }
 
@@ -574,11 +575,11 @@ void io::VTFResDataSource::preprocessFrame(Frame& frame) {
         const float* v = frame.PartPoss(t);
         for (unsigned int p = 0; p < frame.PartCnt(t); ++p) {
             // HAZARD: This cast brackets might be wrong
-            unsigned int x = static_cast<unsigned int>(floorf((float)N * v[3 * p + 0])) /
+            unsigned int x = static_cast<unsigned int>(floorf((float) N * v[3 * p + 0])) /
                              static_cast<unsigned int>(this->extents.GetX());
-            unsigned int y = static_cast<unsigned int>(floorf((float)N * v[3 * p + 1])) /
+            unsigned int y = static_cast<unsigned int>(floorf((float) N * v[3 * p + 1])) /
                              static_cast<unsigned int>(this->extents.GetY());
-            unsigned int z = static_cast<unsigned int>(floorf((float)N * v[3 * p + 2])) /
+            unsigned int z = static_cast<unsigned int>(floorf((float) N * v[3 * p + 2])) /
                              static_cast<unsigned int>(this->extents.GetZ());
             vislib::Array<int>& cell = frame.particleGridCell(x, y, z);
             cell.Add(p);
@@ -593,11 +594,11 @@ void io::VTFResDataSource::preprocessFrame(Frame& frame) {
         for (unsigned int p = 0; p < frame.PartCnt(t); ++p) {
             vislib::math::ShallowVector<float, 3> pos(const_cast<float*>(&v[3 * p]));
 
-            unsigned int x = static_cast<unsigned int>(floorf((float)N * pos.GetX())) /
+            unsigned int x = static_cast<unsigned int>(floorf((float) N * pos.GetX())) /
                              static_cast<unsigned int>(this->extents.GetX());
-            unsigned int y = static_cast<unsigned int>(floorf((float)N * pos.GetY())) /
+            unsigned int y = static_cast<unsigned int>(floorf((float) N * pos.GetY())) /
                              static_cast<unsigned int>(this->extents.GetY());
-            unsigned int z = static_cast<unsigned int>(floorf((float)N * pos.GetZ())) /
+            unsigned int z = static_cast<unsigned int>(floorf((float) N * pos.GetZ())) /
                              static_cast<unsigned int>(this->extents.GetZ());
 
             // over each neighboring cell
@@ -687,7 +688,7 @@ if (!this->parseHeaderAndFrameIndices(this->filename.Param<param::FilePathParam>
 }
 */
     Frame tmpFrame(*this);
-    tmpFrame.SetTypeCount((unsigned int)this->types.Count());
+    tmpFrame.SetTypeCount((unsigned int) this->types.Count());
     // use frame zero to estimate the frame size in memory to calculate the
     // frame cache size
     this->loadFrame(&tmpFrame, 0);
@@ -742,8 +743,8 @@ void io::VTFResDataSource::getFrameFiles(vislib::StringA directory) {
 
     this->frameFiles.Sort(&sortFileArray);
 
-    this->setFrameCount((unsigned int)this->frameFiles.Count());
-    printf("Frame Count %u\n", (unsigned int)this->frameFiles.Count());
+    this->setFrameCount((unsigned int) this->frameFiles.Count());
+    printf("Frame Count %u\n", (unsigned int) this->frameFiles.Count());
 
     // only one type here
     SimpleType type;
@@ -883,7 +884,7 @@ bool io::VTFResDataSource::getDataCallback(Call& caller) {
 
         c2->SetDataHash((this->file == NULL) ? 0 : this->datahash);
         c2->SetUnlocker(new Unlocker(*f));
-        c2->SetParticleListCount((unsigned int)this->types.Count());
+        c2->SetParticleListCount((unsigned int) this->types.Count());
         for (unsigned int i = 0; i < this->types.Count(); i++) {
             c2->AccessParticles(i).SetGlobalRadius(this->types[i].Radius() /* / this->boxScaling*/);
             c2->AccessParticles(i).SetGlobalColour(this->types[i].Red(), this->types[i].Green(), this->types[i].Blue());

--- a/plugins/moldyn_gl/src/rendering/GrimRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/GrimRenderer.cpp
@@ -1114,8 +1114,8 @@ bool GrimRenderer::Render(megamol::mmstd_gl::CallRender3DGL& call) {
             glUniform3fv(this->vert_cnt_shader_2_->getUniformLocation("camIn"), 1, glm::value_ptr(cam_view));
             glUniform3fv(this->vert_cnt_shader_2_->getUniformLocation("camRight"), 1, glm::value_ptr(cam_right));
             glUniform3fv(this->vert_cnt_shader_2_->getUniformLocation("camUp"), 1, glm::value_ptr(cam_up));
-            this->vert_cnt_shader_2_->setUniform("depthTexParams", (GLint)this->depthmap_[0].GetWidth(),
-                (GLint)(this->depthmap_[0].GetHeight() * 2 / 3), (GLint)maxLevel);
+            this->vert_cnt_shader_2_->setUniform("depthTexParams", (GLint) this->depthmap_[0].GetWidth(),
+                (GLint) (this->depthmap_[0].GetHeight() * 2 / 3), (GLint) maxLevel);
 
             glEnable(GL_TEXTURE_2D);
             glActiveTextureARB(GL_TEXTURE2_ARB);
@@ -1445,8 +1445,8 @@ bool GrimRenderer::Render(megamol::mmstd_gl::CallRender3DGL& call) {
             glUniform1i(da_sphere_shader->getUniformLocation("use_shading"), static_cast<int>(!deferred_shading));
 
             if (use_vert_cull) {
-                da_sphere_shader->setUniform("depthTexParams", (GLint)this->depthmap_[0].GetWidth(),
-                    (GLint)(this->depthmap_[0].GetHeight() * 2 / 3), (GLint)maxLevel);
+                da_sphere_shader->setUniform("depthTexParams", (GLint) this->depthmap_[0].GetWidth(),
+                    (GLint) (this->depthmap_[0].GetHeight() * 2 / 3), (GLint) maxLevel);
                 glEnable(GL_TEXTURE_2D);
                 glActiveTextureARB(GL_TEXTURE2_ARB);
                 this->depthmap_[0].BindColourTexture();

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.cpp
@@ -653,7 +653,7 @@ bool SphereRenderer::createResources() {
 
             // TODO glowl implementation of GLSLprogram misses this functionality
             auto ubo_idx = glGetUniformBlockIndex(lighting_prgm_->getHandle(), "cone_buffer");
-            glUniformBlockBinding(lighting_prgm_->getHandle(), ubo_idx, (GLuint)AO_DIR_UBO_BINDING_POINT);
+            glUniformBlockBinding(lighting_prgm_->getHandle(), ubo_idx, (GLuint) AO_DIR_UBO_BINDING_POINT);
 
             // Init volume generator
             this->vol_gen_ = new misc::MDAOVolumeGenerator();
@@ -861,8 +861,8 @@ bool SphereRenderer::isFlagStorageAvailable() {
     auto flagc = this->read_flags_slot_.CallAs<mmstd_gl::FlagCallRead_GL>();
 
     // Update parameter visibility
-    this->select_color_param_.Param<param::ColorParam>()->SetGUIVisible((bool)(flagc != nullptr));
-    this->soft_select_color_param_.Param<param::ColorParam>()->SetGUIVisible((bool)(flagc != nullptr));
+    this->select_color_param_.Param<param::ColorParam>()->SetGUIVisible((bool) (flagc != nullptr));
+    this->soft_select_color_param_.Param<param::ColorParam>()->SetGUIVisible((bool) (flagc != nullptr));
 
     if (flagc == nullptr) {
         this->flags_available_ = false;
@@ -1295,7 +1295,7 @@ bool SphereRenderer::renderSSBO(mmstd_gl::CallRender3DGL& call, MultiParticleDat
                 auto& buf_a = this->buf_array_[i];
                 if (this->state_invalid_ || (buf_a.GetNumChunks() == 0)) {
                     buf_a.SetDataWithSize(parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(),
-                        (GLuint)(2 * 1024 * 1024 * 1024 - 1));
+                        (GLuint) (2 * 1024 * 1024 * 1024 - 1));
                     // 2 GB - khronos: Most implementations will let you allocate a size up to the limit of GPU memory.
                 }
                 const GLuint num_chunks = buf_a.GetNumChunks();
@@ -1312,7 +1312,7 @@ bool SphereRenderer::renderSSBO(mmstd_gl::CallRender3DGL& call, MultiParticleDat
                 }
             } else {
                 const GLuint num_chunks = this->streamer_.SetDataWithSize(
-                    parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(), 3, (GLuint)(32 * 1024 * 1024));
+                    parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(), 3, (GLuint) (32 * 1024 * 1024));
                 glBindBuffer(GL_SHADER_STORAGE_BUFFER, this->streamer_.GetHandle());
                 glBindBufferBase(GL_SHADER_STORAGE_BUFFER, ssbo_vertex_binding_point, this->streamer_.GetHandle());
 
@@ -1338,7 +1338,7 @@ bool SphereRenderer::renderSSBO(mmstd_gl::CallRender3DGL& call, MultiParticleDat
                 auto& col_a = this->col_buf_array_[i];
                 if (this->state_invalid_ || (buf_a.GetNumChunks() == 0)) {
                     buf_a.SetDataWithSize(parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(),
-                        (GLuint)(2 * 1024 * 1024 * 1024 - 1));
+                        (GLuint) (2 * 1024 * 1024 * 1024 - 1));
                     // 2 GB - khronos: Most implementations will let you allocate a size up to the limit of GPU memory.
                     col_a.SetDataWithItems(parts.GetColourData(), col_stride, col_stride, parts.GetCount(),
                         buf_a.GetMaxNumItemsPerChunk());
@@ -1362,7 +1362,7 @@ bool SphereRenderer::renderSSBO(mmstd_gl::CallRender3DGL& call, MultiParticleDat
                 }
             } else {
                 const GLuint num_chunks = this->streamer_.SetDataWithSize(
-                    parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(), 3, (GLuint)(32 * 1024 * 1024));
+                    parts.GetVertexData(), vert_stride, vert_stride, parts.GetCount(), 3, (GLuint) (32 * 1024 * 1024));
                 const GLuint col_size = this->col_streamer_.SetDataWithItems(parts.GetColourData(), col_stride,
                     col_stride, parts.GetCount(), 3, this->streamer_.GetMaxNumItemsPerChunk());
                 glBindBuffer(GL_SHADER_STORAGE_BUFFER, this->streamer_.GetHandle());
@@ -1770,7 +1770,7 @@ bool SphereRenderer::renderAmbientOcclusion(mmstd_gl::CallRender3DGL& call, Mult
     glUniform3fv(the_shader->getUniformLocation("camIn"), 1, glm::value_ptr(this->cur_cam_view_));
     glUniform4fv(the_shader->getUniformLocation("clipDat"), 1, glm::value_ptr(this->cur_clip_dat_));
     glUniform4fv(the_shader->getUniformLocation("clipCol"), 1, glm::value_ptr(this->cur_clip_col_));
-    glUniform1i(the_shader->getUniformLocation("inUseHighPrecision"), (int)high_precision);
+    glUniform1i(the_shader->getUniformLocation("inUseHighPrecision"), (int) high_precision);
 
     GLuint flag_parts_count = 0;
     for (unsigned int i = 0; i < this->gpu_data_.size(); i++) {
@@ -2303,7 +2303,7 @@ void SphereRenderer::getGLSLVersion(int& out_major, int& out_minor) const {
 
     out_major = -1;
     out_minor = -1;
-    std::string glslVerStr((char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
+    std::string glslVerStr((char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
     std::size_t found = glslVerStr.find(".");
     if (found != std::string::npos) {
         out_major = std::atoi(glslVerStr.substr(0, 1).c_str());
@@ -2517,7 +2517,7 @@ void SphereRenderer::renderDeferredPass(mmstd_gl::CallRender3DGL& call) {
 
     this->lighting_prgm_->use();
 
-    ao_dir_ubo_->bind((GLuint)AO_DIR_UBO_BINDING_POINT);
+    ao_dir_ubo_->bind((GLuint) AO_DIR_UBO_BINDING_POINT);
 
     this->lighting_prgm_->setUniform("inColorTex", static_cast<int>(0));
     this->lighting_prgm_->setUniform("inNormalsTex", static_cast<int>(1));

--- a/plugins/moldyn_gl/src/rendering/SphereRenderer.h
+++ b/plugins/moldyn_gl/src/rendering/SphereRenderer.h
@@ -144,7 +144,7 @@ public:
 
         // (OpenGL Version and GLSL Version might not correlate, see Mesa 3D on Stampede ...)
 
-        std::string glsl_ver_str((char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
+        std::string glsl_ver_str((char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
         std::size_t found = glsl_ver_str.find(".");
         int major = -1;
         int minor = -1;
@@ -157,8 +157,8 @@ public:
         }
         megamol::core::utility::log::Log::DefaultLog.WriteInfo(
             "[SphereRenderer] Found GLSL version %d.%d (%s).", major, minor, glsl_ver_str.c_str());
-        if ((major < (int)(SPHERE_MIN_GLSL_MAJOR)) ||
-            (major == (int)(SPHERE_MIN_GLSL_MAJOR) && minor < (int)(SPHERE_MIN_GLSL_MINOR))) {
+        if ((major < (int) (SPHERE_MIN_GLSL_MAJOR)) ||
+            (major == (int) (SPHERE_MIN_GLSL_MAJOR) && minor < (int) (SPHERE_MIN_GLSL_MINOR))) {
             megamol::core::utility::log::Log::DefaultLog.WriteError(
                 "[SphereRenderer] No render mode available. OpenGL "
                 "Shading Language version 1.3 or greater is required.");

--- a/plugins/molecularmaps/src/AmbientOcclusionCalculator.cpp
+++ b/plugins/molecularmaps/src/AmbientOcclusionCalculator.cpp
@@ -329,7 +329,7 @@ void AmbientOcclusionCalculator::createVolumeCPU(AmbientOcclusionCalculator::AOS
 
 #ifdef DEBUG_WRITE
     std::ofstream file("aovolume.raw", std::ios::binary);
-    file.write((char*)vol[0].data(), sizeof(float) * vol[0].size());
+    file.write((char*) vol[0].data(), sizeof(float) * vol[0].size());
     file.close();
 #endif /* DEBUG_WRITE */
 

--- a/plugins/molecularmaps/src/MapGenerator.cpp
+++ b/plugins/molecularmaps/src/MapGenerator.cpp
@@ -1421,7 +1421,7 @@ bool MapGenerator::GetMeshExtents(Call& call) {
         return false;
 
     if (this->store_new_mesh) {
-        MeshMode selected = (MeshMode)this->out_mesh_selection_slot.Param<param::EnumParam>()->Value();
+        MeshMode selected = (MeshMode) this->out_mesh_selection_slot.Param<param::EnumParam>()->Value();
         geocalls_gl::CallTriMeshDataGL::Mesh themesh;
         if (selected == MeshMode::MESH_ORIGINAL) {
             themesh.SetVertexData(static_cast<uint>(this->vertices.size() / 3), this->vertices.data(),
@@ -3619,7 +3619,7 @@ bool MapGenerator::Render(core_gl::view::CallRender3DGL& call) {
         shaderReloaded = true;
     }
 
-    MeshMode meshMode = (MeshMode)this->out_mesh_selection_slot.Param<param::EnumParam>()->Value();
+    MeshMode meshMode = (MeshMode) this->out_mesh_selection_slot.Param<param::EnumParam>()->Value();
     if (this->out_mesh_selection_slot.IsDirty()) {
         store_new_mesh = true;
         this->out_mesh_selection_slot.ResetDirty();

--- a/plugins/molecularmaps/src/ShaderStorageBufferObject.cpp
+++ b/plugins/molecularmaps/src/ShaderStorageBufferObject.cpp
@@ -61,7 +61,7 @@ void ShaderStorageBufferObject::BindAtomicCounter() {
 GLuint ShaderStorageBufferObject::GetAtomicCounterVal() {
     GLuint value;
     glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, m_atomic_counter_buffer);
-    GLuint* ptr = (GLuint*)glMapBufferRange(GL_ATOMIC_COUNTER_BUFFER, 0, sizeof(GLuint), GL_MAP_READ_BIT);
+    GLuint* ptr = (GLuint*) glMapBufferRange(GL_ATOMIC_COUNTER_BUFFER, 0, sizeof(GLuint), GL_MAP_READ_BIT);
     value = ptr[0];
     glUnmapBuffer(GL_ATOMIC_COUNTER_BUFFER);
     return value;
@@ -72,7 +72,7 @@ GLuint ShaderStorageBufferObject::GetAtomicCounterVal() {
  */
 void ShaderStorageBufferObject::ResetAtomicCounter(GLuint p_value) {
     glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, m_atomic_counter_buffer);
-    GLuint* ptr = (GLuint*)glMapBufferRange(GL_ATOMIC_COUNTER_BUFFER, 0, sizeof(GLuint),
+    GLuint* ptr = (GLuint*) glMapBufferRange(GL_ATOMIC_COUNTER_BUFFER, 0, sizeof(GLuint),
         GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
     ptr[0] = p_value;
     glUnmapBuffer(GL_ATOMIC_COUNTER_BUFFER);

--- a/plugins/molecularmaps/src/ShaderStorageBufferObject.inl
+++ b/plugins/molecularmaps/src/ShaderStorageBufferObject.inl
@@ -18,7 +18,7 @@ bool ShaderStorageBufferObject::init(T* p_data_ptr, GLuint p_data_size, GLenum p
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_ssbo);
     glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(T) * p_data_size, NULL, p_usage);
     if (p_data_ptr != NULL) {
-        T* ptr = (T*)glMapBufferRange(
+        T* ptr = (T*) glMapBufferRange(
             GL_SHADER_STORAGE_BUFFER, 0, sizeof(T) * p_data_size, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
         for (GLuint i = 0; i < p_data_size; i++) {
             ptr[i] = p_data_ptr[i];
@@ -35,7 +35,7 @@ bool ShaderStorageBufferObject::init(T* p_data_ptr, GLuint p_data_size, GLenum p
 template<typename T>
 void ShaderStorageBufferObject::GetData(T* data_ptr, GLuint p_data_size) {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_ssbo);
-    T* data_ptr_gpu = (T*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
+    T* data_ptr_gpu = (T*) glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
     memcpy(data_ptr, data_ptr_gpu, p_data_size * sizeof(T));
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
 }

--- a/plugins/molecularmaps/src/helper_includes/helper_cuda.h
+++ b/plugins/molecularmaps/src/helper_includes/helper_cuda.h
@@ -986,7 +986,7 @@ inline void __getLastCudaError(const char* errorMessage, const char* file, const
     cudaError_t err = cudaGetLastError();
 
     if (cudaSuccess != err) {
-        fprintf(stderr, "%s(%i) : getLastCudaError() CUDA error : %s : (%d) %s.\n", file, line, errorMessage, (int)err,
+        fprintf(stderr, "%s(%i) : getLastCudaError() CUDA error : %s : (%d) %s.\n", file, line, errorMessage, (int) err,
             cudaGetErrorString(err));
         DEVICE_RESET
         exit(EXIT_FAILURE);
@@ -1000,7 +1000,7 @@ inline void __getLastCudaError(const char* errorMessage, const char* file, const
 
 // Float To Int conversion
 inline int ftoi(float value) {
-    return (value >= 0 ? (int)(value + 0.5) : (int)(value - 0.5));
+    return (value >= 0 ? (int) (value + 0.5) : (int) (value - 0.5));
 }
 
 // Beginning of GPU Architecture definitions
@@ -1139,7 +1139,7 @@ inline int gpuGetMaxGflopsDeviceId() {
             }
 
             unsigned long long compute_perf =
-                (unsigned long long)deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
+                (unsigned long long) deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
 
             if (compute_perf > max_compute_perf) {
                 // If we find GPU with SM major > 2, search only these

--- a/plugins/molecularmaps/src/helper_includes/helper_cuda_gl.h
+++ b/plugins/molecularmaps/src/helper_includes/helper_cuda_gl.h
@@ -92,8 +92,8 @@ inline int findCudaGLDevice(int argc, const char** argv) {
     int devID = 0;
 
     // If the command-line has a device number specified, use it
-    if (checkCmdLineFlag(argc, (const char**)argv, "device")) {
-        devID = gpuGLDeviceInit(argc, (const char**)argv);
+    if (checkCmdLineFlag(argc, (const char**) argv, "device")) {
+        devID = gpuGLDeviceInit(argc, (const char**) argv);
 
         if (devID < 0) {
             printf("no CUDA capable devices found, exiting...\n");

--- a/plugins/molecularmaps/src/helper_includes/helper_image.h
+++ b/plugins/molecularmaps/src/helper_includes/helper_image.h
@@ -176,7 +176,7 @@ inline bool __loadPPM(
             std::cerr << "__LoadPPM() : Invalid image dimensions." << std::endl;
         }
     } else {
-        *data = (unsigned char*)malloc(sizeof(unsigned char) * width * height * *channels);
+        *data = (unsigned char*) malloc(sizeof(unsigned char) * width * height * *channels);
         *w = width;
         *h = height;
     }
@@ -205,7 +205,7 @@ inline bool sdkLoadPGM(const char* file, T** data, unsigned int* w, unsigned int
     // initialize mem if necessary
     // the correct size is checked / set in loadPGMc()
     if (NULL == *data) {
-        *data = (T*)malloc(sizeof(T) * size);
+        *data = (T*) malloc(sizeof(T) * size);
     }
 
     // copy and cast data
@@ -226,7 +226,7 @@ inline bool sdkLoadPPM4(const char* file, T** data, unsigned int* w, unsigned in
         int size = *w * *h;
         // keep the original pointer
         unsigned char* idata_orig = idata;
-        *data = (T*)malloc(sizeof(T) * size * 4);
+        *data = (T*) malloc(sizeof(T) * size * 4);
         unsigned char* ptr = *data;
 
         for (int i = 0; i < size; i++) {
@@ -286,7 +286,7 @@ inline bool __savePPM(const char* file, unsigned char* data, unsigned int w, uns
 template<class T>
 inline bool sdkSavePGM(const char* file, T* data, unsigned int w, unsigned int h) {
     unsigned int size = w * h;
-    unsigned char* idata = (unsigned char*)malloc(sizeof(unsigned char) * size);
+    unsigned char* idata = (unsigned char*) malloc(sizeof(unsigned char) * size);
 
     std::transform(data, data + size, idata, ConverterToUByte<T>());
 
@@ -302,7 +302,7 @@ inline bool sdkSavePGM(const char* file, T* data, unsigned int w, unsigned int h
 inline bool sdkSavePPM4ub(const char* file, unsigned char* data, unsigned int w, unsigned int h) {
     // strip 4th component
     int size = w * h;
-    unsigned char* ndata = (unsigned char*)malloc(sizeof(unsigned char) * size * 3);
+    unsigned char* ndata = (unsigned char*) malloc(sizeof(unsigned char) * size * 3);
     unsigned char* ptr = ndata;
 
     for (int i = 0; i < size; i++) {
@@ -361,14 +361,14 @@ inline bool sdkReadFile(const char* filename, T** data, unsigned int* len, bool 
         if (*len != data_read.size()) {
             std::cerr << "sdkReadFile() : Initialized memory given but "
                       << "size  mismatch with signal read "
-                      << "(data read / data init = " << (unsigned int)data_read.size() << " / " << *len << ")"
+                      << "(data read / data init = " << (unsigned int) data_read.size() << " / " << *len << ")"
                       << std::endl;
 
             return false;
         }
     } else {
         // allocate storage for the data read
-        *data = (T*)malloc(sizeof(T) * data_read.size());
+        *data = (T*) malloc(sizeof(T) * data_read.size());
         // store signal size
         *len = static_cast<unsigned int>(data_read.size());
     }
@@ -404,7 +404,7 @@ inline bool sdkReadFileBlocks(
 
     // check if the given handle is already initialized
     // allocate storage for the data read
-    data[block_num] = (T*)malloc(block_size);
+    data[block_num] = (T*) malloc(block_size);
 
     // read all data elements
     fseek(fh, block_num * block_size, SEEK_SET);
@@ -494,7 +494,7 @@ inline bool compareData(
     unsigned int error_count = 0;
 
     for (unsigned int i = 0; i < len; ++i) {
-        float diff = (float)reference[i] - (float)data[i];
+        float diff = (float) reference[i] - (float) data[i];
         bool comp = (diff <= epsilon) && (diff >= -epsilon);
         result &= comp;
 
@@ -517,7 +517,7 @@ inline bool compareData(
         return (result) ? true : false;
     } else {
         if (error_count) {
-            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float)error_count * 100 / (float)len, error_count);
+            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float) error_count * 100 / (float) len, error_count);
         }
 
         return (len * threshold > error_count) ? true : false;
@@ -543,12 +543,12 @@ inline bool compareDataAsFloatThreshold(
     assert(epsilon >= 0);
 
     // If we set epsilon to be 0, let's set a minimum threshold
-    float max_error = MAX((float)epsilon, __MIN_EPSILON_ERROR);
+    float max_error = MAX((float) epsilon, __MIN_EPSILON_ERROR);
     int error_count = 0;
     bool result = true;
 
     for (unsigned int i = 0; i < len; ++i) {
-        float diff = fabs((float)reference[i] - (float)data[i]);
+        float diff = fabs((float) reference[i] - (float) data[i]);
         bool comp = (diff < max_error);
         result &= comp;
 
@@ -577,7 +577,7 @@ inline bool compareDataAsFloatThreshold(
         return (error_count == 0) ? true : false;
     } else {
         if (error_count) {
-            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float)error_count * 100 / (float)len, error_count);
+            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float) error_count * 100 / (float) len, error_count);
         }
 
         return ((len * threshold > error_count) ? true : false);
@@ -629,16 +629,16 @@ inline bool sdkCompareBin2BinUint(const char* src_file, const char* ref_file, un
         }
 
         if (src_fp && ref_fp) {
-            src_buffer = (unsigned int*)malloc(nelements * sizeof(unsigned int));
-            ref_buffer = (unsigned int*)malloc(nelements * sizeof(unsigned int));
+            src_buffer = (unsigned int*) malloc(nelements * sizeof(unsigned int));
+            ref_buffer = (unsigned int*) malloc(nelements * sizeof(unsigned int));
 
             fsize = fread(src_buffer, nelements, sizeof(unsigned int), src_fp);
             fsize = fread(ref_buffer, nelements, sizeof(unsigned int), ref_fp);
 
             printf("> compareBin2Bin <unsigned int> nelements=%d, epsilon=%4.2f, threshold=%4.2f\n", nelements, epsilon,
                 threshold);
-            printf("   src_file <%s>, size=%d bytes\n", src_file, (int)fsize);
-            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int)fsize);
+            printf("   src_file <%s>, size=%d bytes\n", src_file, (int) fsize);
+            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int) fsize);
 
             if (!compareData<unsigned int, float>(ref_buffer, src_buffer, nelements, epsilon, threshold)) {
                 error_count++;
@@ -663,7 +663,7 @@ inline bool sdkCompareBin2BinUint(const char* src_file, const char* ref_file, un
     if (error_count == 0) {
         printf("  OK\n");
     } else {
-        printf("  FAILURE: %d errors...\n", (unsigned int)error_count);
+        printf("  FAILURE: %d errors...\n", (unsigned int) error_count);
     }
 
     return (error_count == 0); // returns true if all pixels pass
@@ -705,16 +705,16 @@ inline bool sdkCompareBin2BinFloat(const char* src_file, const char* ref_file, u
         }
 
         if (src_fp && ref_fp) {
-            src_buffer = (float*)malloc(nelements * sizeof(float));
-            ref_buffer = (float*)malloc(nelements * sizeof(float));
+            src_buffer = (float*) malloc(nelements * sizeof(float));
+            ref_buffer = (float*) malloc(nelements * sizeof(float));
 
             fsize = fread(src_buffer, nelements, sizeof(float), src_fp);
             fsize = fread(ref_buffer, nelements, sizeof(float), ref_fp);
 
             printf("> compareBin2Bin <float> nelements=%d, epsilon=%4.2f, threshold=%4.2f\n", nelements, epsilon,
                 threshold);
-            printf("   src_file <%s>, size=%d bytes\n", src_file, (int)fsize);
-            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int)fsize);
+            printf("   src_file <%s>, size=%d bytes\n", src_file, (int) fsize);
+            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int) fsize);
 
             if (!compareDataAsFloatThreshold<float, float>(ref_buffer, src_buffer, nelements, epsilon, threshold)) {
                 error_count++;
@@ -739,7 +739,7 @@ inline bool sdkCompareBin2BinFloat(const char* src_file, const char* ref_file, u
     if (error_count == 0) {
         printf("  OK\n");
     } else {
-        printf("  FAILURE: %d errors...\n", (unsigned int)error_count);
+        printf("  FAILURE: %d errors...\n", (unsigned int) error_count);
     }
 
     return (error_count == 0); // returns true if all pixels pass
@@ -795,7 +795,7 @@ inline bool sdkLoadPPM4ub(const char* file, unsigned char** data, unsigned int* 
         int size = *w * *h;
         // keep the original pointer
         unsigned char* idata_orig = idata;
-        *data = (unsigned char*)malloc(sizeof(unsigned char) * size * 4);
+        *data = (unsigned char*) malloc(sizeof(unsigned char) * size * 4);
         unsigned char* ptr = *data;
 
         for (int i = 0; i < size; i++) {

--- a/plugins/molecularmaps/src/helper_includes/helper_string.h
+++ b/plugins/molecularmaps/src/helper_includes/helper_string.h
@@ -84,7 +84,7 @@ inline int stringRemoveDelimiter(char delimiter, const char* string) {
         string_start++;
     }
 
-    if (string_start >= (int)strlen(string) - 1) {
+    if (string_start >= (int) strlen(string) - 1) {
         return 0;
     }
 
@@ -92,7 +92,7 @@ inline int stringRemoveDelimiter(char delimiter, const char* string) {
 }
 
 inline int getFileExtension(char* filename, char** extension) {
-    int string_length = (int)strlen(filename);
+    int string_length = (int) strlen(filename);
 
     while (filename[string_length--] != '.') {
         if (string_length == 0)
@@ -120,9 +120,9 @@ inline bool checkCmdLineFlag(const int argc, const char** argv, const char* stri
             const char* string_argv = &argv[i][string_start];
 
             const char* equal_pos = strchr(string_argv, '=');
-            int argv_length = (int)(equal_pos == 0 ? strlen(string_argv) : equal_pos - string_argv);
+            int argv_length = (int) (equal_pos == 0 ? strlen(string_argv) : equal_pos - string_argv);
 
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (length == argv_length && !STRNCASECMP(string_argv, string_ref, length)) {
                 bFound = true;
@@ -143,12 +143,12 @@ inline bool getCmdLineArgumentValue(const int argc, const char** argv, const cha
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
-                    *value = (T)atoi(&string_argv[length + auto_inc]);
+                    *value = (T) atoi(&string_argv[length + auto_inc]);
                 }
 
                 bFound = true;
@@ -168,10 +168,10 @@ inline int getCmdLineArgumentInt(const int argc, const char** argv, const char* 
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
                     value = atoi(&string_argv[length + auto_inc]);
                 } else {
@@ -199,12 +199,12 @@ inline float getCmdLineArgumentFloat(const int argc, const char** argv, const ch
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
-                    value = (float)atof(&string_argv[length + auto_inc]);
+                    value = (float) atof(&string_argv[length + auto_inc]);
                 } else {
                     value = 0.f;
                 }
@@ -228,8 +228,8 @@ inline bool getCmdLineArgumentString(const int argc, const char** argv, const ch
     if (argc >= 1) {
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
-            char* string_argv = (char*)&argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            char* string_argv = (char*) &argv[i][string_start];
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
                 *string_retval = &string_argv[length + 1];
@@ -460,7 +460,7 @@ inline char* sdkFindFilePath(const char* filename, const char* executable_path) 
             fclose(fp);
             // File found
             // returning an allocated array here for backwards compatibility reasons
-            char* file_path = (char*)malloc(path.length() + 1);
+            char* file_path = (char*) malloc(path.length() + 1);
             STRCPY(file_path, path.length() + 1, path.c_str());
             return file_path;
         }

--- a/plugins/molecularmaps/src/helper_includes/helper_timer.h
+++ b/plugins/molecularmaps/src/helper_includes/helper_timer.h
@@ -79,10 +79,10 @@ public:
             LARGE_INTEGER temp;
 
             // get the tick frequency from the OS
-            QueryPerformanceFrequency((LARGE_INTEGER*)&temp);
+            QueryPerformanceFrequency((LARGE_INTEGER*) &temp);
 
             // convert to type in which it is needed
-            freq = ((double)temp.QuadPart) / 1000.0;
+            freq = ((double) temp.QuadPart) / 1000.0;
 
             // rememeber query
             freq_set = true;
@@ -145,7 +145,7 @@ private:
 //! Start time measurement
 ////////////////////////////////////////////////////////////////////////////////
 inline void StopWatchWin::start() {
-    QueryPerformanceCounter((LARGE_INTEGER*)&start_time);
+    QueryPerformanceCounter((LARGE_INTEGER*) &start_time);
     running = true;
 }
 
@@ -154,8 +154,8 @@ inline void StopWatchWin::start() {
 //! variable. Also increment the number of times this clock has been run.
 ////////////////////////////////////////////////////////////////////////////////
 inline void StopWatchWin::stop() {
-    QueryPerformanceCounter((LARGE_INTEGER*)&end_time);
-    diff_time = (float)(((double)end_time.QuadPart - (double)start_time.QuadPart) / freq);
+    QueryPerformanceCounter((LARGE_INTEGER*) &end_time);
+    diff_time = (float) (((double) end_time.QuadPart - (double) start_time.QuadPart) / freq);
 
     total_time += diff_time;
     clock_sessions++;
@@ -172,7 +172,7 @@ inline void StopWatchWin::reset() {
     clock_sessions = 0;
 
     if (running) {
-        QueryPerformanceCounter((LARGE_INTEGER*)&start_time);
+        QueryPerformanceCounter((LARGE_INTEGER*) &start_time);
     }
 }
 
@@ -189,8 +189,8 @@ inline float StopWatchWin::getTime() {
 
     if (running) {
         LARGE_INTEGER temp;
-        QueryPerformanceCounter((LARGE_INTEGER*)&temp);
-        retval += (float)(((double)(temp.QuadPart - start_time.QuadPart)) / freq);
+        QueryPerformanceCounter((LARGE_INTEGER*) &temp);
+        retval += (float) (((double) (temp.QuadPart - start_time.QuadPart)) / freq);
     }
 
     return retval;
@@ -330,7 +330,7 @@ inline float StopWatchLinux::getDiffTime() {
     gettimeofday(&t_time, 0);
 
     // time difference in milli-seconds
-    return (float)(1000.0 * (t_time.tv_sec - start_time.tv_sec) + (0.001 * (t_time.tv_usec - start_time.tv_usec)));
+    return (float) (1000.0 * (t_time.tv_sec - start_time.tv_sec) + (0.001 * (t_time.tv_usec - start_time.tv_usec)));
 }
 #endif // WIN32
 
@@ -345,9 +345,9 @@ inline float StopWatchLinux::getDiffTime() {
 inline bool sdkCreateTimer(StopWatchInterface** timer_interface) {
     //printf("sdkCreateTimer called object %08x\n", (void *)*timer_interface);
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-    *timer_interface = (StopWatchInterface*)new StopWatchWin();
+    *timer_interface = (StopWatchInterface*) new StopWatchWin();
 #else
-    *timer_interface = (StopWatchInterface*)new StopWatchLinux();
+    *timer_interface = (StopWatchInterface*) new StopWatchLinux();
 #endif
     return (*timer_interface != NULL) ? true : false;
 }

--- a/plugins/molecularmaps/src/kxsort.h
+++ b/plugins/molecularmaps/src/kxsort.h
@@ -124,7 +124,7 @@ inline void radix_sort_core_(RandomIt s, RandomIt e, RadixTraits radix_traits) {
 
 template<class RandomIt, class ValueType, class RadixTraits>
 inline void radix_sort_entry_(RandomIt s, RandomIt e, ValueType*, RadixTraits radix_traits) {
-    if (e - s <= (int)kInsertSortThreshold)
+    if (e - s <= (int) kInsertSortThreshold)
         insert_sort_core_<RandomIt, ValueType, RadixTraits>(s, e, radix_traits);
     else
         radix_sort_core_<RandomIt, ValueType, RadixTraits, RadixTraits::nBytes - 1>(s, e, radix_traits);
@@ -133,9 +133,9 @@ inline void radix_sort_entry_(RandomIt s, RandomIt e, ValueType*, RadixTraits ra
 template<class RandomIt, class ValueType>
 inline void radix_sort_entry_(RandomIt s, RandomIt e, ValueType*) {
     if (ValueType(-1) > ValueType(0)) {
-        radix_sort_entry_(s, e, (ValueType*)(0), RadixTraitsUnsigned<ValueType>());
+        radix_sort_entry_(s, e, (ValueType*) (0), RadixTraitsUnsigned<ValueType>());
     } else {
-        radix_sort_entry_(s, e, (ValueType*)(0), RadixTraitsSigned<ValueType>());
+        radix_sort_entry_(s, e, (ValueType*) (0), RadixTraitsSigned<ValueType>());
     }
 }
 

--- a/plugins/molsurfmapcluster_gl/src/ProteinViewRenderer.cpp
+++ b/plugins/molsurfmapcluster_gl/src/ProteinViewRenderer.cpp
@@ -205,7 +205,7 @@ bool ProteinViewRenderer::create(void) {
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), 0);
     glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*) (3 * sizeof(float)));
 
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/plugins/optix_hpg/src/CUDAToGL.h
+++ b/plugins/optix_hpg/src/CUDAToGL.h
@@ -35,7 +35,7 @@ inline constexpr auto cuda_to_gl_init_func = [](std::shared_ptr<glowl::Framebuff
 
     fbo = std::make_shared<CUDAFramebuffer>();
 
-    glGenTextures(1, (GLuint*)&fbo->data.col_tex);
+    glGenTextures(1, (GLuint*) &fbo->data.col_tex);
     glBindTexture(GL_TEXTURE_2D, fbo->data.col_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
@@ -59,7 +59,7 @@ inline constexpr auto cuda_to_gl_init_func = [](std::shared_ptr<glowl::Framebuff
 
     CUDA_CHECK_ERROR(cuSurfObjectCreate(&fbo->colorBuffer, &surf_desc));
 
-    glGenTextures(1, (GLuint*)&fbo->data.depth_tex);
+    glGenTextures(1, (GLuint*) &fbo->data.depth_tex);
     glBindTexture(GL_TEXTURE_2D, fbo->data.depth_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);

--- a/plugins/optix_hpg/src/optix/MMOptixModule.cpp
+++ b/plugins/optix_hpg/src/optix/MMOptixModule.cpp
@@ -70,7 +70,7 @@ std::tuple<CUmodule, CUfunction> get_bounds_function(std::string const& ptx_code
         CU_JIT_ERROR_LOG_BUFFER,
         CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES,
     };
-    void* optionValues[] = {(void*)0, (char*)log, (unsigned int*)&log_size};
+    void* optionValues[] = {(void*) 0, (char*) log, (unsigned int*) &log_size};
     CUDA_CHECK_ERROR(cuModuleLoadDataEx(&bounds_module, ptx_out.c_str(), 3, options, optionValues));
 #if DEBUG
     if (log_size > 1) {
@@ -254,13 +254,13 @@ void megamol::optix_hpg::MMOptixModule::ComputeBounds(
     uint32_t threadsPerBlock = blockDims.x * blockDims.y * blockDims.z;
 
     uint32_t numBlocks = (num_elements + threadsPerBlock - 1) / threadsPerBlock;
-    uint32_t numBlocks_x = 1 + uint32_t(powf((float)numBlocks, 1.f / 3.f));
-    uint32_t numBlocks_y = 1 + uint32_t(sqrtf((float)(numBlocks / numBlocks_x)));
+    uint32_t numBlocks_x = 1 + uint32_t(powf((float) numBlocks, 1.f / 3.f));
+    uint32_t numBlocks_y = 1 + uint32_t(sqrtf((float) (numBlocks / numBlocks_x)));
     uint32_t numBlocks_z = (numBlocks + numBlocks_x * numBlocks_y - 1) / numBlocks_x * numBlocks_y;
 
     glm::uvec3 gridDims(numBlocks_x, numBlocks_y, numBlocks_z);
 
-    void* args[] = {&data_in, &bounds_out, (void*)&num_elements};
+    void* args[] = {&data_in, &bounds_out, (void*) &num_elements};
 
     CUDA_CHECK_ERROR(cuLaunchKernel(bounds_function_, gridDims.x, gridDims.y, gridDims.z, blockDims.x, blockDims.y,
         blockDims.z, 0, stream, args, nullptr));

--- a/plugins/optix_hpg/src/optix/MeshGeometry.cpp
+++ b/plugins/optix_hpg/src/optix/MeshGeometry.cpp
@@ -149,8 +149,8 @@ bool megamol::optix_hpg::MeshGeometry::assertData(mesh::CallMesh& call, Context 
 
         SBTRecord<device::MeshGeoData> sbt_record;
         OPTIX_CHECK_ERROR(optixSbtRecordPackHeader(mesh_module_, &sbt_record));
-        sbt_record.data.index_buffer = (glm::uvec3*)mesh_idx_data_.back();
-        sbt_record.data.vertex_buffer = (glm::vec3*)mesh_pos_data_.back();
+        sbt_record.data.index_buffer = (glm::uvec3*) mesh_idx_data_.back();
+        sbt_record.data.vertex_buffer = (glm::vec3*) mesh_pos_data_.back();
 
         sbt_records_.push_back(sbt_record);
 

--- a/plugins/optix_hpg/src/optix/Renderer.cpp
+++ b/plugins/optix_hpg/src/optix/Renderer.cpp
@@ -63,7 +63,7 @@ void megamol::optix_hpg::Renderer::setup() {
     OPTIX_CHECK_ERROR(optixSbtRecordPackHeader(miss_module_, &sbt_miss_records_[0]));
     OPTIX_CHECK_ERROR(optixSbtRecordPackHeader(miss_occlusion_module_, &sbt_miss_records_[1]));
 
-    sbt_raygen_record_.data.frameStateBuffer = (device::FrameState*)get_frame_state_buffer();
+    sbt_raygen_record_.data.frameStateBuffer = (device::FrameState*) get_frame_state_buffer();
 }
 
 

--- a/plugins/optix_hpg/src/optix/SphereGeometry.cpp
+++ b/plugins/optix_hpg/src/optix/SphereGeometry.cpp
@@ -171,7 +171,7 @@ bool megamol::optix_hpg::SphereGeometry::assertData(geocalls::MultiParticleDataC
         SBTRecord<device::SphereGeoData> sbt_record;
         OPTIX_CHECK_ERROR(optixSbtRecordPackHeader(sphere_module_, &sbt_record));
 
-        sbt_record.data.particleBufferPtr = (device::Particle*)particle_data_[pl_idx];
+        sbt_record.data.particleBufferPtr = (device::Particle*) particle_data_[pl_idx];
         sbt_record.data.colorBufferPtr = nullptr;
         sbt_record.data.radius = particles.GetGlobalRadius();
         sbt_record.data.hasColorData = has_color;
@@ -180,7 +180,7 @@ bool megamol::optix_hpg::SphereGeometry::assertData(geocalls::MultiParticleDataC
                 particles.GetGlobalColour()[2] / 255.f, particles.GetGlobalColour()[3] / 255.f);
 
         if (has_color) {
-            sbt_record.data.colorBufferPtr = (glm::vec4*)color_data_[pl_idx];
+            sbt_record.data.colorBufferPtr = (glm::vec4*) color_data_[pl_idx];
         }
         sbt_records_.push_back(sbt_record);
 

--- a/plugins/optix_hpg/src/optix/TransitionCalculator.cpp
+++ b/plugins/optix_hpg/src/optix/TransitionCalculator.cpp
@@ -195,8 +195,8 @@ bool megamol::optix_hpg::TransitionCalculator::assertData(
 
     SBTRecord<device::TransitionCalculatorData> mesh_sbt_record;
     OPTIX_CHECK_ERROR(optixSbtRecordPackHeader(mesh_module_, &mesh_sbt_record));
-    mesh_sbt_record.data.index_buffer = (glm::uvec3*)mesh_idx_data;
-    mesh_sbt_record.data.vertex_buffer = (glm::vec3*)mesh_pos_data;
+    mesh_sbt_record.data.index_buffer = (glm::uvec3*) mesh_idx_data;
+    mesh_sbt_record.data.vertex_buffer = (glm::vec3*) mesh_pos_data;
 
     ///----------------------------------------------
 
@@ -306,10 +306,10 @@ bool megamol::optix_hpg::TransitionCalculator::assertData(
         CUDA_CHECK_ERROR(cuMemsetD32Async(mesh_outbound_ctr, 0, (num_vertices / 3), optix_ctx_->GetExecStream()));
         CUDA_CHECK_ERROR(cuMemsetD8Async(ray_state, 0, ray_vec.size(), optix_ctx_->GetExecStream()));
 
-        mesh_sbt_record.data.mesh_inbound_ctr_ptr = (std::uint32_t*)mesh_inbound_ctr;
-        mesh_sbt_record.data.mesh_outbound_ctr_ptr = (std::uint32_t*)mesh_outbound_ctr;
-        mesh_sbt_record.data.ray_state = (std::uint8_t*)ray_state;
-        mesh_sbt_record.data.ray_buffer = (void*)ray_buffer_.back();
+        mesh_sbt_record.data.mesh_inbound_ctr_ptr = (std::uint32_t*) mesh_inbound_ctr;
+        mesh_sbt_record.data.mesh_outbound_ctr_ptr = (std::uint32_t*) mesh_outbound_ctr;
+        mesh_sbt_record.data.ray_state = (std::uint8_t*) ray_state;
+        mesh_sbt_record.data.ray_buffer = (void*) ray_buffer_.back();
         mesh_sbt_record.data.num_rays = ray_vec.size();
         mesh_sbt_record.data.num_tris = num_vertices / 3;
         mesh_sbt_record.data.world = geo_handle;

--- a/plugins/optix_hpg/src/optix/random.h
+++ b/plugins/optix_hpg/src/optix/random.h
@@ -58,7 +58,7 @@ static __host__ __device__ __inline__ unsigned int lcg2(unsigned int& prev) {
 
 // Generate random float in [0, 1)
 static __host__ __device__ __inline__ float rnd(unsigned int& prev) {
-    return ((float)lcg(prev) / (float)0x01000000);
+    return ((float) lcg(prev) / (float) 0x01000000);
 }
 
 static __host__ __device__ __inline__ unsigned int rot_seed(unsigned int seed, unsigned int frame) {

--- a/plugins/optix_hpg/src/optix/utils_device.h
+++ b/plugins/optix_hpg/src/optix/utils_device.h
@@ -104,7 +104,7 @@ typedef struct Ray {
 
 template<typename T>
 inline __device__ T const& getProgramData() {
-    return *(T const*)optixGetSbtDataPointer();
+    return *(T const*) optixGetSbtDataPointer();
 }
 
 
@@ -130,7 +130,7 @@ inline __device__ void* getPerRayDataPointer() {
 
 template<typename T>
 inline __device__ T& getPerRayData() {
-    return *(T*)getPerRayDataPointer();
+    return *(T*) getPerRayDataPointer();
 }
 
 /** Faceforward
@@ -300,7 +300,7 @@ inline __device__ void lighting(PerRayData& prd, glm::vec3 const& geo_col, glm::
         float3 Pn = make_float3(P.x, P.y, P.z);
         float3 Ln = make_float3(L.x, L.y, L.z);
         unsigned int occluded = 0;
-        optixTrace(prd.world, Pn, Ln, 0.01f, Ldist - 0.01f, 0.0f, (OptixVisibilityMask)-1,
+        optixTrace(prd.world, Pn, Ln, 0.01f, Ldist - 0.01f, 0.0f, (OptixVisibilityMask) -1,
             OPTIX_RAY_FLAG_TERMINATE_ON_FIRST_HIT, 1, 2, 1, occluded);
 
         if (!occluded) {

--- a/plugins/probe_gl/src/ProbeBillboardGlyphRenderTasks.cpp
+++ b/plugins/probe_gl/src/ProbeBillboardGlyphRenderTasks.cpp
@@ -463,7 +463,7 @@ bool megamol::probe_gl::ProbeBillboardGlyphRenderTasks::getDataCallback(core::Ca
                     {GL_TEXTURE_WRAP_S, GL_CLAMP}};
                 try {
                     this->m_transfer_function = std::make_shared<glowl::Texture2D>(
-                        "ProbeTransferFunction", tex_layout, (GLvoid*)tfc->GetTextureData());
+                        "ProbeTransferFunction", tex_layout, (GLvoid*) tfc->GetTextureData());
                 } catch (glowl::TextureException const& exc) {
                     megamol::core::utility::log::Log::DefaultLog.WriteError(
                         "Error on transfer texture view creation: %s. [%s, %s, line %d]\n", exc.what(), __FILE__,

--- a/plugins/protein/include/protein/AbstractVTKLegacyData.h
+++ b/plugins/protein/include/protein/AbstractVTKLegacyData.h
@@ -140,7 +140,7 @@ public:
                 nBitsPerElement = 8;
                 break;
             }
-            size_t memSize = (size_t)ceil(nElements * nComponents * nBitsPerElement / 8);
+            size_t memSize = (size_t) ceil(nElements * nComponents * nBitsPerElement / 8);
 
             // (Re)allocate memory if necessary
             if (this->allocated < memSize) {

--- a/plugins/protein/include/protein/GridNeighbourFinder.h
+++ b/plugins/protein/include/protein/GridNeighbourFinder.h
@@ -49,7 +49,7 @@ public:
             /* resize bounding-box and grid structure */
             vislib::math::Dimension<T, 3> dim = boundingBox.GetSize();
             for (int i = 0; i < 3; i++)
-                this->gridResolution[i] = (unsigned int)floor(dim[i] / (2 * searchDistance) + 1.0);
+                this->gridResolution[i] = (unsigned int) floor(dim[i] / (2 * searchDistance) + 1.0);
             this->gridSize = this->gridResolution[0] * this->gridResolution[1] * this->gridResolution[2];
             this->elementBBox = boundingBox;
 
@@ -71,8 +71,8 @@ public:
         /** fill the internal grid structure */
         vislib::math::Dimension<T, 3> bBoxDimension = this->elementBBox.GetSize();
         for (int i = 0; i < 3; i++) {
-            this->gridResolutionFactors[i] = (T)this->gridResolution[i] / bBoxDimension[i];
-            this->cellSize[i] = (T)bBoxDimension[i] / this->gridResolution[i]; //(T)1.0) / gridResolutionFactors[i];
+            this->gridResolutionFactors[i] = (T) this->gridResolution[i] / bBoxDimension[i];
+            this->cellSize[i] = (T) bBoxDimension[i] / this->gridResolution[i]; //(T)1.0) / gridResolutionFactors[i];
         }
         // sort the element positions into the grid ...
         for (unsigned int i = 0; i < this->elementCount; i++) {
@@ -92,12 +92,12 @@ public:
         // calculate range in the grid ...
         int min[3], max[3];
         for (unsigned int i = 0; i < 3; i++) {
-            min[i] = (int)floor((relPos[i] - distance) * gridResolutionFactors[i]);
+            min[i] = (int) floor((relPos[i] - distance) * gridResolutionFactors[i]);
             if (min[i] < 0)
                 min[i] = 0;
-            max[i] = (int)ceil((relPos[i] + distance) * gridResolutionFactors[i]);
-            if (max[i] >= (int)gridResolution[i])
-                max[i] = (int)gridResolution[i] - 1;
+            max[i] = (int) ceil((relPos[i] + distance) * gridResolutionFactors[i]);
+            if (max[i] >= (int) gridResolution[i])
+                max[i] = (int) gridResolution[i] - 1;
         }
 
         // loop over all cells inside the sphere (point, distance)
@@ -123,9 +123,9 @@ private:
     VISLIB_FORCEINLINE void insertPointIntoGrid(const T* point) {
         //Point relPos = sub(point, elementOrigin);
         unsigned int indexX =
-            (unsigned int)(/*relPos.X()*/ (point[0] - elementOrigin[0]) * gridResolutionFactors[0]); // floor()?
-        unsigned int indexY = (unsigned int)(/*relPos.Y()*/ (point[1] - elementOrigin[1]) * gridResolutionFactors[1]);
-        unsigned int indexZ = (unsigned int)(/*relPos.Z()*/ (point[2] - elementOrigin[2]) * gridResolutionFactors[2]);
+            (unsigned int) (/*relPos.X()*/ (point[0] - elementOrigin[0]) * gridResolutionFactors[0]); // floor()?
+        unsigned int indexY = (unsigned int) (/*relPos.Y()*/ (point[1] - elementOrigin[1]) * gridResolutionFactors[1]);
+        unsigned int indexZ = (unsigned int) (/*relPos.Z()*/ (point[2] - elementOrigin[2]) * gridResolutionFactors[2]);
         ASSERT(indexX < gridResolution[0] && indexY < gridResolution[1] && indexZ < gridResolution[2]);
         vislib::Array<const T*>& cell = elementGrid[cellIndex(indexX, indexY, indexZ)];
         cell.Add(point);
@@ -133,9 +133,9 @@ private:
 
     VISLIB_FORCEINLINE void findNeighboursInCell(
         const vislib::Array<const T*>& cell, const T* point, T distance, vislib::Array<unsigned int>& resIdx) const {
-        for (int i = 0; i < (int)cell.Count(); i++)
+        for (int i = 0; i < (int) cell.Count(); i++)
             if (dist(cell[i], point) <= distance)
-                resIdx.Add((unsigned int)((cell[i] - elementPositions) / 3)); // store atom index
+                resIdx.Add((unsigned int) ((cell[i] - elementPositions) / 3)); // store atom index
     }
 
     inline unsigned int cellIndex(unsigned int x, unsigned int y, unsigned int z) const {

--- a/plugins/protein/include/protein/ReducedSurface.h
+++ b/plugins/protein/include/protein/ReducedSurface.h
@@ -52,7 +52,7 @@ public:
         };
         /** getter for the edge list size */
         const unsigned int GetEdgeCount() const {
-            return (unsigned int)edgeList.size();
+            return (unsigned int) edgeList.size();
         };
         /** add edge */
         void AddEdge(RSEdge* edge) {
@@ -331,7 +331,7 @@ public:
      * @return The number of RS-vertices.
      */
     unsigned int GetRSVertexCount() {
-        return (unsigned int)rsVertex.size();
+        return (unsigned int) rsVertex.size();
     };
 
     /**
@@ -339,7 +339,7 @@ public:
      * @return The number of RS-edges.
      */
     unsigned int GetRSEdgeCount() {
-        return (unsigned int)rsEdge.size();
+        return (unsigned int) rsEdge.size();
     };
 
     /**
@@ -347,7 +347,7 @@ public:
      * @return The number of RS-faces.
      */
     unsigned int GetRSFaceCount() {
-        return (unsigned int)rsFace.size();
+        return (unsigned int) rsFace.size();
     };
 
     /**

--- a/plugins/protein/src/BSpline.cpp
+++ b/plugins/protein/src/BSpline.cpp
@@ -69,17 +69,17 @@ void protein::BSpline::setG(vislib::math::Vector<float, 3> v1, vislib::math::Vec
 void protein::BSpline::setN(unsigned int n) {
     this->N = n;
 
-    this->S.SetAt(0, 0, 6.0f / (float)pow((double)n, (double)3));
+    this->S.SetAt(0, 0, 6.0f / (float) pow((double) n, (double) 3));
     this->S.SetAt(0, 1, 0.0f);
     this->S.SetAt(0, 2, 0.0f);
     this->S.SetAt(0, 3, 0.0f);
-    this->S.SetAt(1, 0, 6.0f / (float)pow((double)n, (double)3));
-    this->S.SetAt(1, 1, 2.0f / (float)pow((double)n, (double)2));
+    this->S.SetAt(1, 0, 6.0f / (float) pow((double) n, (double) 3));
+    this->S.SetAt(1, 1, 2.0f / (float) pow((double) n, (double) 2));
     this->S.SetAt(1, 2, 0.0f);
     this->S.SetAt(1, 3, 0.0f);
-    this->S.SetAt(2, 0, 1.0f / (float)pow((double)n, (double)3));
-    this->S.SetAt(2, 1, 1.0f / (float)pow((double)n, (double)2));
-    this->S.SetAt(2, 2, 1.0f / (float)n);
+    this->S.SetAt(2, 0, 1.0f / (float) pow((double) n, (double) 3));
+    this->S.SetAt(2, 1, 1.0f / (float) pow((double) n, (double) 2));
+    this->S.SetAt(2, 2, 1.0f / (float) n);
     this->S.SetAt(2, 3, 0.0f);
     this->S.SetAt(3, 0, 0.0f);
     this->S.SetAt(3, 1, 0.0f);
@@ -165,7 +165,7 @@ bool protein::BSpline::computeSpline() {
         }
 
         // FIX START
-        unsigned int end = (unsigned int)this->backbone.size() - 1;
+        unsigned int end = (unsigned int) this->backbone.size() - 1;
 
         // assign the geometry matrix
         this->setG(

--- a/plugins/protein/src/CrystalStructureDataSource.cpp
+++ b/plugins/protein/src/CrystalStructureDataSource.cpp
@@ -122,8 +122,8 @@ protein::CrystalStructureDataSource::CrystalStructureDataSource()
     case CHKPT_SOURCE:
         (*dirc)(1); // Call for get extend
         (*dirc)(0); // Call for get data
-        this->atomCnt = (unsigned int)dirc->AccessParticles(0).GetCount();
-        this->dipoleCnt = (unsigned int)dirc->AccessParticles(0).GetCount();
+        this->atomCnt = (unsigned int) dirc->AccessParticles(0).GetCount();
+        this->dipoleCnt = (unsigned int) dirc->AccessParticles(0).GetCount();
         this->cellCnt = 0;
         this->frameCnt = 1;
         break;
@@ -325,7 +325,7 @@ bool protein::CrystalStructureDataSource::loadFiles() {
     }
 
     fileAtoms.seekg(0, std::ios::beg);
-    fileAtoms.read((char*)bufferAtoms, this->atomCnt * 7 * sizeof(int));
+    fileAtoms.read((char*) bufferAtoms, this->atomCnt * 7 * sizeof(int));
     fileAtoms.close();
 
     // Set atom types and colors
@@ -380,7 +380,7 @@ bool protein::CrystalStructureDataSource::loadFiles() {
     }
 
     fileCells.seekg(0, std::ios::beg);
-    fileCells.read((char*)this->cells, this->cellCnt * 15 * sizeof(int));
+    fileCells.read((char*) this->cells, this->cellCnt * 15 * sizeof(int));
     fileCells.close();
 
     //printf("  cells done ...\n"); // DEBUG
@@ -526,8 +526,8 @@ void protein::CrystalStructureDataSource::updateParams() {
         case CHKPT_SOURCE:
             (*dirc)(1); // Call for get extend
             (*dirc)(0); // Call for get data
-            this->atomCnt = (unsigned int)dirc->AccessParticles(0).GetCount();
-            this->dipoleCnt = (unsigned int)dirc->AccessParticles(0).GetCount();
+            this->atomCnt = (unsigned int) dirc->AccessParticles(0).GetCount();
+            this->dipoleCnt = (unsigned int) dirc->AccessParticles(0).GetCount();
             this->cellCnt = 0;
             this->frameCnt = 1;
             break;
@@ -604,7 +604,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         }
 
         // Read frame data of the displacement frame from file
-        file.read((char*)(fr->dipole), this->dipoleCnt * 3 * sizeof(float));
+        file.read((char*) (fr->dipole), this->dipoleCnt * 3 * sizeof(float));
 
         // Skip frames
         // Note: -1 because we already skipped one frame by reading it
@@ -613,7 +613,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         file.seekg(this->atomCnt * 3 * sizeof(float) * fr->GetFrameIdx(), std::ios::beg);
 
         // Read atom pos from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
 
         // Close file
         file.close();
@@ -661,7 +661,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         }
 
         // Read frame data of the displacement frame from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
         // Calc displacement
 #pragma omp parallel for
         for (int di = 0; di < static_cast<int>(dipoleCnt); di++) {
@@ -678,7 +678,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         file.seekg(this->atomCnt * 3 * sizeof(float) * fr->GetFrameIdx(), std::ios::beg);
 
         // Read atom pos from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
 
         // Close file
         file.close();
@@ -709,7 +709,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         file.seekg(this->atomCnt * 3 * sizeof(float) * fr->GetFrameIdx(), std::ios::beg);
 
         // Read atom pos from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
 
         // Close file
         file.close();
@@ -787,7 +787,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         if (!(*dirc)(1))
             return false;
 
-        this->dipoleCnt = (unsigned int)dirc->AccessParticles(0).GetCount();
+        this->dipoleCnt = (unsigned int) dirc->AccessParticles(0).GetCount();
 
         // Note: we only have one particle list in this case
         geocalls::MultiParticleDataCall::Particles& parts = dirc->AccessParticles(0);
@@ -874,7 +874,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         file.seekg(this->atomCnt * 3 * sizeof(float) * fr->GetFrameIdx(), std::ios::beg);
 
         // Read atom pos from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
 
         // Close file
         file.close();
@@ -940,7 +940,7 @@ bool protein::CrystalStructureDataSource::WriteFrameData(CrystalStructureDataSou
         file.seekg(this->atomCnt * 3 * sizeof(float) * fr->GetFrameIdx(), std::ios::beg);
 
         // Read atom pos from file
-        file.read((char*)(fr->atomPos), this->atomCnt * 3 * sizeof(float));
+        file.read((char*) (fr->atomPos), this->atomCnt * 3 * sizeof(float));
 
         // Close file
         file.close();

--- a/plugins/protein/src/GROLoader.cpp
+++ b/plugins/protein/src/GROLoader.cpp
@@ -72,7 +72,7 @@ int GROLoader::Frame::decodebits(char* buff, int offset, int bitsize) {
     char tmpBuff[] = {buff[3], buff[2], buff[1], buff[0]};
 
     // interprete char-array as an integer
-    num = *(int*)tmpBuff;
+    num = *(int*) tmpBuff;
     // cut off right offset
     num = num >> (32 - (offset + bitsize));
 
@@ -151,7 +151,7 @@ unsigned int GROLoader::Frame::sizeofints(unsigned int sizes[]) {
 
     num = 1;
     num_of_bytes--;
-    while (bytes[num_of_bytes] >= (unsigned int)num) {
+    while (bytes[num_of_bytes] >= (unsigned int) num) {
         num_of_bits++;
         num *= 2;
     }
@@ -166,7 +166,7 @@ int GROLoader::Frame::sizeofint(int size) {
     unsigned int num = 1;
     int num_of_bits = 0;
 
-    while ((unsigned int)size >= num && num_of_bits < 32) {
+    while ((unsigned int) size >= num && num_of_bits < 32) {
         num_of_bits++;
         num <<= 1;
     }
@@ -210,33 +210,33 @@ bool GROLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write date to outfile
     int date = 1995;
-    changeByteOrder((char*)&date);
-    outfile->write((char*)&date, 4);
+    changeByteOrder((char*) &date);
+    outfile->write((char*) &date, 4);
 
     // write number of atoms to outfile
     int atomCount = AtomCount();
-    changeByteOrder((char*)&atomCount);
-    outfile->write((char*)&atomCount, 4);
+    changeByteOrder((char*) &atomCount);
+    outfile->write((char*) &atomCount, 4);
 
     // write simulation step to outfile
     int step = frame;
-    changeByteOrder((char*)&step);
-    outfile->write((char*)&step, 4);
+    changeByteOrder((char*) &step);
+    outfile->write((char*) &step, 4);
 
     // write simulation time to outfile
-    float simtime = (float)frame;
-    changeByteOrder((char*)&simtime);
-    outfile->write((char*)&simtime, 4);
+    float simtime = (float) frame;
+    changeByteOrder((char*) &simtime);
+    outfile->write((char*) &simtime, 4);
 
     precision /= 10.0;
 
     // get the range of values
-    minInt[0] = (int)(minFloats[0] * precision + 1);
-    minInt[1] = (int)(minFloats[1] * precision + 1);
-    minInt[2] = (int)(minFloats[2] * precision + 1);
-    maxInt[0] = (int)(maxFloats[0] * precision + 1);
-    maxInt[1] = (int)(maxFloats[1] * precision + 1);
-    maxInt[2] = (int)(maxFloats[2] * precision + 1);
+    minInt[0] = (int) (minFloats[0] * precision + 1);
+    minInt[1] = (int) (minFloats[1] * precision + 1);
+    minInt[2] = (int) (minFloats[2] * precision + 1);
+    maxInt[0] = (int) (maxFloats[0] * precision + 1);
+    maxInt[1] = (int) (maxFloats[1] * precision + 1);
+    maxInt[2] = (int) (maxFloats[2] * precision + 1);
 
     sizes[0] = maxInt[0] - minInt[0] + 1;
     sizes[1] = maxInt[1] - minInt[1] + 1;
@@ -247,42 +247,42 @@ bool GROLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write the bounding box to outfile
     float* box = new float[9];
-    box[0] = (float)sizes[0] / precision;
+    box[0] = (float) sizes[0] / precision;
     box[1] = 0.0;
     box[2] = 0.0;
     box[3] = 0.0;
-    box[4] = (float)sizes[1] / precision;
+    box[4] = (float) sizes[1] / precision;
     box[5] = 0.0;
     box[6] = 0.0;
     box[7] = 0.0;
-    box[8] = (float)sizes[2] / precision;
+    box[8] = (float) sizes[2] / precision;
 
     for (i = 0; i < 9; i++)
-        changeByteOrder((char*)&box[i]);
+        changeByteOrder((char*) &box[i]);
 
-    outfile->write((char*)box, 36);
+    outfile->write((char*) box, 36);
 
     // write number of atoms to outfile
-    outfile->write((char*)&atomCount, 4);
+    outfile->write((char*) &atomCount, 4);
 
     // write precision to outfile
     float prec = precision * 10.0f;
-    changeByteOrder((char*)&prec);
-    outfile->write((char*)&prec, 4);
+    changeByteOrder((char*) &prec);
+    outfile->write((char*) &prec, 4);
 
     // write maxint[] and minint[] to outfile
     int maxVal[] = {maxInt[0], maxInt[1], maxInt[2]};
     int minVal[] = {minInt[0], minInt[1], minInt[2]};
     for (i = 0; i < 3; i++) {
-        changeByteOrder((char*)&maxVal[i]);
-        changeByteOrder((char*)&minVal[i]);
+        changeByteOrder((char*) &maxVal[i]);
+        changeByteOrder((char*) &minVal[i]);
     }
-    outfile->write((char*)&minVal, 12);
-    outfile->write((char*)&maxVal, 12);
+    outfile->write((char*) &minVal, 12);
+    outfile->write((char*) &maxVal, 12);
 
     // write smallidx to outfile
     int smallidx = 0;
-    outfile->write((char*)&smallidx, 4);
+    outfile->write((char*) &smallidx, 4);
 
     unsigned int bitoffset = 0;
 
@@ -300,9 +300,9 @@ bool GROLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
     // unsigned ints and encode
     for (i = 0; i < AtomCount(); i++) {
 
-        thiscoord[0] = (int)(atomPosition[i * 3 + 0] * precision) - minInt[0];
-        thiscoord[1] = (int)(atomPosition[i * 3 + 1] * precision) - minInt[1];
-        thiscoord[2] = (int)(atomPosition[i * 3 + 2] * precision) - minInt[2];
+        thiscoord[0] = (int) (atomPosition[i * 3 + 0] * precision) - minInt[0];
+        thiscoord[1] = (int) (atomPosition[i * 3 + 1] * precision) - minInt[1];
+        thiscoord[2] = (int) (atomPosition[i * 3 + 2] * precision) - minInt[2];
 
         encodeints(charPt, bitsize, sizes, thiscoord, bitoffset);
 
@@ -323,8 +323,8 @@ bool GROLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write the size to outfile
     unsigned int s = byteSize;
-    changeByteOrder((char*)&s);
-    outfile->write((char*)&s, 4);
+    changeByteOrder((char*) &s);
+    outfile->write((char*) &s, 4);
 
     // write buffer to file
     outfile->write(charbuff, byteSize + ((4 - byteSize % 4) % 4));
@@ -402,7 +402,7 @@ bool GROLoader::Frame::encodeints(
 void GROLoader::Frame::encodebits(char* outbuff, int bitsize, int bitoffset, unsigned int num) {
 
     num <<= (32 - (bitoffset + bitsize));
-    char* numpt = (char*)&num;
+    char* numpt = (char*) &num;
 
     // change byte order on little endian systems
     outbuff[0] = outbuff[0] | numpt[3];
@@ -458,33 +458,33 @@ void GROLoader::Frame::readFrame(std::fstream* file) {
     if (atomCount <= 3) {
         float posX, posY, posZ;
         for (i = 0; i < atomCount; i++) {
-            file->read((char*)&posX, 4);
-            changeByteOrder((char*)&posX);
-            file->read((char*)&posY, 4);
-            changeByteOrder((char*)&posY);
-            file->read((char*)&posZ, 4);
-            changeByteOrder((char*)&posZ);
+            file->read((char*) &posX, 4);
+            changeByteOrder((char*) &posX);
+            file->read((char*) &posY, 4);
+            changeByteOrder((char*) &posY);
+            file->read((char*) &posZ, 4);
+            changeByteOrder((char*) &posZ);
             this->SetAtomPosition(i, posX, posY, posZ);
         }
         return;
     }
 
     // read the precision of the float coordinates
-    file->read((char*)&precision, 4);
-    changeByteOrder((char*)&precision);
+    file->read((char*) &precision, 4);
+    changeByteOrder((char*) &precision);
     precision /= 10.0f;
 
     // read the lower bound of 'big' integer-coordinates
-    file->read((char*)&minint, 12);
-    changeByteOrder((char*)&minint[0]);
-    changeByteOrder((char*)&minint[1]);
-    changeByteOrder((char*)&minint[2]);
+    file->read((char*) &minint, 12);
+    changeByteOrder((char*) &minint[0]);
+    changeByteOrder((char*) &minint[1]);
+    changeByteOrder((char*) &minint[2]);
 
     // read the upper bound of 'big' integer-coordinates
-    file->read((char*)&maxint, 12);
-    changeByteOrder((char*)&maxint[0]);
-    changeByteOrder((char*)&maxint[1]);
-    changeByteOrder((char*)&maxint[2]);
+    file->read((char*) &maxint, 12);
+    changeByteOrder((char*) &maxint[0]);
+    changeByteOrder((char*) &maxint[1]);
+    changeByteOrder((char*) &maxint[2]);
 
 
     sizeint[0] = maxint[0] - minint[0] + 1;
@@ -506,12 +506,12 @@ void GROLoader::Frame::readFrame(std::fstream* file) {
 
     // read number of bits used to encode 'small' integers
     // note: changes dynamically within one frame
-    file->read((char*)&smallidx, 4);
-    changeByteOrder((char*)&smallidx);
+    file->read((char*) &smallidx, 4);
+    changeByteOrder((char*) &smallidx);
 
     // calculate maxidx/minidx
     int minidx, maxidx;
-    if (LASTIDX < (unsigned int)(smallidx + 8)) {
+    if (LASTIDX < (unsigned int) (smallidx + 8)) {
         maxidx = LASTIDX;
     } else {
         maxidx = smallidx + 8;
@@ -534,15 +534,15 @@ void GROLoader::Frame::readFrame(std::fstream* file) {
     larger = magicints[maxidx];
 
     // read the size of the compressed data-block
-    file->read((char*)&size, 4);
-    changeByteOrder((char*)&size);
+    file->read((char*) &size, 4);
+    changeByteOrder((char*) &size);
 
-    buffer = new int[(int)(atomCount * 3 * 1.2)];
+    buffer = new int[(int) (atomCount * 3 * 1.2)];
 
     // get the compressed data-block
-    file->read((char*)&buffer[0], size);
+    file->read((char*) &buffer[0], size);
 
-    buffPt = (char*)buffer;
+    buffPt = (char*) buffer;
     bit_offset = 0;
 
 
@@ -626,8 +626,8 @@ void GROLoader::Frame::readFrame(std::fstream* file) {
                     prevcoord[2] = tempCoord;
 
                     // calculate float-value of the old coordinate
-                    this->SetAtomPosition(i, (float)prevcoord[0] / precision, (float)prevcoord[1] / precision,
-                        (float)prevcoord[2] / precision);
+                    this->SetAtomPosition(i, (float) prevcoord[0] / precision, (float) prevcoord[1] / precision,
+                        (float) prevcoord[2] / precision);
                     i++;
                 } else {
                     prevcoord[0] = thiscoord[0];
@@ -635,13 +635,13 @@ void GROLoader::Frame::readFrame(std::fstream* file) {
                     prevcoord[2] = thiscoord[2];
                 }
 
-                this->SetAtomPosition(i, (float)thiscoord[0] / precision, (float)thiscoord[1] / precision,
-                    (float)thiscoord[2] / precision);
+                this->SetAtomPosition(i, (float) thiscoord[0] / precision, (float) thiscoord[1] / precision,
+                    (float) thiscoord[2] / precision);
                 i++;
             }
         } else {
-            this->SetAtomPosition(
-                i, (float)thiscoord[0] / precision, (float)thiscoord[1] / precision, (float)thiscoord[2] / precision);
+            this->SetAtomPosition(i, (float) thiscoord[0] / precision, (float) thiscoord[1] / precision,
+                (float) thiscoord[2] / precision);
             i++;
         }
 
@@ -927,18 +927,18 @@ bool GROLoader::getData(core::Call& call) {
     }
 
     dc->SetConnections(
-        static_cast<unsigned int>(this->connectivity.Count() / 2), (unsigned int*)this->connectivity.PeekElements());
+        static_cast<unsigned int>(this->connectivity.Count() / 2), (unsigned int*) this->connectivity.PeekElements());
     dc->SetResidues(static_cast<unsigned int>(this->residue.Count()),
-        (const MolecularDataCall::Residue**)this->residue.PeekElements());
+        (const MolecularDataCall::Residue**) this->residue.PeekElements());
     // dc->SetAtomResidueIndices(this->atomResidueIdx.PeekElements());
     dc->SetSolventResidueIndices(
         static_cast<unsigned int>(this->solventResidueIdx.Count()), this->solventResidueIdx.PeekElements());
     dc->SetResidueTypeNames(static_cast<unsigned int>(this->residueTypeName.Count()),
-        (vislib::StringA*)this->residueTypeName.PeekElements());
-    dc->SetMolecules(
-        static_cast<unsigned int>(this->molecule.Count()), (MolecularDataCall::Molecule*)this->molecule.PeekElements());
+        (vislib::StringA*) this->residueTypeName.PeekElements());
+    dc->SetMolecules(static_cast<unsigned int>(this->molecule.Count()),
+        (MolecularDataCall::Molecule*) this->molecule.PeekElements());
     dc->SetChains(
-        static_cast<unsigned int>(this->chain.Count()), (MolecularDataCall::Chain*)this->chain.PeekElements());
+        static_cast<unsigned int>(this->chain.Count()), (MolecularDataCall::Chain*) this->chain.PeekElements());
 
     if (!this->secStructAvailable && this->strideFlagSlot.Param<param::BoolParam>()->Value()) {
         time_t t = clock(); // DEBUG
@@ -1065,11 +1065,11 @@ void GROLoader::release() {
     // stop frame-loading thread before clearing data array
     resetFrameCache();
 
-    for (int i = 0; i < (int)this->data.Count(); i++)
+    for (int i = 0; i < (int) this->data.Count(); i++)
         delete data[i];
     this->data.Clear();
 
-    for (int i = 0; i < (int)this->residue.Count(); i++)
+    for (int i = 0; i < (int) this->residue.Count(); i++)
         delete residue[i];
     this->residue.Clear();
 
@@ -1133,7 +1133,7 @@ void GROLoader::loadFile(const vislib::TString& filename) {
 
     this->bbox.Set(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-    for (int i = 0; i < (int)this->data.Count(); i++)
+    for (int i = 0; i < (int) this->data.Count(); i++)
         delete data[i];
     this->data.Clear();
 
@@ -1260,7 +1260,7 @@ void GROLoader::loadFile(const vislib::TString& filename) {
         for (resCnt = 0; resCnt < this->residue.Count(); ++resCnt) {
             // check if the current residue is an amino acid
             if (this->residue[resCnt]->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-                aminoacid = (MolecularDataCall::AminoAcid*)this->residue[resCnt];
+                aminoacid = (MolecularDataCall::AminoAcid*) this->residue[resCnt];
                 idx = aminoacid->FirstAtomIndex();
                 cnt = idx + aminoacid->AtomCount();
                 // loop over all atom of the current amino acid
@@ -1308,9 +1308,9 @@ void GROLoader::loadFile(const vislib::TString& filename) {
 
                 xtcFile.seekg(4, std::ios_base::cur);
                 // read number of atoms
-                xtcFile.read((char*)&nAtoms, 4);
+                xtcFile.read((char*) &nAtoms, 4);
                 // change byte order
-                num = (char*)&nAtoms;
+                num = (char*) &nAtoms;
                 tmpByte = num[0];
                 num[0] = num[3];
                 num[3] = tmpByte;
@@ -1345,7 +1345,7 @@ void GROLoader::loadFile(const vislib::TString& filename) {
 
 
     } else {
-        Log::DefaultLog.WriteError("Could not load file %s", (const char*)T2A(filename)); // DEBUG
+        Log::DefaultLog.WriteError("Could not load file %s", (const char*) T2A(filename)); // DEBUG
     }
 }
 
@@ -1444,7 +1444,7 @@ void GROLoader::parseAtomEntry(vislib::StringA& atomEntry, unsigned int atom, un
         if (this->IsAminoAcid(resName)) {
             MolecularDataCall::AminoAcid* res =
                 new MolecularDataCall::AminoAcid(atom, 1, 0, 0, 0, 0, atomBBox, resTypeIdx, -1, newResSeq);
-            this->residue.Add((MolecularDataCall::Residue*)res);
+            this->residue.Add((MolecularDataCall::Residue*) res);
         } else {
             MolecularDataCall::Residue* res =
                 new MolecularDataCall::Residue(atom, 1, atomBBox, resTypeIdx, -1, newResSeq);
@@ -1476,7 +1476,7 @@ void GROLoader::parseAtomEntry(vislib::StringA& atomEntry, unsigned int atom, un
         if (this->IsAminoAcid(resName)) {
             MolecularDataCall::AminoAcid* res =
                 new MolecularDataCall::AminoAcid(atom, 1, 0, 0, 0, 0, atomBBox, resTypeIdx, -1, newResSeq);
-            this->residue.Add((MolecularDataCall::Residue*)res);
+            this->residue.Add((MolecularDataCall::Residue*) res);
         } else {
             MolecularDataCall::Residue* res =
                 new MolecularDataCall::Residue(atom, 1, atomBBox, resTypeIdx, -1, newResSeq);
@@ -1838,14 +1838,14 @@ bool GROLoader::readNumXTCFrames() {
     while (!xtcFile.eof()) {
 
         // add the offset to the offset array
-        this->XTCFrameOffset.Add((unsigned int)xtcFile.tellg());
+        this->XTCFrameOffset.Add((unsigned int) xtcFile.tellg());
 
         // skip some header data
         xtcFile.seekg(56, std::ios_base::cur);
         // read precision
-        xtcFile.read((char*)&precision, 4);
+        xtcFile.read((char*) &precision, 4);
         // change byte-order
-        num = (char*)&precision;
+        num = (char*) &precision;
         tmpByte = num[0];
         num[0] = num[3];
         num[3] = tmpByte;
@@ -1855,19 +1855,19 @@ bool GROLoader::readNumXTCFrames() {
         precision /= 10.0f;
 
         // get the lower bound
-        xtcFile.read((char*)&minint, 12);
+        xtcFile.read((char*) &minint, 12);
         // get the upper bound
-        xtcFile.read((char*)&maxint, 12);
+        xtcFile.read((char*) &maxint, 12);
         // change byte-order
         for (i = 0; i < 3; i++) {
-            num = (char*)&minint[i];
+            num = (char*) &minint[i];
             tmpByte = num[0];
             num[0] = num[3];
             num[3] = tmpByte;
             tmpByte = num[1];
             num[1] = num[2];
             num[2] = tmpByte;
-            num = (char*)&maxint[i];
+            num = (char*) &maxint[i];
             tmpByte = num[0];
             num[0] = num[3];
             num[3] = tmpByte;
@@ -1880,19 +1880,19 @@ bool GROLoader::readNumXTCFrames() {
         this->bbox.Union(tmpBBox);
         // get the current frames bounding box including the atom radius
         // note: atom radius is divided by 10
-        tmpBBox = vislib::math::Cuboid<float>((float)minint[0] / precision - 0.3f, (float)minint[1] / precision - 0.3f,
-            (float)minint[2] / precision - 0.3f,
+        tmpBBox = vislib::math::Cuboid<float>((float) minint[0] / precision - 0.3f,
+            (float) minint[1] / precision - 0.3f, (float) minint[2] / precision - 0.3f,
 
-            (float)maxint[0] / precision + 0.3f, (float)maxint[1] / precision + 0.3f,
-            (float)maxint[2] / precision + 0.3f);
+            (float) maxint[0] / precision + 0.3f, (float) maxint[1] / precision + 0.3f,
+            (float) maxint[2] / precision + 0.3f);
 
         // skip some header data
         xtcFile.seekg(4, std::ios_base::cur);
 
         // read size of the compressed block of data
-        xtcFile.read((char*)&size, 4);
+        xtcFile.read((char*) &size, 4);
         // change byte-order
-        num = (char*)&size;
+        num = (char*) &size;
         tmpByte = num[0];
         num[0] = num[3];
         num[3] = tmpByte;

--- a/plugins/protein/src/HostArr.h
+++ b/plugins/protein/src/HostArr.h
@@ -81,7 +81,7 @@ public:
      * @param c The byte value
      */
     void Set(char c) {
-        memset((char*)(this->pt), c, this->GetSize() * sizeof(T));
+        memset((char*) (this->pt), c, this->GetSize() * sizeof(T));
     }
 
     /**
@@ -94,7 +94,7 @@ public:
         if ((this->pt == nullptr) || (sizeNew > this->size)) {
             this->Release();
             //this->pt = new T[sizeNew];
-            this->pt = (T*)malloc(sizeNew * sizeof(T));
+            this->pt = (T*) malloc(sizeNew * sizeof(T));
             this->size = sizeNew;
         }
         this->count = sizeNew;

--- a/plugins/protein/src/HydroBondFilter.cpp
+++ b/plugins/protein/src/HydroBondFilter.cpp
@@ -125,7 +125,7 @@ void HydroBondFilter::fillSecStructVector(MolecularDataCall& mdc) {
 
                 // is the current residue really an aminoacid?
                 if (mdc.Residues()[aaIdx]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                    acid = (MolecularDataCall::AminoAcid*)(mdc.Residues()[aaIdx]);
+                    acid = (MolecularDataCall::AminoAcid*) (mdc.Residues()[aaIdx]);
                 else
                     continue;
 

--- a/plugins/protein/src/MDDriverConnector.cpp
+++ b/plugins/protein/src/MDDriverConnector.cpp
@@ -512,9 +512,9 @@ bool MDDriverConnector::sendHeader() {
  */
 int MDDriverConnector::byteSwap(int input) {
     char output[4];
-    output[0] = ((char*)&input)[3];
-    output[1] = ((char*)&input)[2];
-    output[2] = ((char*)&input)[1];
-    output[3] = ((char*)&input)[0];
-    return *((int*)output);
+    output[0] = ((char*) &input)[3];
+    output[1] = ((char*) &input)[2];
+    output[2] = ((char*) &input)[1];
+    output[3] = ((char*) &input)[0];
+    return *((int*) output);
 }

--- a/plugins/protein/src/MoleculeLoader.cpp
+++ b/plugins/protein/src/MoleculeLoader.cpp
@@ -110,7 +110,7 @@ bool MoleculeLoader::getMDCData(core::Call& call) {
     mdc->SetFormerAtomIndices(s.former_atom_indices_.data());
 
     mdc->SetConnections(s.connectivity_.size(), &s.connectivity_.front().x);
-    mdc->SetResidues(s.residues_.size(), (const protein_calls::MolecularDataCall::Residue**)s.residues_.data());
+    mdc->SetResidues(s.residues_.size(), (const protein_calls::MolecularDataCall::Residue**) s.residues_.data());
     mdc->SetSolventResidueIndices(s.solvent_residue_index_.size(), s.solvent_residue_index_.data());
     mdc->SetResidueTypeNames(s.residue_type_names_.size(), s.residue_type_names_.data());
     mdc->SetMolecules(s.molecules_.size(), s.molecules_.data());

--- a/plugins/protein/src/PDBInterpolator.cpp
+++ b/plugins/protein/src/PDBInterpolator.cpp
@@ -49,11 +49,11 @@ bool PDBInterpolator::getData(core::Call& call) {
 
     float call_time = mdc->Calltime();
 
-    int call_time_one = (int)call_time;
+    int call_time_one = (int) call_time;
     int call_time_two = call_time_one + 1;
-    float x = call_time - (float)call_time_one;
+    float x = call_time - (float) call_time_one;
 
-    mdc->SetCalltime((float)call_time_one);
+    mdc->SetCalltime((float) call_time_one);
     mdc->SetFrameID(static_cast<int>(call_time_one));
 
     if (!(*mdc)(MolecularDataCall::CallForGetData))
@@ -64,7 +64,7 @@ bool PDBInterpolator::getData(core::Call& call) {
     float* pos0 = new float[mdc->AtomCount() * 3];
     memcpy(pos0, mdc->AtomPositions(), mdc->AtomCount() * 3 * sizeof(float));
 
-    mdc->SetCalltime((float)call_time_one);
+    mdc->SetCalltime((float) call_time_one);
     mdc->SetFrameID(static_cast<int>(call_time_one));
 
     if (!(*mdc)(MolecularDataCall::CallForGetData))

--- a/plugins/protein/src/PDBLoader.cpp
+++ b/plugins/protein/src/PDBLoader.cpp
@@ -95,7 +95,7 @@ int PDBLoader::Frame::decodebits(char* buff, int offset, int bitsize) {
     char tmpBuff[] = {buff[3], buff[2], buff[1], buff[0]};
 
     // interprete char-array as an integer
-    num = *(int*)tmpBuff;
+    num = *(int*) tmpBuff;
     // cut off right offset
     num = num >> (32 - (offset + bitsize));
 
@@ -174,7 +174,7 @@ unsigned int PDBLoader::Frame::sizeofints(unsigned int sizes[]) {
 
     num = 1;
     num_of_bytes--;
-    while (bytes[num_of_bytes] >= (unsigned int)num) {
+    while (bytes[num_of_bytes] >= (unsigned int) num) {
         num_of_bits++;
         num *= 2;
     }
@@ -189,7 +189,7 @@ int PDBLoader::Frame::sizeofint(int size) {
     unsigned int num = 1;
     int num_of_bits = 0;
 
-    while ((unsigned int)size >= num && num_of_bits < 32) {
+    while ((unsigned int) size >= num && num_of_bits < 32) {
         num_of_bits++;
         num <<= 1;
     }
@@ -233,33 +233,33 @@ bool PDBLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write date to outfile
     int date = 1995;
-    changeByteOrder((char*)&date);
-    outfile->write((char*)&date, 4);
+    changeByteOrder((char*) &date);
+    outfile->write((char*) &date, 4);
 
     // write number of atoms to outfile
     int atomCount = AtomCount();
-    changeByteOrder((char*)&atomCount);
-    outfile->write((char*)&atomCount, 4);
+    changeByteOrder((char*) &atomCount);
+    outfile->write((char*) &atomCount, 4);
 
     // write simulation step to outfile
     int step = frame;
-    changeByteOrder((char*)&step);
-    outfile->write((char*)&step, 4);
+    changeByteOrder((char*) &step);
+    outfile->write((char*) &step, 4);
 
     // write simulation time to outfile
-    float simtime = (float)frame;
-    changeByteOrder((char*)&simtime);
-    outfile->write((char*)&simtime, 4);
+    float simtime = (float) frame;
+    changeByteOrder((char*) &simtime);
+    outfile->write((char*) &simtime, 4);
 
     precision /= 10.0;
 
     // get the range of values
-    minInt[0] = (int)(minFloats[0] * precision + 1);
-    minInt[1] = (int)(minFloats[1] * precision + 1);
-    minInt[2] = (int)(minFloats[2] * precision + 1);
-    maxInt[0] = (int)(maxFloats[0] * precision + 1);
-    maxInt[1] = (int)(maxFloats[1] * precision + 1);
-    maxInt[2] = (int)(maxFloats[2] * precision + 1);
+    minInt[0] = (int) (minFloats[0] * precision + 1);
+    minInt[1] = (int) (minFloats[1] * precision + 1);
+    minInt[2] = (int) (minFloats[2] * precision + 1);
+    maxInt[0] = (int) (maxFloats[0] * precision + 1);
+    maxInt[1] = (int) (maxFloats[1] * precision + 1);
+    maxInt[2] = (int) (maxFloats[2] * precision + 1);
 
     sizes[0] = maxInt[0] - minInt[0] + 1;
     sizes[1] = maxInt[1] - minInt[1] + 1;
@@ -270,42 +270,42 @@ bool PDBLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write the bounding box to outfile
     float* box = new float[9];
-    box[0] = (float)sizes[0] / precision;
+    box[0] = (float) sizes[0] / precision;
     box[1] = 0.0;
     box[2] = 0.0;
     box[3] = 0.0;
-    box[4] = (float)sizes[1] / precision;
+    box[4] = (float) sizes[1] / precision;
     box[5] = 0.0;
     box[6] = 0.0;
     box[7] = 0.0;
-    box[8] = (float)sizes[2] / precision;
+    box[8] = (float) sizes[2] / precision;
 
     for (i = 0; i < 9; i++)
-        changeByteOrder((char*)&box[i]);
+        changeByteOrder((char*) &box[i]);
 
-    outfile->write((char*)box, 36);
+    outfile->write((char*) box, 36);
 
     // write number of atoms to outfile
-    outfile->write((char*)&atomCount, 4);
+    outfile->write((char*) &atomCount, 4);
 
     // write precision to outfile
     float prec = precision * 10.0f;
-    changeByteOrder((char*)&prec);
-    outfile->write((char*)&prec, 4);
+    changeByteOrder((char*) &prec);
+    outfile->write((char*) &prec, 4);
 
     // write maxint[] and minint[] to outfile
     int maxVal[] = {maxInt[0], maxInt[1], maxInt[2]};
     int minVal[] = {minInt[0], minInt[1], minInt[2]};
     for (i = 0; i < 3; i++) {
-        changeByteOrder((char*)&maxVal[i]);
-        changeByteOrder((char*)&minVal[i]);
+        changeByteOrder((char*) &maxVal[i]);
+        changeByteOrder((char*) &minVal[i]);
     }
-    outfile->write((char*)&minVal, 12);
-    outfile->write((char*)&maxVal, 12);
+    outfile->write((char*) &minVal, 12);
+    outfile->write((char*) &maxVal, 12);
 
     // write smallidx to outfile
     int smallidx = 0;
-    outfile->write((char*)&smallidx, 4);
+    outfile->write((char*) &smallidx, 4);
 
     unsigned int bitoffset = 0;
 
@@ -323,9 +323,9 @@ bool PDBLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
     // unsigned ints and encode
     for (i = 0; i < AtomCount(); i++) {
 
-        thiscoord[0] = (int)(atomPosition[i * 3 + 0] * precision) - minInt[0];
-        thiscoord[1] = (int)(atomPosition[i * 3 + 1] * precision) - minInt[1];
-        thiscoord[2] = (int)(atomPosition[i * 3 + 2] * precision) - minInt[2];
+        thiscoord[0] = (int) (atomPosition[i * 3 + 0] * precision) - minInt[0];
+        thiscoord[1] = (int) (atomPosition[i * 3 + 1] * precision) - minInt[1];
+        thiscoord[2] = (int) (atomPosition[i * 3 + 2] * precision) - minInt[2];
 
         encodeints(charPt, bitsize, sizes, thiscoord, bitoffset);
 
@@ -346,8 +346,8 @@ bool PDBLoader::Frame::writeFrame(std::ofstream* outfile, float precision, float
 
     // write the size to outfile
     unsigned int s = byteSize;
-    changeByteOrder((char*)&s);
-    outfile->write((char*)&s, 4);
+    changeByteOrder((char*) &s);
+    outfile->write((char*) &s, 4);
 
     // write buffer to file
     outfile->write(charbuff, byteSize + ((4 - byteSize % 4) % 4));
@@ -425,7 +425,7 @@ bool PDBLoader::Frame::encodeints(
 void PDBLoader::Frame::encodebits(char* outbuff, int bitsize, int bitoffset, unsigned int num) {
 
     num <<= (32 - (bitoffset + bitsize));
-    char* numpt = (char*)&num;
+    char* numpt = (char*) &num;
 
     // change byte order on little endian systems
     outbuff[0] = outbuff[0] | numpt[3];
@@ -481,34 +481,34 @@ void PDBLoader::Frame::readFrame(std::fstream* file) {
     if (atomCount <= 3) {
         float posX, posY, posZ;
         for (i = 0; i < atomCount; i++) {
-            file->read((char*)&posX, 4);
-            changeByteOrder((char*)&posX);
-            file->read((char*)&posY, 4);
-            changeByteOrder((char*)&posY);
-            file->read((char*)&posZ, 4);
-            changeByteOrder((char*)&posZ);
+            file->read((char*) &posX, 4);
+            changeByteOrder((char*) &posX);
+            file->read((char*) &posY, 4);
+            changeByteOrder((char*) &posY);
+            file->read((char*) &posZ, 4);
+            changeByteOrder((char*) &posZ);
             this->SetAtomPosition(i, posX, posY, posZ);
         }
         return;
     }
 
     // read the precision of the float coordinates
-    file->read((char*)&precision, 4);
-    changeByteOrder((char*)&precision);
+    file->read((char*) &precision, 4);
+    changeByteOrder((char*) &precision);
     precision /= 10.0f;
 
     // read the lower bound of 'big' integer-coordinates
-    file->read((char*)&minint, 12);
+    file->read((char*) &minint, 12);
 
-    changeByteOrder((char*)&minint[0]);
-    changeByteOrder((char*)&minint[1]);
-    changeByteOrder((char*)&minint[2]);
+    changeByteOrder((char*) &minint[0]);
+    changeByteOrder((char*) &minint[1]);
+    changeByteOrder((char*) &minint[2]);
 
     // read the upper bound of 'big' integer-coordinates
-    file->read((char*)&maxint, 12);
-    changeByteOrder((char*)&maxint[0]);
-    changeByteOrder((char*)&maxint[1]);
-    changeByteOrder((char*)&maxint[2]);
+    file->read((char*) &maxint, 12);
+    changeByteOrder((char*) &maxint[0]);
+    changeByteOrder((char*) &maxint[1]);
+    changeByteOrder((char*) &maxint[2]);
 
 
     sizeint[0] = maxint[0] - minint[0] + 1;
@@ -530,17 +530,17 @@ void PDBLoader::Frame::readFrame(std::fstream* file) {
 
     // read number of bits used to encode 'small' integers
     // note: changes dynamically within one frame
-    file->read((char*)&smallidx, 4);
+    file->read((char*) &smallidx, 4);
     if (*file) {
         //std::cout << "all characters read successfully.";
     } else {
         std::cout << "error: only " << file->gcount() << " could be read";
     }
-    changeByteOrder((char*)&smallidx);
+    changeByteOrder((char*) &smallidx);
 
     // calculate maxidx/minidx
     int minidx, maxidx;
-    if (LASTIDX < (unsigned int)(smallidx + 8)) {
+    if (LASTIDX < (unsigned int) (smallidx + 8)) {
         maxidx = LASTIDX;
     } else {
         maxidx = smallidx + 8;
@@ -563,15 +563,15 @@ void PDBLoader::Frame::readFrame(std::fstream* file) {
     larger = magicints[maxidx];
 
     // read the size of the compressed data-block
-    file->read((char*)&size, 4);
-    changeByteOrder((char*)&size);
+    file->read((char*) &size, 4);
+    changeByteOrder((char*) &size);
 
-    buffer = new int[(int)(atomCount * 3 * 1.2)];
+    buffer = new int[(int) (atomCount * 3 * 1.2)];
 
     // get the compressed data-block
-    file->read((char*)&buffer[0], size);
+    file->read((char*) &buffer[0], size);
 
-    buffPt = (char*)buffer;
+    buffPt = (char*) buffer;
     bit_offset = 0;
 
 
@@ -655,8 +655,8 @@ void PDBLoader::Frame::readFrame(std::fstream* file) {
                     prevcoord[2] = tempCoord;
 
                     // calculate float-value of the old coordinate
-                    this->SetAtomPosition(i, (float)prevcoord[0] / precision, (float)prevcoord[1] / precision,
-                        (float)prevcoord[2] / precision);
+                    this->SetAtomPosition(i, (float) prevcoord[0] / precision, (float) prevcoord[1] / precision,
+                        (float) prevcoord[2] / precision);
                     i++;
                 } else {
                     prevcoord[0] = thiscoord[0];
@@ -664,13 +664,13 @@ void PDBLoader::Frame::readFrame(std::fstream* file) {
                     prevcoord[2] = thiscoord[2];
                 }
 
-                this->SetAtomPosition(i, (float)thiscoord[0] / precision, (float)thiscoord[1] / precision,
-                    (float)thiscoord[2] / precision);
+                this->SetAtomPosition(i, (float) thiscoord[0] / precision, (float) thiscoord[1] / precision,
+                    (float) thiscoord[2] / precision);
                 i++;
             }
         } else {
-            this->SetAtomPosition(
-                i, (float)thiscoord[0] / precision, (float)thiscoord[1] / precision, (float)thiscoord[2] / precision);
+            this->SetAtomPosition(i, (float) thiscoord[0] / precision, (float) thiscoord[1] / precision,
+                (float) thiscoord[2] / precision);
             i++;
         }
 
@@ -936,18 +936,18 @@ bool PDBLoader::getData(core::Call& call) {
     }
 
     dc->SetConnections(
-        static_cast<unsigned int>(this->connectivity.Count() / 2), (unsigned int*)this->connectivity.PeekElements());
+        static_cast<unsigned int>(this->connectivity.Count() / 2), (unsigned int*) this->connectivity.PeekElements());
     dc->SetResidues(static_cast<unsigned int>(this->residue.Count()),
-        (const MolecularDataCall::Residue**)this->residue.PeekElements());
+        (const MolecularDataCall::Residue**) this->residue.PeekElements());
     // dc->SetAtomResidueIndices(this->atomResidueIdx.PeekElements());
     dc->SetSolventResidueIndices(
         static_cast<unsigned int>(this->solventResidueIdx.Count()), this->solventResidueIdx.PeekElements());
     dc->SetResidueTypeNames(static_cast<unsigned int>(this->residueTypeName.Count()),
-        (vislib::StringA*)this->residueTypeName.PeekElements());
-    dc->SetMolecules(
-        static_cast<unsigned int>(this->molecule.Count()), (MolecularDataCall::Molecule*)this->molecule.PeekElements());
+        (vislib::StringA*) this->residueTypeName.PeekElements());
+    dc->SetMolecules(static_cast<unsigned int>(this->molecule.Count()),
+        (MolecularDataCall::Molecule*) this->molecule.PeekElements());
     dc->SetChains(
-        static_cast<unsigned int>(this->chain.Count()), (MolecularDataCall::Chain*)this->chain.PeekElements());
+        static_cast<unsigned int>(this->chain.Count()), (MolecularDataCall::Chain*) this->chain.PeekElements());
 
     if ((!this->secStructAvailable || this->recomputeStridePerFrameSlot.Param<param::BoolParam>()->Value()) &&
         this->strideFlagSlot.Param<param::BoolParam>()->Value()) {
@@ -1026,11 +1026,11 @@ void PDBLoader::release() {
     // stop frame-loading thread before clearing data array
     resetFrameCache();
 
-    for (int i = 0; i < (int)this->data.Count(); i++)
+    for (int i = 0; i < (int) this->data.Count(); i++)
         delete data[i];
     this->data.Clear();
 
-    for (int i = 0; i < (int)this->residue.Count(); i++)
+    for (int i = 0; i < (int) this->residue.Count(); i++)
         delete residue[i];
     this->residue.Clear();
 
@@ -1094,7 +1094,7 @@ void PDBLoader::loadFile(const std::filesystem::path& filename) {
 
     this->bbox.Set(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
-    for (int i = 0; i < (int)this->data.Count(); i++)
+    for (int i = 0; i < (int) this->data.Count(); i++)
         delete data[i];
     this->data.Clear();
 
@@ -1335,7 +1335,7 @@ void PDBLoader::loadFile(const std::filesystem::path& filename) {
         MolecularDataCall::Chain::ChainType chainType = MolecularDataCall::Chain::ChainType::UNSPECIFIC;
         MolecularDataCall::Chain new_chain = MolecularDataCall::Chain(firstMolIdx, molCnt, name, chainType);
         this->chain.Add(new_chain);
-        this->molecule.Add(MolecularDataCall::Molecule(0, (unsigned int)this->residue.Count(), 0));
+        this->molecule.Add(MolecularDataCall::Molecule(0, (unsigned int) this->residue.Count(), 0));
     }
 
     // search for CA, C, O and N in amino acids
@@ -1343,7 +1343,7 @@ void PDBLoader::loadFile(const std::filesystem::path& filename) {
     for (resCnt = 0; resCnt < this->residue.Count(); ++resCnt) {
         // check if the current residue is an amino acid
         if (this->residue[resCnt]->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-            aminoacid = (MolecularDataCall::AminoAcid*)this->residue[resCnt];
+            aminoacid = (MolecularDataCall::AminoAcid*) this->residue[resCnt];
             idx = aminoacid->FirstAtomIndex();
             cnt = idx + aminoacid->AtomCount();
             // loop over all atom of the current amino acid
@@ -1439,9 +1439,9 @@ void PDBLoader::loadFile(const std::filesystem::path& filename) {
 
             xtcFile.seekg(4, std::ios_base::cur);
             // read number of atoms
-            xtcFile.read((char*)&nAtoms, 4);
+            xtcFile.read((char*) &nAtoms, 4);
             // change byte order
-            num = (char*)&nAtoms;
+            num = (char*) &nAtoms;
             tmpByte = num[0];
             num[0] = num[3];
             num[3] = tmpByte;
@@ -1621,7 +1621,7 @@ void PDBLoader::parseAtomEntry(vislib::StringA& atomEntry, unsigned int atom, un
         if (this->IsAminoAcid(resName)) {
             MolecularDataCall::AminoAcid* res =
                 new MolecularDataCall::AminoAcid(atom, 1, 0, 0, 0, 0, atomBBox, resTypeIdx, -1, newResSeq);
-            this->residue.Add((MolecularDataCall::Residue*)res);
+            this->residue.Add((MolecularDataCall::Residue*) res);
         } else {
             MolecularDataCall::Residue* res =
                 new MolecularDataCall::Residue(atom, 1, atomBBox, resTypeIdx, -1, newResSeq);
@@ -1653,7 +1653,7 @@ void PDBLoader::parseAtomEntry(vislib::StringA& atomEntry, unsigned int atom, un
         if (this->IsAminoAcid(resName)) {
             MolecularDataCall::AminoAcid* res =
                 new MolecularDataCall::AminoAcid(atom, 1, 0, 0, 0, 0, atomBBox, resTypeIdx, -1, newResSeq);
-            this->residue.Add((MolecularDataCall::Residue*)res);
+            this->residue.Add((MolecularDataCall::Residue*) res);
         } else {
             MolecularDataCall::Residue* res =
                 new MolecularDataCall::Residue(atom, 1, atomBBox, resTypeIdx, -1, newResSeq);
@@ -2113,20 +2113,20 @@ bool PDBLoader::readNumXTCFrames() {
 
     // get length of file:
     xtcFile.seekg(0, xtcFile.end);
-    int xtcFileLength = (int)xtcFile.tellg();
+    int xtcFileLength = (int) xtcFile.tellg();
     xtcFile.seekg(0, xtcFile.beg);
 
     // read until eof
     while (!xtcFile.eof() && xtcFile.tellg() < xtcFileLength) {
         // add the offset to the offset array
-        this->XTCFrameOffset.Add((unsigned int)xtcFile.tellg());
+        this->XTCFrameOffset.Add((unsigned int) xtcFile.tellg());
 
         // skip some header data
         xtcFile.seekg(56, std::ios_base::cur);
         // read precision
-        xtcFile.read((char*)&precision, 4);
+        xtcFile.read((char*) &precision, 4);
         // change byte-order
-        num = (char*)&precision;
+        num = (char*) &precision;
         tmpByte = num[0];
         num[0] = num[3];
         num[3] = tmpByte;
@@ -2136,19 +2136,19 @@ bool PDBLoader::readNumXTCFrames() {
         precision /= 10.0f;
 
         // get the lower bound
-        xtcFile.read((char*)&minint, 12);
+        xtcFile.read((char*) &minint, 12);
         // get the upper bound
-        xtcFile.read((char*)&maxint, 12);
+        xtcFile.read((char*) &maxint, 12);
         // change byte-order
         for (i = 0; i < 3; i++) {
-            num = (char*)&minint[i];
+            num = (char*) &minint[i];
             tmpByte = num[0];
             num[0] = num[3];
             num[3] = tmpByte;
             tmpByte = num[1];
             num[1] = num[2];
             num[2] = tmpByte;
-            num = (char*)&maxint[i];
+            num = (char*) &maxint[i];
             tmpByte = num[0];
             num[0] = num[3];
             num[3] = tmpByte;
@@ -2161,19 +2161,19 @@ bool PDBLoader::readNumXTCFrames() {
         this->bbox.Union(tmpBBox);
         // get the current frames bounding box including the atom radius
         // note: atom radius is divided by 10
-        tmpBBox = vislib::math::Cuboid<float>((float)minint[0] / precision - 0.3f, (float)minint[1] / precision - 0.3f,
-            (float)minint[2] / precision - 0.3f,
+        tmpBBox = vislib::math::Cuboid<float>((float) minint[0] / precision - 0.3f,
+            (float) minint[1] / precision - 0.3f, (float) minint[2] / precision - 0.3f,
 
-            (float)maxint[0] / precision + 0.3f, (float)maxint[1] / precision + 0.3f,
-            (float)maxint[2] / precision + 0.3f);
+            (float) maxint[0] / precision + 0.3f, (float) maxint[1] / precision + 0.3f,
+            (float) maxint[2] / precision + 0.3f);
 
         // skip some header data
         xtcFile.seekg(4, std::ios_base::cur);
 
         // read size of the compressed block of data
-        xtcFile.read((char*)&size, 4);
+        xtcFile.read((char*) &size, 4);
         // change byte-order
-        num = (char*)&size;
+        num = (char*) &size;
         tmpByte = num[0];
         num[0] = num[3];
         num[3] = tmpByte;

--- a/plugins/protein/src/ProteinAligner.cpp
+++ b/plugins/protein/src/ProteinAligner.cpp
@@ -168,7 +168,7 @@ void ProteinAligner::getCAlphaPosList(const MolecularDataCall& input, std::vecto
     for (unsigned int res = 0; res < resCnt; ++res) {
         MolecularDataCall::AminoAcid* amino;
         if (input.Residues()[res]->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-            amino = (MolecularDataCall::AminoAcid*)(input.Residues()[res]);
+            amino = (MolecularDataCall::AminoAcid*) (input.Residues()[res]);
         } else {
             continue;
         }

--- a/plugins/protein/src/ProteinExploder.cpp
+++ b/plugins/protein/src/ProteinExploder.cpp
@@ -220,7 +220,7 @@ void ProteinExploder::computeMidPoint(MolecularDataCall& call) {
         midpoint.SetY(midpoint.GetY() + call.AtomPositions()[i * 3 + 1]);
         midpoint.SetZ(midpoint.GetZ() + call.AtomPositions()[i * 3 + 2]);
     }
-    midpoint /= (float)call.AtomCount();
+    midpoint /= (float) call.AtomCount();
 
     if (useMassCenterParam.Param<param::BoolParam>()->Value()) {
         float weightSum = 0.0f;

--- a/plugins/protein/src/ReducedSurface.cpp
+++ b/plugins/protein/src/ReducedSurface.cpp
@@ -150,17 +150,17 @@ void ReducedSurface::ComputeReducedSurface() {
     this->bBox = this->molecule->AccessBoundingBoxes().ObjectSpaceBBox();
     // set voxel lenght --> diameter of the probe + maximum atom diameter
     this->voxelLength = 2 * this->probeRadius + 2 * 3.0f;
-    unsigned int tmpSize = (unsigned int)ceilf(this->bBox.Width() / this->voxelLength);
+    unsigned int tmpSize = (unsigned int) ceilf(this->bBox.Width() / this->voxelLength);
     this->voxelMap.clear();
     this->voxelMapProbes.clear();
     this->voxelMap.resize(tmpSize);
     this->voxelMapProbes.resize(tmpSize);
     for (cnt1 = 0; cnt1 < this->voxelMap.size(); ++cnt1) {
-        this->voxelMap[cnt1].resize((unsigned int)ceilf(this->bBox.Height() / this->voxelLength));
-        this->voxelMapProbes[cnt1].resize((unsigned int)ceilf(this->bBox.Height() / this->voxelLength));
+        this->voxelMap[cnt1].resize((unsigned int) ceilf(this->bBox.Height() / this->voxelLength));
+        this->voxelMapProbes[cnt1].resize((unsigned int) ceilf(this->bBox.Height() / this->voxelLength));
         for (cnt2 = 0; cnt2 < this->voxelMap[cnt1].size(); ++cnt2) {
-            this->voxelMap[cnt1][cnt2].resize((unsigned int)ceilf(this->bBox.Depth() / this->voxelLength));
-            this->voxelMapProbes[cnt1][cnt2].resize((unsigned int)ceilf(this->bBox.Depth() / this->voxelLength));
+            this->voxelMap[cnt1][cnt2].resize((unsigned int) ceilf(this->bBox.Depth() / this->voxelLength));
+            this->voxelMapProbes[cnt1][cnt2].resize((unsigned int) ceilf(this->bBox.Depth() / this->voxelLength));
         }
     }
     std::cout << "time for resizing voxel maps:  " << (double(clock() - t) / double(CLOCKS_PER_SEC)) << std::endl;
@@ -180,33 +180,33 @@ void ReducedSurface::ComputeReducedSurface() {
         this->rsVertex.push_back(new RSVertex(tmpVec1, radius, cnt1));
 
         // add RS-vertex to voxel map cell
-        this->voxelMap[(unsigned int)std::min((unsigned int)this->voxelMap.size() - 1,
-            (unsigned int)std::max(0, (int)floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))]
-                      [(unsigned int)std::min((unsigned int)this->voxelMap[0].size() - 1,
-                          (unsigned int)std::max(0, (int)floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))]
-                      [(unsigned int)std::min((unsigned int)this->voxelMap[0][0].size() - 1,
-                           (unsigned int)std::max(0, (int)floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
+        this->voxelMap[(unsigned int) std::min((unsigned int) this->voxelMap.size() - 1,
+            (unsigned int) std::max(0, (int) floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))]
+                      [(unsigned int) std::min((unsigned int) this->voxelMap[0].size() - 1,
+                          (unsigned int) std::max(0, (int) floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))]
+                      [(unsigned int) std::min((unsigned int) this->voxelMap[0][0].size() - 1,
+                           (unsigned int) std::max(0, (int) floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
                           .push_back(this->rsVertex.back());
         // if this is the first atom OR the x-value is larger than the current smallest x
         // --> store cnt as xIdx
         if (this->rsVertex.size() > 0 ||
             (this->rsVertex[xIdx]->GetPosition().GetX() - this->rsVertex[xIdx]->GetRadius()) >
                 (this->rsVertex.back()->GetPosition().GetX() - this->rsVertex.back()->GetRadius())) {
-            xIdx = (unsigned int)this->rsVertex.size() - 1;
+            xIdx = (unsigned int) this->rsVertex.size() - 1;
         }
         // if this is the first atom OR the y-value is larger than the current smallest y
         // --> store cnt as yIdx
         if (this->rsVertex.size() > 0 ||
             (this->rsVertex[yIdx]->GetPosition().GetY() - this->rsVertex[yIdx]->GetRadius()) >
                 (this->rsVertex.back()->GetPosition().GetY() - this->rsVertex.back()->GetRadius())) {
-            yIdx = (unsigned int)this->rsVertex.size() - 1;
+            yIdx = (unsigned int) this->rsVertex.size() - 1;
         }
         // if this is the first atom OR the z-value is larger than the current smallest z
         // --> store cnt as zIdx
         if (this->rsVertex.size() > 0 ||
             (this->rsVertex[zIdx]->GetPosition().GetZ() - this->rsVertex[zIdx]->GetRadius()) >
                 (this->rsVertex.back()->GetPosition().GetZ() - this->rsVertex.back()->GetRadius())) {
-            zIdx = (unsigned int)this->rsVertex.size() - 1;
+            zIdx = (unsigned int) this->rsVertex.size() - 1;
         }
     }
 
@@ -317,7 +317,7 @@ void ReducedSurface::ComputeRSFace(unsigned int edgeIdx) {
     unsigned int cnt;
     int result = -1;
     // the angle between two faces
-    float angle = (float)vislib::math::PI_DOUBLE * 5.0f;
+    float angle = (float) vislib::math::PI_DOUBLE * 5.0f;
     float alpha;
     // names of the variables according to: Connolly "Analytical Molecular Surface Calculation", 1983
     vislib::math::Vector<float, 3> ai = edge->GetVertex1()->GetPosition();
@@ -636,12 +636,13 @@ void ReducedSurface::ComputeRSFace(unsigned int edgeIdx) {
             }
             // add probe position to voxel map cell
             face->SetProbeIndex(
-                std::min((unsigned int)this->voxelMapProbes.size() - 1,
-                    (unsigned int)std::max(0, (int)floorf((probeCenterNewFace.GetX() - bBox.Left()) / voxelLength))),
-                std::min((unsigned int)this->voxelMapProbes[0].size() - 1,
-                    (unsigned int)std::max(0, (int)floorf((probeCenterNewFace.GetY() - bBox.Bottom()) / voxelLength))),
-                std::min((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                    (unsigned int)std::max(0, (int)floorf((probeCenterNewFace.GetZ() - bBox.Back()) / voxelLength))));
+                std::min((unsigned int) this->voxelMapProbes.size() - 1,
+                    (unsigned int) std::max(0, (int) floorf((probeCenterNewFace.GetX() - bBox.Left()) / voxelLength))),
+                std::min((unsigned int) this->voxelMapProbes[0].size() - 1,
+                    (unsigned int) std::max(
+                        0, (int) floorf((probeCenterNewFace.GetY() - bBox.Bottom()) / voxelLength))),
+                std::min((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                    (unsigned int) std::max(0, (int) floorf((probeCenterNewFace.GetZ() - bBox.Back()) / voxelLength))));
             this->voxelMapProbes[face->GetProbeIndex().GetX()][face->GetProbeIndex().GetY()]
                                 [face->GetProbeIndex().GetZ()]
                                     .push_back(face);
@@ -717,7 +718,7 @@ float ReducedSurface::ComputeAngleBetweenProbes(vislib::math::Vector<float, 3> t
     angle = acos(cosinus);
     // correct angle if the new probe lies in the back of the plane
     if ((dist1 < 0.0f && dist2 > 0.0f) || (dist1 > 0.0f && dist2 < 0.0f))
-        angle = 2.0f * (float)vislib::math::PI_DOUBLE - angle;
+        angle = 2.0f * (float) vislib::math::PI_DOUBLE - angle;
     return angle;
 }
 
@@ -797,12 +798,12 @@ bool ReducedSurface::ComputeFirstFixedProbePos(RSVertex* vI, RSVertex* vJ, RSVer
             this->rsEdge[this->rsEdge.size() - 2], this->rsEdge[this->rsEdge.size() - 1], uijk, pijk1));
         // add probe position to voxel map cell
         this->rsFace.back()->SetProbeIndex(
-            std::min((unsigned int)this->voxelMapProbes.size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk1.GetX() - bBox.Left()) / voxelLength))),
-            std::min((unsigned int)this->voxelMapProbes[0].size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk1.GetY() - bBox.Bottom()) / voxelLength))),
-            std::min((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk1.GetZ() - bBox.Back()) / voxelLength))));
+            std::min((unsigned int) this->voxelMapProbes.size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk1.GetX() - bBox.Left()) / voxelLength))),
+            std::min((unsigned int) this->voxelMapProbes[0].size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk1.GetY() - bBox.Bottom()) / voxelLength))),
+            std::min((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk1.GetZ() - bBox.Back()) / voxelLength))));
         this->voxelMapProbes[this->rsFace.back()->GetProbeIndex().GetX()][this->rsFace.back()->GetProbeIndex().GetY()]
                             [this->rsFace.back()->GetProbeIndex().GetZ()]
                                 .push_back(this->rsFace.back());
@@ -831,12 +832,12 @@ bool ReducedSurface::ComputeFirstFixedProbePos(RSVertex* vI, RSVertex* vJ, RSVer
             this->rsEdge[this->rsEdge.size() - 2], this->rsEdge[this->rsEdge.size() - 1], uijk * (-1.0f), pijk2));
         // add probe position to voxel map cell
         this->rsFace.back()->SetProbeIndex(
-            std::min((unsigned int)this->voxelMapProbes.size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk2.GetX() - bBox.Left()) / voxelLength))),
-            std::min((unsigned int)this->voxelMapProbes[0].size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk2.GetY() - bBox.Bottom()) / voxelLength))),
-            std::min((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                (unsigned int)std::max(0, (int)floorf((pijk2.GetZ() - bBox.Back()) / voxelLength))));
+            std::min((unsigned int) this->voxelMapProbes.size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk2.GetX() - bBox.Left()) / voxelLength))),
+            std::min((unsigned int) this->voxelMapProbes[0].size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk2.GetY() - bBox.Bottom()) / voxelLength))),
+            std::min((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                (unsigned int) std::max(0, (int) floorf((pijk2.GetZ() - bBox.Back()) / voxelLength))));
         this->voxelMapProbes[this->rsFace.back()->GetProbeIndex().GetX()][this->rsFace.back()->GetProbeIndex().GetY()]
                             [this->rsFace.back()->GetProbeIndex().GetZ()]
                                 .push_back(this->rsFace.back());
@@ -861,17 +862,17 @@ void ReducedSurface::ComputeVicinity(vislib::math::Vector<float, 3> m, float rad
     // maxXId = (unsigned int)floorf( this->bBox.Width() / this->voxelLength);
     // maxYId = (unsigned int)floorf( this->bBox.Height() / this->voxelLength);
     // maxZId = (unsigned int)floorf( this->bBox.Depth() / this->voxelLength);
-    maxXId = (unsigned int)this->voxelMap.size() - 1;
-    maxYId = (unsigned int)this->voxelMap[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMap[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMap.size() - 1;
+    maxYId = (unsigned int) this->voxelMap[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMap[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
-    xId = (unsigned int)std::max(0, (int)floorf((m.GetX() - bBox.Left()) / voxelLength));
-    xId = (unsigned int)std::min(maxXId, xId);
-    yId = (unsigned int)std::max(0, (int)floorf((m.GetY() - bBox.Bottom()) / voxelLength));
-    yId = (unsigned int)std::min(maxYId, yId);
-    zId = (unsigned int)std::max(0, (int)floorf((m.GetZ() - bBox.Back()) / voxelLength));
-    zId = (unsigned int)std::min(maxZId, zId);
+    xId = (unsigned int) std::max(0, (int) floorf((m.GetX() - bBox.Left()) / voxelLength));
+    xId = (unsigned int) std::min(maxXId, xId);
+    yId = (unsigned int) std::max(0, (int) floorf((m.GetY() - bBox.Bottom()) / voxelLength));
+    yId = (unsigned int) std::min(maxYId, yId);
+    zId = (unsigned int) std::max(0, (int) floorf((m.GetZ() - bBox.Back()) / voxelLength));
+    zId = (unsigned int) std::min(maxZId, zId);
 
     float distance;
     // float threshold;
@@ -931,17 +932,17 @@ void ReducedSurface::ComputeVicinity(vislib::math::Vector<float, 3> m, float rad
 void ReducedSurface::ComputeVicinityEdge(RSEdge* edge) {
     unsigned int cnt, xId, yId, zId, maxXId, maxYId, maxZId;
 
-    maxXId = (unsigned int)this->voxelMap.size() - 1;
-    maxYId = (unsigned int)this->voxelMap[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMap[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMap.size() - 1;
+    maxYId = (unsigned int) this->voxelMap[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMap[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
     xId = std::min(
-        maxXId, (unsigned int)std::max(0, (int)floorf((edge->GetTorusCenter().GetX() - bBox.Left()) / voxelLength)));
-    yId = std::min(
-        maxYId, (unsigned int)std::max(0, (int)floorf((edge->GetTorusCenter().GetY() - bBox.Bottom()) / voxelLength)));
+        maxXId, (unsigned int) std::max(0, (int) floorf((edge->GetTorusCenter().GetX() - bBox.Left()) / voxelLength)));
+    yId = std::min(maxYId,
+        (unsigned int) std::max(0, (int) floorf((edge->GetTorusCenter().GetY() - bBox.Bottom()) / voxelLength)));
     zId = std::min(
-        maxZId, (unsigned int)std::max(0, (int)floorf((edge->GetTorusCenter().GetZ() - bBox.Back()) / voxelLength)));
+        maxZId, (unsigned int) std::max(0, (int) floorf((edge->GetTorusCenter().GetZ() - bBox.Back()) / voxelLength)));
 
     float distance, threshold;
     // clear old vicinity indices
@@ -984,17 +985,17 @@ void ReducedSurface::ComputeVicinityVertex(RSVertex* vertex) {
     // maxXId = (unsigned int)floorf( this->bBox.Width() / this->voxelLength);
     // maxYId = (unsigned int)floorf( this->bBox.Height() / this->voxelLength);
     // maxZId = (unsigned int)floorf( this->bBox.Depth() / this->voxelLength);
-    maxXId = (unsigned int)this->voxelMap.size() - 1;
-    maxYId = (unsigned int)this->voxelMap[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMap[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMap.size() - 1;
+    maxYId = (unsigned int) this->voxelMap[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMap[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
-    xId = (unsigned int)std::max(0, (int)floorf((vertex->GetPosition().GetX() - bBox.Left()) / voxelLength));
-    xId = (unsigned int)std::min(maxXId, xId);
-    yId = (unsigned int)std::max(0, (int)floorf((vertex->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
-    yId = (unsigned int)std::min(maxYId, yId);
-    zId = (unsigned int)std::max(0, (int)floorf((vertex->GetPosition().GetZ() - bBox.Back()) / voxelLength));
-    zId = (unsigned int)std::min(maxZId, zId);
+    xId = (unsigned int) std::max(0, (int) floorf((vertex->GetPosition().GetX() - bBox.Left()) / voxelLength));
+    xId = (unsigned int) std::min(maxXId, xId);
+    yId = (unsigned int) std::max(0, (int) floorf((vertex->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
+    yId = (unsigned int) std::min(maxYId, yId);
+    zId = (unsigned int) std::max(0, (int) floorf((vertex->GetPosition().GetZ() - bBox.Back()) / voxelLength));
+    zId = (unsigned int) std::min(maxZId, zId);
 
     float distance, threshold;
     // clear old vicinity indices
@@ -1033,9 +1034,9 @@ std::vector<ReducedSurface::RSFace*> ReducedSurface::GetProbesCutEdge(RSEdge* ed
     // maxXId = (unsigned int)floorf( this->bBox.Width() / this->voxelLength);
     // maxYId = (unsigned int)floorf( this->bBox.Height() / this->voxelLength);
     // maxZId = (unsigned int)floorf( this->bBox.Depth() / this->voxelLength);
-    maxXId = (unsigned int)this->voxelMapProbes.size() - 1;
-    maxYId = (unsigned int)this->voxelMapProbes[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMapProbes[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMapProbes.size() - 1;
+    maxYId = (unsigned int) this->voxelMapProbes[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMapProbes[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
     vislib::math::Vector<float, 3> v1, v2, center, probe, dir21;
@@ -1049,9 +1050,9 @@ std::vector<ReducedSurface::RSFace*> ReducedSurface::GetProbesCutEdge(RSEdge* ed
     // normalize dir21
     dir21.Normalise();
     // compute voxel indices for edge center
-    xId = std::min((unsigned int)std::max(0, (int)floorf((center.GetX() - bBox.Left()) / voxelLength)), maxXId);
-    yId = std::min((unsigned int)std::max(0, (int)floorf((center.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
-    zId = std::min((unsigned int)std::max(0, (int)floorf((center.GetZ() - bBox.Back()) / voxelLength)), maxZId);
+    xId = std::min((unsigned int) std::max(0, (int) floorf((center.GetX() - bBox.Left()) / voxelLength)), maxXId);
+    yId = std::min((unsigned int) std::max(0, (int) floorf((center.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
+    zId = std::min((unsigned int) std::max(0, (int) floorf((center.GetZ() - bBox.Back()) / voxelLength)), maxZId);
 
     float dist1, dist2, edgeLen, lenH;
     edgeLen = (v1 - v2).Length();
@@ -1093,9 +1094,9 @@ void ReducedSurface::WriteProbesCutEdge(RSEdge* edge) {
     // maxXId = (unsigned int)floorf( this->bBox.Width() / this->voxelLength);
     // maxYId = (unsigned int)floorf( this->bBox.Height() / this->voxelLength);
     // maxZId = (unsigned int)floorf( this->bBox.Depth() / this->voxelLength);
-    maxXId = (unsigned int)this->voxelMapProbes.size() - 1;
-    maxYId = (unsigned int)this->voxelMapProbes[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMapProbes[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMapProbes.size() - 1;
+    maxYId = (unsigned int) this->voxelMapProbes[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMapProbes[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
     vislib::math::Vector<float, 3> v1, v2, center, probe, dir21;
@@ -1109,9 +1110,9 @@ void ReducedSurface::WriteProbesCutEdge(RSEdge* edge) {
     // normalize dir21
     dir21.Normalise();
     // compute voxel indices for edge center
-    xId = std::min((unsigned int)std::max(0, (int)floorf((center.GetX() - bBox.Left()) / voxelLength)), maxXId);
-    yId = std::min((unsigned int)std::max(0, (int)floorf((center.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
-    zId = std::min((unsigned int)std::max(0, (int)floorf((center.GetZ() - bBox.Back()) / voxelLength)), maxZId);
+    xId = std::min((unsigned int) std::max(0, (int) floorf((center.GetX() - bBox.Left()) / voxelLength)), maxXId);
+    yId = std::min((unsigned int) std::max(0, (int) floorf((center.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
+    zId = std::min((unsigned int) std::max(0, (int) floorf((center.GetZ() - bBox.Back()) / voxelLength)), maxZId);
 
     float dist1, dist2, edgeLen, lenH;
     edgeLen = (v1 - v2).Length();
@@ -1151,18 +1152,18 @@ void ReducedSurface::ComputeProbeCutVertex(RSVertex* vertex) {
     // maxXId = (unsigned int)floorf( this->bBox.Width() / this->voxelLength);
     // maxYId = (unsigned int)floorf( this->bBox.Height() / this->voxelLength);
     // maxZId = (unsigned int)floorf( this->bBox.Depth() / this->voxelLength);
-    maxXId = (unsigned int)this->voxelMap.size() - 1;
-    maxYId = (unsigned int)this->voxelMap[0].size() - 1;
-    maxZId = (unsigned int)this->voxelMap[0][0].size() - 1;
+    maxXId = (unsigned int) this->voxelMap.size() - 1;
+    maxYId = (unsigned int) this->voxelMap[0].size() - 1;
+    maxZId = (unsigned int) this->voxelMap[0][0].size() - 1;
     int cntX, cntY, cntZ;
 
     vislib::math::Vector<float, 3> v1, probe;
     // first vertex of the edge
     v1 = vertex->GetPosition();
     // compute voxel indices for edge center
-    xId = std::min((unsigned int)std::max(0, (int)floorf((v1.GetX() - bBox.Left()) / voxelLength)), maxXId);
-    yId = std::min((unsigned int)std::max(0, (int)floorf((v1.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
-    zId = std::min((unsigned int)std::max(0, (int)floorf((v1.GetZ() - bBox.Back()) / voxelLength)), maxZId);
+    xId = std::min((unsigned int) std::max(0, (int) floorf((v1.GetX() - bBox.Left()) / voxelLength)), maxXId);
+    yId = std::min((unsigned int) std::max(0, (int) floorf((v1.GetY() - bBox.Bottom()) / voxelLength)), maxYId);
+    zId = std::min((unsigned int) std::max(0, (int) floorf((v1.GetZ() - bBox.Back()) / voxelLength)), maxZId);
 
     float dist;
     // clear old face list
@@ -1303,27 +1304,27 @@ bool ReducedSurface::UpdateData(const float lowerThreshold, const float upperThr
             // the lower threshold is exceeded
             lowerThresholdExceeded = true;
             // compute old voxel map index
-            oldVoxelMapIdxX = (unsigned int)std::max(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetX() - bBox.Left()) / voxelLength));
-            oldVoxelMapIdxX = std::min(oldVoxelMapIdxX, (unsigned int)this->voxelMap.size() - 1);
-            oldVoxelMapIdxY = (unsigned int)std::max(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
-            oldVoxelMapIdxY = std::min(oldVoxelMapIdxY, (unsigned int)this->voxelMap[oldVoxelMapIdxX].size() - 1);
-            oldVoxelMapIdxZ = (unsigned int)std::max(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetZ() - bBox.Back()) / voxelLength));
+            oldVoxelMapIdxX = (unsigned int) std::max(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetX() - bBox.Left()) / voxelLength));
+            oldVoxelMapIdxX = std::min(oldVoxelMapIdxX, (unsigned int) this->voxelMap.size() - 1);
+            oldVoxelMapIdxY = (unsigned int) std::max(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
+            oldVoxelMapIdxY = std::min(oldVoxelMapIdxY, (unsigned int) this->voxelMap[oldVoxelMapIdxX].size() - 1);
+            oldVoxelMapIdxZ = (unsigned int) std::max(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetZ() - bBox.Back()) / voxelLength));
             oldVoxelMapIdxZ =
-                std::min(oldVoxelMapIdxZ, (unsigned int)this->voxelMap[oldVoxelMapIdxX][oldVoxelMapIdxY].size() - 1);
+                std::min(oldVoxelMapIdxZ, (unsigned int) this->voxelMap[oldVoxelMapIdxX][oldVoxelMapIdxY].size() - 1);
             // compute new voxel map index --> make sure the index is within bounds
             newVoxelMapIdxX =
-                (unsigned int)std::max(0, (int)floorf((tmpVec1.GetX() - bBox.Left()) / this->voxelLength));
-            newVoxelMapIdxX = std::min(newVoxelMapIdxX, (unsigned int)this->voxelMap.size() - 1);
+                (unsigned int) std::max(0, (int) floorf((tmpVec1.GetX() - bBox.Left()) / this->voxelLength));
+            newVoxelMapIdxX = std::min(newVoxelMapIdxX, (unsigned int) this->voxelMap.size() - 1);
             newVoxelMapIdxY =
-                (unsigned int)std::max(0, (int)floorf((tmpVec1.GetY() - bBox.Bottom()) / this->voxelLength));
-            newVoxelMapIdxY = std::min(newVoxelMapIdxY, (unsigned int)this->voxelMap[newVoxelMapIdxX].size() - 1);
+                (unsigned int) std::max(0, (int) floorf((tmpVec1.GetY() - bBox.Bottom()) / this->voxelLength));
+            newVoxelMapIdxY = std::min(newVoxelMapIdxY, (unsigned int) this->voxelMap[newVoxelMapIdxX].size() - 1);
             newVoxelMapIdxZ =
-                (unsigned int)std::max(0, (int)floorf((tmpVec1.GetZ() - bBox.Back()) / this->voxelLength));
+                (unsigned int) std::max(0, (int) floorf((tmpVec1.GetZ() - bBox.Back()) / this->voxelLength));
             newVoxelMapIdxZ =
-                std::min(newVoxelMapIdxZ, (unsigned int)this->voxelMap[newVoxelMapIdxX][newVoxelMapIdxY].size() - 1);
+                std::min(newVoxelMapIdxZ, (unsigned int) this->voxelMap[newVoxelMapIdxX][newVoxelMapIdxY].size() - 1);
             // if the new atom position lies in another voxel --> remove old and add new position
             if ((oldVoxelMapIdxX != newVoxelMapIdxX) || (oldVoxelMapIdxY != newVoxelMapIdxY) ||
                 (oldVoxelMapIdxZ != newVoxelMapIdxZ)) {

--- a/plugins/protein/src/ReducedSurfaceSimplified.cpp
+++ b/plugins/protein/src/ReducedSurfaceSimplified.cpp
@@ -120,17 +120,17 @@ void ReducedSurfaceSimplified::ComputeReducedSurfaceSimplified() {
     this->bBox = this->protein->AccessBoundingBoxes().ObjectSpaceBBox();
     // set voxel lenght --> diameter of the probe + maximum atom diameter
     this->voxelLength = 2 * this->probeRadius + 2 * maxRad;
-    unsigned int tmpSize = (unsigned int)ceilf(this->bBox.Width() / this->voxelLength);
+    unsigned int tmpSize = (unsigned int) ceilf(this->bBox.Width() / this->voxelLength);
     this->voxelMap.clear();
     this->voxelMapProbes.clear();
     this->voxelMap.resize(tmpSize);
     this->voxelMapProbes.resize(tmpSize);
     for (cnt1 = 0; cnt1 < this->voxelMap.size(); ++cnt1) {
-        this->voxelMap[cnt1].resize((unsigned int)ceilf(this->bBox.Height() / this->voxelLength));
-        this->voxelMapProbes[cnt1].resize((unsigned int)ceilf(this->bBox.Height() / this->voxelLength));
+        this->voxelMap[cnt1].resize((unsigned int) ceilf(this->bBox.Height() / this->voxelLength));
+        this->voxelMapProbes[cnt1].resize((unsigned int) ceilf(this->bBox.Height() / this->voxelLength));
         for (cnt2 = 0; cnt2 < this->voxelMap[cnt1].size(); ++cnt2) {
-            this->voxelMap[cnt1][cnt2].resize((unsigned int)ceilf(this->bBox.Depth() / this->voxelLength));
-            this->voxelMapProbes[cnt1][cnt2].resize((unsigned int)ceilf(this->bBox.Depth() / this->voxelLength));
+            this->voxelMap[cnt1][cnt2].resize((unsigned int) ceilf(this->bBox.Depth() / this->voxelLength));
+            this->voxelMapProbes[cnt1][cnt2].resize((unsigned int) ceilf(this->bBox.Depth() / this->voxelLength));
         }
     }
     //std::cout << "time for resizing voxel map (" << voxelMap.size() << "," << voxelMap[0].size() << "," << voxelMap[0][0].size() << "):  " << ( double( clock() - t) / double( CLOCKS_PER_SEC) ) << std::endl;
@@ -151,15 +151,15 @@ void ReducedSurfaceSimplified::ComputeReducedSurfaceSimplified() {
                 this->rsVertex.push_back(new RSVertex(tmpVec1, radius, index));
                 // add RS-vertex to voxel map cell
                 this
-                    ->voxelMap[(unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap.size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))][(
-                        unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap[0].size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))][(
-                        unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap[0][0].size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
+                    ->voxelMap[(unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap.size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))][(
+                        unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap[0].size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))][(
+                        unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap[0][0].size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
                     .push_back(this->rsVertex.back());
                 // if this is the first atom OR the x-value is larger than the current smallest x
                 // --> store cnt as xIdx
@@ -196,15 +196,15 @@ void ReducedSurfaceSimplified::ComputeReducedSurfaceSimplified() {
                 this->rsVertex.push_back(new RSVertex(tmpVec1, radius, index));
                 // add RS-vertex to voxel map cell
                 this
-                    ->voxelMap[(unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap.size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))][(
-                        unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap[0].size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))][(
-                        unsigned int)vislib::math::Min<unsigned int>((unsigned int)this->voxelMap[0][0].size() - 1,
-                        (unsigned int)vislib::math::Max<unsigned int>(
-                            0, (int)floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
+                    ->voxelMap[(unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap.size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetX() - bBox.Left()) / voxelLength)))][(
+                        unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap[0].size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetY() - bBox.Bottom()) / voxelLength)))][(
+                        unsigned int) vislib::math::Min<unsigned int>((unsigned int) this->voxelMap[0][0].size() - 1,
+                        (unsigned int) vislib::math::Max<unsigned int>(
+                            0, (int) floorf((tmpVec1.GetZ() - bBox.Back()) / voxelLength)))]
                     .push_back(this->rsVertex.back());
                 // if this is the first atom OR the x-value is larger than the current smallest x
                 // --> store cnt as xIdx
@@ -402,7 +402,7 @@ void ReducedSurfaceSimplified::ComputeRSFace(unsigned int edgeIdx) {
     unsigned int cnt;
     int result = -1;
     // the angle between two faces
-    float angle = (float)vislib::math::PI_DOUBLE * 5.0f;
+    float angle = (float) vislib::math::PI_DOUBLE * 5.0f;
     float alpha;
     // names of the variables according to: Connolly "Analytical Molecular Surface Calculation", 1983
     vislib::math::Vector<float, 3> ai = edge->GetVertex1()->GetPosition();
@@ -718,15 +718,15 @@ void ReducedSurfaceSimplified::ComputeRSFace(unsigned int edgeIdx) {
                 face->SetDualFace(dualFace);
             }
             // add probe position to voxel map cell
-            face->SetProbeIndex(vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes.size() - 1,
-                                    (unsigned int)vislib::math::Max<unsigned int>(
-                                        0, (int)floorf((probeCenterNewFace.GetX() - bBox.Left()) / voxelLength))),
-                vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0].size() - 1,
-                    (unsigned int)vislib::math::Max<unsigned int>(
-                        0, (int)floorf((probeCenterNewFace.GetY() - bBox.Bottom()) / voxelLength))),
-                vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                    (unsigned int)vislib::math::Max<unsigned int>(
-                        0, (int)floorf((probeCenterNewFace.GetZ() - bBox.Back()) / voxelLength))));
+            face->SetProbeIndex(vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes.size() - 1,
+                                    (unsigned int) vislib::math::Max<unsigned int>(
+                                        0, (int) floorf((probeCenterNewFace.GetX() - bBox.Left()) / voxelLength))),
+                vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0].size() - 1,
+                    (unsigned int) vislib::math::Max<unsigned int>(
+                        0, (int) floorf((probeCenterNewFace.GetY() - bBox.Bottom()) / voxelLength))),
+                vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                    (unsigned int) vislib::math::Max<unsigned int>(
+                        0, (int) floorf((probeCenterNewFace.GetZ() - bBox.Back()) / voxelLength))));
             this->voxelMapProbes[face->GetProbeIndex().GetX()][face->GetProbeIndex().GetY()]
                                 [face->GetProbeIndex().GetZ()]
                                     .push_back(face);
@@ -802,7 +802,7 @@ float ReducedSurfaceSimplified::ComputeAngleBetweenProbes(vislib::math::Vector<f
     angle = acos(cosinus);
     // correct angle if the new probe lies in the back of the plane
     if ((dist1 < 0.0f && dist2 > 0.0f) || (dist1 > 0.0f && dist2 < 0.0f))
-        angle = 2.0f * (float)vislib::math::PI_DOUBLE - angle;
+        angle = 2.0f * (float) vislib::math::PI_DOUBLE - angle;
     return angle;
 }
 
@@ -882,15 +882,15 @@ bool ReducedSurfaceSimplified::ComputeFirstFixedProbePos(RSVertex* vI, RSVertex*
             this->rsEdge[this->rsEdge.size() - 2], this->rsEdge[this->rsEdge.size() - 1], uijk, pijk1));
         // add probe position to voxel map cell
         this->rsFace.back()->SetProbeIndex(
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes.size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk1.GetX() - bBox.Left()) / voxelLength))),
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0].size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk1.GetY() - bBox.Bottom()) / voxelLength))),
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk1.GetZ() - bBox.Back()) / voxelLength))));
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes.size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk1.GetX() - bBox.Left()) / voxelLength))),
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0].size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk1.GetY() - bBox.Bottom()) / voxelLength))),
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk1.GetZ() - bBox.Back()) / voxelLength))));
         this->voxelMapProbes[this->rsFace.back()->GetProbeIndex().GetX()][this->rsFace.back()->GetProbeIndex().GetY()]
                             [this->rsFace.back()->GetProbeIndex().GetZ()]
                                 .push_back(this->rsFace.back());
@@ -919,15 +919,15 @@ bool ReducedSurfaceSimplified::ComputeFirstFixedProbePos(RSVertex* vI, RSVertex*
             this->rsEdge[this->rsEdge.size() - 2], this->rsEdge[this->rsEdge.size() - 1], uijk * (-1.0f), pijk2));
         // add probe position to voxel map cell
         this->rsFace.back()->SetProbeIndex(
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes.size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk2.GetX() - bBox.Left()) / voxelLength))),
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0].size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk2.GetY() - bBox.Bottom()) / voxelLength))),
-            vislib::math::Min<unsigned int>((unsigned int)this->voxelMapProbes[0][0].size() - 1,
-                (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((pijk2.GetZ() - bBox.Back()) / voxelLength))));
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes.size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk2.GetX() - bBox.Left()) / voxelLength))),
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0].size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk2.GetY() - bBox.Bottom()) / voxelLength))),
+            vislib::math::Min<unsigned int>((unsigned int) this->voxelMapProbes[0][0].size() - 1,
+                (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((pijk2.GetZ() - bBox.Back()) / voxelLength))));
         this->voxelMapProbes[this->rsFace.back()->GetProbeIndex().GetX()][this->rsFace.back()->GetProbeIndex().GetY()]
                             [this->rsFace.back()->GetProbeIndex().GetZ()]
                                 .push_back(this->rsFace.back());
@@ -957,12 +957,12 @@ void ReducedSurfaceSimplified::ComputeVicinity(vislib::math::Vector<float, 3> m,
     maxZId = static_cast<unsigned int>(this->voxelMap[0][0].size() - 1);
     int cntX, cntY, cntZ;
 
-    xId = (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((m.GetX() - bBox.Left()) / voxelLength));
-    xId = (unsigned int)vislib::math::Min<unsigned int>(maxXId, xId);
-    yId = (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((m.GetY() - bBox.Bottom()) / voxelLength));
-    yId = (unsigned int)vislib::math::Min<unsigned int>(maxYId, yId);
-    zId = (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((m.GetZ() - bBox.Back()) / voxelLength));
-    zId = (unsigned int)vislib::math::Min<unsigned int>(maxZId, zId);
+    xId = (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((m.GetX() - bBox.Left()) / voxelLength));
+    xId = (unsigned int) vislib::math::Min<unsigned int>(maxXId, xId);
+    yId = (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((m.GetY() - bBox.Bottom()) / voxelLength));
+    yId = (unsigned int) vislib::math::Min<unsigned int>(maxYId, yId);
+    zId = (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((m.GetZ() - bBox.Back()) / voxelLength));
+    zId = (unsigned int) vislib::math::Min<unsigned int>(maxZId, zId);
 
     float distance;
     //float threshold;
@@ -1027,14 +1027,14 @@ void ReducedSurfaceSimplified::ComputeVicinityEdge(RSEdge* edge) {
     int cntX, cntY, cntZ;
 
     xId = vislib::math::Min<unsigned int>(
-        maxXId, (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((edge->GetTorusCenter().GetX() - bBox.Left()) / voxelLength)));
+        maxXId, (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((edge->GetTorusCenter().GetX() - bBox.Left()) / voxelLength)));
     yId = vislib::math::Min<unsigned int>(
-        maxYId, (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((edge->GetTorusCenter().GetY() - bBox.Bottom()) / voxelLength)));
+        maxYId, (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((edge->GetTorusCenter().GetY() - bBox.Bottom()) / voxelLength)));
     zId = vislib::math::Min<unsigned int>(
-        maxZId, (unsigned int)vislib::math::Max<unsigned int>(
-                    0, (int)floorf((edge->GetTorusCenter().GetZ() - bBox.Back()) / voxelLength)));
+        maxZId, (unsigned int) vislib::math::Max<unsigned int>(
+                    0, (int) floorf((edge->GetTorusCenter().GetZ() - bBox.Back()) / voxelLength)));
 
     float distance, threshold;
     // clear old vicinity indices
@@ -1082,15 +1082,15 @@ void ReducedSurfaceSimplified::ComputeVicinityVertex(RSVertex* vertex) {
     maxZId = static_cast<unsigned int>(this->voxelMap[0][0].size() - 1);
     int cntX, cntY, cntZ;
 
-    xId = (unsigned int)vislib::math::Max<unsigned int>(
-        0, (int)floorf((vertex->GetPosition().GetX() - bBox.Left()) / voxelLength));
-    xId = (unsigned int)vislib::math::Min<unsigned int>(maxXId, xId);
-    yId = (unsigned int)vislib::math::Max<unsigned int>(
-        0, (int)floorf((vertex->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
-    yId = (unsigned int)vislib::math::Min<unsigned int>(maxYId, yId);
-    zId = (unsigned int)vislib::math::Max<unsigned int>(
-        0, (int)floorf((vertex->GetPosition().GetZ() - bBox.Back()) / voxelLength));
-    zId = (unsigned int)vislib::math::Min<unsigned int>(maxZId, zId);
+    xId = (unsigned int) vislib::math::Max<unsigned int>(
+        0, (int) floorf((vertex->GetPosition().GetX() - bBox.Left()) / voxelLength));
+    xId = (unsigned int) vislib::math::Min<unsigned int>(maxXId, xId);
+    yId = (unsigned int) vislib::math::Max<unsigned int>(
+        0, (int) floorf((vertex->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
+    yId = (unsigned int) vislib::math::Min<unsigned int>(maxYId, yId);
+    zId = (unsigned int) vislib::math::Max<unsigned int>(
+        0, (int) floorf((vertex->GetPosition().GetZ() - bBox.Back()) / voxelLength));
+    zId = (unsigned int) vislib::math::Min<unsigned int>(maxZId, zId);
 
     float distance, threshold;
     // clear old vicinity indices
@@ -1146,13 +1146,13 @@ std::vector<ReducedSurfaceSimplified::RSFace*> ReducedSurfaceSimplified::GetProb
     dir21.Normalise();
     // compute voxel indices for edge center
     xId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetX() - bBox.Left()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetX() - bBox.Left()) / voxelLength)),
         maxXId);
     yId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetY() - bBox.Bottom()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetY() - bBox.Bottom()) / voxelLength)),
         maxYId);
     zId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetZ() - bBox.Back()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetZ() - bBox.Back()) / voxelLength)),
         maxZId);
 
     float dist1, dist2, edgeLen, lenH;
@@ -1212,13 +1212,13 @@ void ReducedSurfaceSimplified::WriteProbesCutEdge(RSEdge* edge) {
     dir21.Normalise();
     // compute voxel indices for edge center
     xId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetX() - bBox.Left()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetX() - bBox.Left()) / voxelLength)),
         maxXId);
     yId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetY() - bBox.Bottom()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetY() - bBox.Bottom()) / voxelLength)),
         maxYId);
     zId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((center.GetZ() - bBox.Back()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((center.GetZ() - bBox.Back()) / voxelLength)),
         maxZId);
 
     float dist1, dist2, edgeLen, lenH;
@@ -1269,12 +1269,14 @@ void ReducedSurfaceSimplified::ComputeProbeCutVertex(RSVertex* vertex) {
     v1 = vertex->GetPosition();
     // compute voxel indices for edge center
     xId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((v1.GetX() - bBox.Left()) / voxelLength)), maxXId);
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((v1.GetX() - bBox.Left()) / voxelLength)),
+        maxXId);
     yId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((v1.GetY() - bBox.Bottom()) / voxelLength)),
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((v1.GetY() - bBox.Bottom()) / voxelLength)),
         maxYId);
     zId = vislib::math::Min<unsigned int>(
-        (unsigned int)vislib::math::Max<unsigned int>(0, (int)floorf((v1.GetZ() - bBox.Back()) / voxelLength)), maxZId);
+        (unsigned int) vislib::math::Max<unsigned int>(0, (int) floorf((v1.GetZ() - bBox.Back()) / voxelLength)),
+        maxZId);
 
     float dist;
     // clear old face list
@@ -1418,29 +1420,31 @@ bool ReducedSurfaceSimplified::UpdateData(const float lowerThreshold, const floa
             // the lower threshold is exceeded
             lowerThresholdExceeded = true;
             // compute old voxel map index
-            oldVoxelMapIdxX = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetX() - bBox.Left()) / voxelLength));
-            oldVoxelMapIdxX = vislib::math::Min<unsigned int>(oldVoxelMapIdxX, (unsigned int)this->voxelMap.size() - 1);
-            oldVoxelMapIdxY = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
+            oldVoxelMapIdxX = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetX() - bBox.Left()) / voxelLength));
+            oldVoxelMapIdxX =
+                vislib::math::Min<unsigned int>(oldVoxelMapIdxX, (unsigned int) this->voxelMap.size() - 1);
+            oldVoxelMapIdxY = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetY() - bBox.Bottom()) / voxelLength));
             oldVoxelMapIdxY = vislib::math::Min<unsigned int>(
-                oldVoxelMapIdxY, (unsigned int)this->voxelMap[oldVoxelMapIdxX].size() - 1);
-            oldVoxelMapIdxZ = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((this->rsVertex[cnt3]->GetPosition().GetZ() - bBox.Back()) / voxelLength));
+                oldVoxelMapIdxY, (unsigned int) this->voxelMap[oldVoxelMapIdxX].size() - 1);
+            oldVoxelMapIdxZ = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((this->rsVertex[cnt3]->GetPosition().GetZ() - bBox.Back()) / voxelLength));
             oldVoxelMapIdxZ = vislib::math::Min<unsigned int>(
-                oldVoxelMapIdxZ, (unsigned int)this->voxelMap[oldVoxelMapIdxX][oldVoxelMapIdxY].size() - 1);
+                oldVoxelMapIdxZ, (unsigned int) this->voxelMap[oldVoxelMapIdxX][oldVoxelMapIdxY].size() - 1);
             // compute new voxel map index --> make sure the index is within bounds
-            newVoxelMapIdxX = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((tmpVec1.GetX() - bBox.Left()) / this->voxelLength));
-            newVoxelMapIdxX = vislib::math::Min<unsigned int>(newVoxelMapIdxX, (unsigned int)this->voxelMap.size() - 1);
-            newVoxelMapIdxY = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((tmpVec1.GetY() - bBox.Bottom()) / this->voxelLength));
+            newVoxelMapIdxX = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((tmpVec1.GetX() - bBox.Left()) / this->voxelLength));
+            newVoxelMapIdxX =
+                vislib::math::Min<unsigned int>(newVoxelMapIdxX, (unsigned int) this->voxelMap.size() - 1);
+            newVoxelMapIdxY = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((tmpVec1.GetY() - bBox.Bottom()) / this->voxelLength));
             newVoxelMapIdxY = vislib::math::Min<unsigned int>(
-                newVoxelMapIdxY, (unsigned int)this->voxelMap[newVoxelMapIdxX].size() - 1);
-            newVoxelMapIdxZ = (unsigned int)vislib::math::Max<unsigned int>(
-                0, (int)floorf((tmpVec1.GetZ() - bBox.Back()) / this->voxelLength));
+                newVoxelMapIdxY, (unsigned int) this->voxelMap[newVoxelMapIdxX].size() - 1);
+            newVoxelMapIdxZ = (unsigned int) vislib::math::Max<unsigned int>(
+                0, (int) floorf((tmpVec1.GetZ() - bBox.Back()) / this->voxelLength));
             newVoxelMapIdxZ = vislib::math::Min<unsigned int>(
-                newVoxelMapIdxZ, (unsigned int)this->voxelMap[newVoxelMapIdxX][newVoxelMapIdxY].size() - 1);
+                newVoxelMapIdxZ, (unsigned int) this->voxelMap[newVoxelMapIdxX][newVoxelMapIdxY].size() - 1);
             // if the new atom position lies in another voxel --> remove old and add new position
             if ((oldVoxelMapIdxX != newVoxelMapIdxX) || (oldVoxelMapIdxY != newVoxelMapIdxY) ||
                 (oldVoxelMapIdxZ != newVoxelMapIdxZ)) {

--- a/plugins/protein/src/ReducedSurfaceSimplified.h
+++ b/plugins/protein/src/ReducedSurfaceSimplified.h
@@ -45,7 +45,7 @@ public:
         unsigned int SidechainAtomIndex(unsigned int idx) const;
         /** The number of amino acids in this chain */
         unsigned int AminoAcidCount() const {
-            return (unsigned int)backbonePos.size();
+            return (unsigned int) backbonePos.size();
         };
         /** The maximum radius of a backbone or sidechain */
         float MaxRadius() const {
@@ -121,7 +121,7 @@ public:
         };
         /** getter for the edge list size */
         const unsigned int GetEdgeCount() const {
-            return (unsigned int)edgeList.size();
+            return (unsigned int) edgeList.size();
         };
         /** add edge */
         void AddEdge(RSEdge* edge) {
@@ -389,7 +389,7 @@ public:
      * @return The number of RS-vertices.
      */
     unsigned int GetRSVertexCount() {
-        return (unsigned int)rsVertex.size();
+        return (unsigned int) rsVertex.size();
     };
 
     /**
@@ -397,7 +397,7 @@ public:
      * @return The number of RS-edges.
      */
     unsigned int GetRSEdgeCount() {
-        return (unsigned int)rsEdge.size();
+        return (unsigned int) rsEdge.size();
     };
 
     /**
@@ -405,7 +405,7 @@ public:
      * @return The number of RS-faces.
      */
     unsigned int GetRSFaceCount() {
-        return (unsigned int)rsFace.size();
+        return (unsigned int) rsFace.size();
     };
 
     /**
@@ -462,7 +462,7 @@ public:
     bool UpdateData(const float lowerThreshold, const float upperThreshold);
 
     unsigned int SimpleChainCount() const {
-        return (unsigned int)simpleChain.size();
+        return (unsigned int) simpleChain.size();
     };
     const SimplifiedChain* SimpleChain(unsigned int idx) const {
         return simpleChain.at(idx);

--- a/plugins/protein/src/SolventHydroBondGenerator.cpp
+++ b/plugins/protein/src/SolventHydroBondGenerator.cpp
@@ -106,7 +106,7 @@ void megamol::protein::SolventHydroBondGenerator::calcSpatialProbabilities(
     int nFrames = src->FrameCount();
     int nAtoms = src->AtomCount();
 
-    if ((int)this->middleAtomPos.Count() < nAtoms * 3) {
+    if ((int) this->middleAtomPos.Count() < nAtoms * 3) {
         this->middleAtomPos.SetCount(nAtoms * 3);
     }
     memset(&this->middleAtomPos[0], 0, this->middleAtomPos.Count() * sizeof(float));
@@ -390,7 +390,7 @@ Wasserstoffbruecken bilden und dabei als Donor und Aktzeptor dienen koenne. Dabe
                 neighbourFinder.FindNeighboursInRange(
                     &atomPositions[atomIndex * 3], hbondDonorAcceptorDist, privateNeighbourIndices);
 
-                for (int nIdx = 0; nIdx < (int)privateNeighbourIndices.Count(); nIdx++) {
+                for (int nIdx = 0; nIdx < (int) privateNeighbourIndices.Count(); nIdx++) {
                     int neighbIndex = privateNeighbourIndices[nIdx];
                     //char elementNeighb = atomTypes[atomTypeIndices[neighbIndex]].Name()[0];
 

--- a/plugins/protein/src/Stride.cpp
+++ b/plugins/protein/src/Stride.cpp
@@ -19,9 +19,9 @@ Stride::Stride(MolecularDataCall* mol) : Successful(false) {
     // set hydrogen bond count to zero
     HydroBondCnt = 0;
 
-    ProteinChain = (CHAIN**)ckalloc(MAX_CHAIN * sizeof(CHAIN*));
-    HydroBond = (HBOND**)ckalloc(MAXHYDRBOND * sizeof(HBOND*));
-    StrideCmd = (COMMAND*)ckalloc(sizeof(COMMAND));
+    ProteinChain = (CHAIN**) ckalloc(MAX_CHAIN * sizeof(CHAIN*));
+    HydroBond = (HBOND**) ckalloc(MAXHYDRBOND * sizeof(HBOND*));
+    StrideCmd = (COMMAND*) ckalloc(sizeof(COMMAND));
 
     // set default values for command variable
     DefaultCmd(StrideCmd);
@@ -110,7 +110,7 @@ void Stride::GetChains(MolecularDataCall* mol) {
     // build chains from Molecular Data Call
     //////////////////////////////////////////////////////
 
-    ProteinChainCnt = std::min((unsigned int)mol->MoleculeCount(), (unsigned int)MAX_CHAIN);
+    ProteinChainCnt = std::min((unsigned int) mol->MoleculeCount(), (unsigned int) MAX_CHAIN);
     chain = 0;
 
     // iterate over all chains
@@ -130,7 +130,7 @@ void Stride::GetChains(MolecularDataCall* mol) {
             atomCount = mol->Residues()[idx + cntRes]->AtomCount();
             ProteinChain[cntCha]->NAtom += atomCount;
 
-            ProteinChain[cntCha]->Rsd[cntRes] = (RESIDUE*)ckalloc(sizeof(RESIDUE));
+            ProteinChain[cntCha]->Rsd[cntRes] = (RESIDUE*) ckalloc(sizeof(RESIDUE));
 
             r = ProteinChain[cntCha]->Rsd[cntRes];
             r->NAtom = atomCount;
@@ -176,8 +176,8 @@ void Stride::GetChains(MolecularDataCall* mol) {
         c->Resolution = 0.0f;
         for (i = 0; i < c->NRes; ++i) {
             r = c->Rsd[i];
-            r->Inv = (INVOLVED*)ckalloc(sizeof(INVOLVED));
-            r->Prop = (PROPERTY*)ckalloc(sizeof(PROPERTY));
+            r->Inv = (INVOLVED*) ckalloc(sizeof(INVOLVED));
+            r->Prop = (PROPERTY*) ckalloc(sizeof(PROPERTY));
             r->Inv->NBondDnr = 0;
             r->Inv->NBondAcc = 0;
             r->Inv->InterchainHBonds = STRIDE_NO;
@@ -300,12 +300,12 @@ bool Stride::WriteToInterface(MolecularDataCall* mol) {
                 sec.back().SetType(MolecularDataCall::SecStructure::TYPE_SHEET);
             else
                 sec.back().SetType(MolecularDataCall::SecStructure::TYPE_COIL);
-            mol->SetMoleculeSecondaryStructure(Cn, idx, (unsigned int)sec.size() - idx);
-            idx = (int)sec.size();
+            mol->SetMoleculeSecondaryStructure(Cn, idx, (unsigned int) sec.size() - idx);
+            idx = (int) sec.size();
         }
         // handled all residues of current chain, copy sec struct to interface
-        mol->SetSecondaryStructureCount((unsigned int)sec.size());
-        for (i = 0; i < (int)sec.size(); ++i) {
+        mol->SetSecondaryStructureCount((unsigned int) sec.size());
+        for (i = 0; i < (int) sec.size(); ++i) {
             mol->SetSecondaryStructure(i, sec[i]);
         }
 
@@ -361,8 +361,8 @@ void Stride::DefaultCmd(COMMAND* Cmd) {
     strcpy(Cmd->OutFile, "");
     strcpy(Cmd->InputFile, "");
 
-    Cmd->NActive = (int)strlen(Cmd->Active);
-    Cmd->NProcessed = (int)strlen(Cmd->Processed);
+    Cmd->NActive = (int) strlen(Cmd->Active);
+    Cmd->NProcessed = (int) strlen(Cmd->Processed);
 }
 
 int Stride::ReadPDBFile(CHAIN** Chain, int* Cn, COMMAND* Cmd) {
@@ -407,8 +407,8 @@ int Stride::ReadPDBFile(CHAIN** Chain, int* Cn, COMMAND* Cmd) {
         c->Resolution = Resolution;
         for (i = 0; i < c->NRes; i++) {
             r = c->Rsd[i];
-            r->Inv = (INVOLVED*)ckalloc(sizeof(INVOLVED));
-            r->Prop = (PROPERTY*)ckalloc(sizeof(PROPERTY));
+            r->Inv = (INVOLVED*) ckalloc(sizeof(INVOLVED));
+            r->Prop = (PROPERTY*) ckalloc(sizeof(PROPERTY));
             r->Inv->NBondDnr = 0;
             r->Inv->NBondAcc = 0;
             r->Inv->InterchainHBonds = STRIDE_NO;
@@ -530,13 +530,13 @@ float** Stride::DefaultHelixMap(COMMAND* Cmd) {
             0.0006944445f, 0.0036063762f, 0.0080820229f, 0.0101532144f, 0.0076146079f, 0.0032324446f, 0.0006009616f,
             0.0000000000f, 0.0000000000f, 0.0000000000f, 0.0000000000f}};
 
-    Map = (float**)ckalloc(DEFNUMPIXEL * sizeof(float*));
+    Map = (float**) ckalloc(DEFNUMPIXEL * sizeof(float*));
 
     for (i = 0; i < DEFNUMPIXEL; i++)
         Map[i] = &(Data[i][0]);
 
     Cmd->NPixel = DEFNUMPIXEL;
-    Cmd->PhiPsiStep = (float)(MAXPHIPSI - MINPHIPSI) / (float)Cmd->NPixel;
+    Cmd->PhiPsiStep = (float) (MAXPHIPSI - MINPHIPSI) / (float) Cmd->NPixel;
 
     return (Map);
 }
@@ -601,13 +601,13 @@ float** Stride::DefaultSheetMap(COMMAND* Cmd) {
             0.0000000000f, 0.0000000000f, 0.0010016026f, 0.0046167620f, 0.0157516468f, 0.0453012958f, 0.0937970504f,
             0.1454590708f, 0.1861637682f, 0.2019522935f, 0.1764564067f}};
 
-    Map = (float**)ckalloc(DEFNUMPIXEL * sizeof(float*));
+    Map = (float**) ckalloc(DEFNUMPIXEL * sizeof(float*));
 
     for (i = 0; i < DEFNUMPIXEL; i++)
         Map[i] = &(Data[i][0]);
 
     Cmd->NPixel = DEFNUMPIXEL;
-    Cmd->PhiPsiStep = (float)(MAXPHIPSI - MINPHIPSI) / (float)Cmd->NPixel;
+    Cmd->PhiPsiStep = (float) (MAXPHIPSI - MINPHIPSI) / (float) Cmd->NPixel;
 
     return (Map);
 }
@@ -645,7 +645,7 @@ int Stride::PlaceHydrogens(CHAIN* Chain) {
             Length_N_H = Dist(r->Coord[N], r->Coord[H]);
 
             for (i = 0; i < 3; i++)
-                r->Coord[H][i] = r->Coord[N][i] + (float)DIST_N_H * (r->Coord[H][i] - r->Coord[N][i]) / Length_N_H;
+                r->Coord[H][i] = r->Coord[N][i] + (float) DIST_N_H * (r->Coord[H][i] - r->Coord[N][i]) / Length_N_H;
 
             strcpy(r->AtomType[H], "H");
             r->NAtom++;
@@ -661,8 +661,8 @@ int Stride::FindHydrogenBonds(CHAIN** Chain, int NChain, HBOND** HBond, COMMAND*
     int NDnr = 0, NAcc = 0;
     int dc, ac, ccd, cca, cc, hc = 0, i;
 
-    Dnr = (DONOR**)ckalloc(MAXDONOR * sizeof(DONOR*));
-    Acc = (ACCEPTOR**)ckalloc(MAXACCEPTOR * sizeof(ACCEPTOR*));
+    Dnr = (DONOR**) ckalloc(MAXDONOR * sizeof(DONOR*));
+    Acc = (ACCEPTOR**) ckalloc(MAXACCEPTOR * sizeof(ACCEPTOR*));
 
     for (cc = 0; cc < NChain; cc++) {
         FindDnr(Chain[cc], Dnr, &NDnr, Cmd);
@@ -670,8 +670,8 @@ int Stride::FindHydrogenBonds(CHAIN** Chain, int NChain, HBOND** HBond, COMMAND*
     }
 
     BOOLEAN *BondedDonor, *BondedAcceptor;
-    BondedDonor = (BOOLEAN*)ckalloc(NDnr * sizeof(BOOLEAN));
-    BondedAcceptor = (BOOLEAN*)ckalloc(NAcc * sizeof(BOOLEAN));
+    BondedDonor = (BOOLEAN*) ckalloc(NDnr * sizeof(BOOLEAN));
+    BondedAcceptor = (BOOLEAN*) ckalloc(NAcc * sizeof(BOOLEAN));
 
     for (i = 0; i < NDnr; i++)
         BondedDonor[i] = STRIDE_NO;
@@ -693,7 +693,7 @@ int Stride::FindHydrogenBonds(CHAIN** Chain, int NChain, HBOND** HBond, COMMAND*
 
             if (hc == MAXHYDRBOND)
                 die("Number of hydrogen bonds exceeds current limit of %d in %s\n", MAXHYDRBOND, Chain[0]->File);
-            HBond[hc] = (HBOND*)ckalloc(sizeof(HBOND));
+            HBond[hc] = (HBOND*) ckalloc(sizeof(HBOND));
 
             HBond[hc]->ExistHydrBondRose = STRIDE_NO;
             HBond[hc]->ExistHydrBondBaker = STRIDE_NO;
@@ -886,8 +886,8 @@ void Stride::DiscrPhiPsi(CHAIN** Chain, int NChain, COMMAND* Cmd) {
 
             if (Res != 0) {
                 for (i = 0; i < Cmd->NPixel; i++)
-                    if (r->Prop->Phi > MINPHIPSI + (float)(i)*Cmd->PhiPsiStep &&
-                        r->Prop->Phi <= MINPHIPSI + (float)(i + 1) * Cmd->PhiPsiStep) {
+                    if (r->Prop->Phi > MINPHIPSI + (float) (i) *Cmd->PhiPsiStep &&
+                        r->Prop->Phi <= MINPHIPSI + (float) (i + 1) * Cmd->PhiPsiStep) {
                         r->Prop->PhiZn = i;
                         break;
                     }
@@ -895,8 +895,8 @@ void Stride::DiscrPhiPsi(CHAIN** Chain, int NChain, COMMAND* Cmd) {
 
             if (Res != Chain[Cn]->NRes - 1) {
                 for (i = 0; i < Cmd->NPixel; i++)
-                    if (r->Prop->Psi > MINPHIPSI + (float)(i)*Cmd->PhiPsiStep &&
-                        r->Prop->Psi <= MINPHIPSI + (float)(i + 1) * Cmd->PhiPsiStep) {
+                    if (r->Prop->Psi > MINPHIPSI + (float) (i) *Cmd->PhiPsiStep &&
+                        r->Prop->Psi <= MINPHIPSI + (float) (i + 1) * Cmd->PhiPsiStep) {
                         r->Prop->PsiZn = i;
                         break;
                     }
@@ -920,7 +920,7 @@ void Stride::Helix(CHAIN** Chain, int Cn, HBOND** HBond, COMMAND* Cmd, float** P
 
     CONSTf = 1 + Cmd->C1_H;
 
-    Prob = (float*)ckalloc(MAX_RES * sizeof(float));
+    Prob = (float*) ckalloc(MAX_RES * sizeof(float));
 
     for (i = 0; i < Chain[Cn]->NRes; i++)
         Prob[i] = 0.0;
@@ -1001,13 +1001,13 @@ void Stride::Sheet(CHAIN** Chain, int Cn1, int Cn2, HBOND** HBond, COMMAND* Cmd,
     char *AntiPar1, *Par1, *AntiPar2, *Par2;
     int i;
 
-    PatN = (PATTERN**)ckalloc(MAXHYDRBOND * sizeof(PATTERN*));
-    PatP = (PATTERN**)ckalloc(MAXHYDRBOND * sizeof(PATTERN*));
+    PatN = (PATTERN**) ckalloc(MAXHYDRBOND * sizeof(PATTERN*));
+    PatP = (PATTERN**) ckalloc(MAXHYDRBOND * sizeof(PATTERN*));
 
-    AntiPar1 = (char*)ckalloc(Chain[Cn1]->NRes * sizeof(char)); /* Antiparallel strands */
-    Par1 = (char*)ckalloc(Chain[Cn1]->NRes * sizeof(char));     /* Parallel strands */
-    AntiPar2 = (char*)ckalloc(Chain[Cn2]->NRes * sizeof(char)); /* Antiparallel strands */
-    Par2 = (char*)ckalloc(Chain[Cn2]->NRes * sizeof(char));     /* Parallel strands */
+    AntiPar1 = (char*) ckalloc(Chain[Cn1]->NRes * sizeof(char)); /* Antiparallel strands */
+    Par1 = (char*) ckalloc(Chain[Cn1]->NRes * sizeof(char));     /* Parallel strands */
+    AntiPar2 = (char*) ckalloc(Chain[Cn2]->NRes * sizeof(char)); /* Antiparallel strands */
+    Par2 = (char*) ckalloc(Chain[Cn2]->NRes * sizeof(char));     /* Parallel strands */
 
     for (i = 0; i < Chain[Cn1]->NRes; i++) {
         AntiPar1[i] = 'C';
@@ -1199,7 +1199,7 @@ void Stride::BetaTurn(CHAIN** Chain, int Cn) {
             r[3]->Prop->Asn = 'T';
 
         Tn = Chain[Cn]->NAssignedTurn;
-        Chain[Cn]->AssignedTurn[Tn] = (TURN*)ckalloc(sizeof(TURN));
+        Chain[Cn]->AssignedTurn[Tn] = (TURN*) ckalloc(sizeof(TURN));
         t = Chain[Cn]->AssignedTurn[Tn];
         strcpy(t->Res1, r[0]->ResType);
         strcpy(t->Res2, r[3]->ResType);
@@ -1249,7 +1249,7 @@ void Stride::GammaTurn(CHAIN** Chain, int Cn, HBOND** HBond) {
             r[3]->Prop->Asn = 'T';
 
         Tn = Chain[Cn]->NAssignedTurn;
-        Chain[Cn]->AssignedTurn[Tn] = (TURN*)ckalloc(sizeof(TURN));
+        Chain[Cn]->AssignedTurn[Tn] = (TURN*) ckalloc(sizeof(TURN));
         t = Chain[Cn]->AssignedTurn[Tn];
         strcpy(t->Res1, r[1]->ResType);
         strcpy(t->Res2, r[3]->ResType);
@@ -1293,7 +1293,7 @@ int Stride::SSBond(CHAIN** Chain, int NChain) {
                         FindAtom(Chain[Cn1], Res1, "SG", &S1) && FindAtom(Chain[Cn2], Res2, "SG", &S2) &&
                         Dist(Chain[Cn1]->Rsd[Res1]->Coord[S1], Chain[Cn2]->Rsd[Res2]->Coord[S2]) <= SSDIST) {
                         Bn = Chain[0]->NBond;
-                        Chain[0]->SSbond[Bn] = (SSBOND*)ckalloc(sizeof(SSBOND));
+                        Chain[0]->SSbond[Bn] = (SSBOND*) ckalloc(sizeof(SSBOND));
                         strcpy(Chain[0]->SSbond[Bn]->PDB_ResNumb1, Chain[Cn1]->Rsd[Res1]->PDB_ResNumb);
                         strcpy(Chain[0]->SSbond[Bn]->PDB_ResNumb2, Chain[Cn2]->Rsd[Res2]->PDB_ResNumb);
                         Chain[0]->SSbond[Bn]->ChainId1 = Chain[Cn1]->Id;
@@ -1408,7 +1408,7 @@ void Stride::ReportShort(CHAIN** Chain, int NChain, FILE* Out, COMMAND* Cmd) {
             if (!Chain[Cn]->Valid)
                 continue;
 
-            Asn = (char*)ckalloc(Chain[Cn]->NRes * sizeof(char));
+            Asn = (char*) ckalloc(Chain[Cn]->NRes * sizeof(char));
             ExtractAsn(Chain, Cn, Asn);
             NStr = Boundaries(Asn, Chain[Cn]->NRes, (*StrTypes), Bound);
 
@@ -1443,7 +1443,7 @@ void Stride::Glue(const char* String1, const char* String2, FILE* Out) {
     BUFFER Bf;
 
     strcpy(Bf, String1);
-    strncpy(Bf, String2, (int)strlen(String2));
+    strncpy(Bf, String2, (int) strlen(String2));
 
     fprintf(Out, "%s", Bf);
 }
@@ -1520,7 +1520,7 @@ int Stride::Process_ATOM(BUFFER Buffer, CHAIN** Chain, int* ChainNumber, BOOLEAN
         }
         NR = Chain[CC]->NRes;
         strcpy(LastRes[CC], Field[0]);
-        Chain[CC]->Rsd[NR] = (RESIDUE*)ckalloc(sizeof(RESIDUE));
+        Chain[CC]->Rsd[NR] = (RESIDUE*) ckalloc(sizeof(RESIDUE));
         strcpy(Chain[CC]->Rsd[NR]->PDB_ResNumb, LastRes[CC]);
         Chain[CC]->Rsd[NR]->NAtom = 0;
         SplitString(Buffer + 17, Field, 1);
@@ -1544,28 +1544,28 @@ int Stride::Process_ATOM(BUFFER Buffer, CHAIN** Chain, int* ChainNumber, BOOLEAN
     strcpy(Tmp, Buffer);
     Buffer[38] = ' ';
     SplitString(Tmp + 30, Field, 1);
-    r->Coord[NA][0] = (float)atof(Field[0]);
+    r->Coord[NA][0] = (float) atof(Field[0]);
 
     strcpy(Tmp, Buffer);
     Buffer[46] = ' ';
     SplitString(Tmp + 38, Field, 1);
-    r->Coord[NA][1] = (float)atof(Field[0]);
+    r->Coord[NA][1] = (float) atof(Field[0]);
 
     strcpy(Tmp, Buffer);
     Buffer[54] = ' ';
     SplitString(Tmp + 46, Field, 1);
-    r->Coord[NA][2] = (float)atof(Field[0]);
+    r->Coord[NA][2] = (float) atof(Field[0]);
 
     if (Buffer[57] == '.') {
         strcpy(Tmp, Buffer);
         Tmp[60] = ' ';
         SplitString(Tmp + 54, Field, 1);
-        r->Occupancy[NA] = (float)atof(Field[0]);
+        r->Occupancy[NA] = (float) atof(Field[0]);
     } else
         r->Occupancy[NA] = -1.00;
 
     SplitString(Buffer + 63, Field, 1);
-    r->TempFactor[NA] = (float)atof(Field[0]);
+    r->TempFactor[NA] = (float) atof(Field[0]);
 
     r->NAtom++;
 
@@ -1652,9 +1652,9 @@ float Stride::Torsion(float* Coord1, float* Coord2, float* Coord3, float* Coord4
 
     /* Find the components of the three bond vectors */
     for (i = 0; i < 3; i++) {
-        Comp[0][i] = (double)(Coord2[i] - Coord1[i]);
-        Comp[1][i] = (double)(Coord3[i] - Coord2[i]);
-        Comp[2][i] = (double)(Coord4[i] - Coord3[i]);
+        Comp[0][i] = (double) (Coord2[i] - Coord1[i]);
+        Comp[1][i] = (double) (Coord3[i] - Coord2[i]);
+        Comp[2][i] = (double) (Coord4[i] - Coord3[i]);
     }
 
     /* Calculate vectors perpendicular to the planes 123 and 234 */
@@ -1696,7 +1696,7 @@ float Stride::Torsion(float* Coord1, float* Coord2, float* Coord3, float* Coord4
         TripleScalarProd += Comp[0][i] * Perp_234[i];
 
     /* Torsion angle has the sign of the triple scalar product */
-    return ((TripleScalarProd > 0.0) ? (float)AbsTorsAng : (float)(-AbsTorsAng));
+    return ((TripleScalarProd > 0.0) ? (float) AbsTorsAng : (float) (-AbsTorsAng));
 }
 
 float Stride::Dist(float* Coord1, float* Coord2) {
@@ -1834,7 +1834,7 @@ int Stride::DefineDnr(
         //free ( Dnr[*dc] );
         return (FAILURE);
     } else {
-        Dnr[*dc] = (DONOR*)ckalloc(sizeof(DONOR));
+        Dnr[*dc] = (DONOR*) ckalloc(sizeof(DONOR));
         memcpy(Dnr[*dc], &tempDonor, sizeof(DONOR));
         (*dc)++;
     }
@@ -1967,7 +1967,7 @@ int Stride::DefineAcceptor(
         //free ( Acc[*ac] );
         return (FAILURE);
     } else {
-        Acc[*ac] = (ACCEPTOR*)ckalloc(sizeof(ACCEPTOR));
+        Acc[*ac] = (ACCEPTOR*) ckalloc(sizeof(ACCEPTOR));
         memcpy(Acc[*ac], &tempAcc, sizeof(ACCEPTOR));
         (*ac)++;
     }
@@ -1984,7 +1984,7 @@ void Stride::GRID_Energy(float* CA2, float* C, float* O, float* H, float* N, COM
     /***** Distance dependence ( 8-6 potential ) ****/
     if (Cmd->Truncate && HBond->AccDonDist < RmGRID)
         HBond->AccDonDist = RmGRID;
-    HBond->Er = float(CGRID / pow((double)HBond->AccDonDist, 8.0) - DGRID / pow((double)HBond->AccDonDist, 6.0));
+    HBond->Er = float(CGRID / pow((double) HBond->AccDonDist, 8.0) - DGRID / pow((double) HBond->AccDonDist, 6.0));
 
     /************** Angular dependance ****************/
     /* Find projection of the hydrogen on the O-C-CA plane */
@@ -1997,14 +1997,14 @@ void Stride::GRID_Energy(float* CA2, float* C, float* O, float* H, float* N, COM
 
     /* Calculate both angle-dependent HB energy components Et and Ep */
     if (HBond->ti >= 0.0 && HBond->ti < 90.0)
-        HBond->Et = (float)(cos(RAD(HBond->to)) * (0.9f + 0.1f * sin(RAD(2.0f * HBond->ti))));
+        HBond->Et = (float) (cos(RAD(HBond->to)) * (0.9f + 0.1f * sin(RAD(2.0f * HBond->ti))));
     else if (HBond->ti >= 90.0f && HBond->ti < 110.0f)
-        HBond->Et = (float)(K1GRID * cos(RAD(HBond->to)) * (pow((K2GRID - pow(cos(RAD(HBond->ti)), 2.0)), 3.0)));
+        HBond->Et = (float) (K1GRID * cos(RAD(HBond->to)) * (pow((K2GRID - pow(cos(RAD(HBond->ti)), 2.0)), 3.0)));
     else
         HBond->Et = 0.0f;
 
     if (HBond->p > 90.0f && HBond->p < 270.0f)
-        HBond->Ep = (float)pow(cos(RAD(HBond->p)), 2.0);
+        HBond->Ep = (float) pow(cos(RAD(HBond->p)), 2.0);
     else
         HBond->Ep = 0.0f;
 
@@ -2034,7 +2034,7 @@ float Stride::Ang(float* Coord1, float* Coord2, float* Coord3) {
     else if (D < 0.0 && fabs(D + 1.0) < Eps)
         D += Eps;
 
-    return ((float)(RADDEG * acos(D)));
+    return ((float) (RADDEG * acos(D)));
 }
 
 int Stride::FindChain(CHAIN** Chain, int NChain, char ChainId) {
@@ -2119,7 +2119,7 @@ int Stride::Link(HBOND** HBond, CHAIN** Chain, int Cn1, int Cn2, RESIDUE* Res1_1
     if (Prob1 < Treshold && Prob2 < Treshold) {
 
         if (!Test) {
-            Pattern[*NumPat] = (PATTERN*)ckalloc(sizeof(PATTERN));
+            Pattern[*NumPat] = (PATTERN*) ckalloc(sizeof(PATTERN));
             Pattern[*NumPat]->ExistPattern = STRIDE_YES;
             Pattern[*NumPat]->Hb1 = HBond[BondNumber1];
             Pattern[*NumPat]->Hb2 = HBond[BondNumber2];
@@ -3079,7 +3079,7 @@ int Stride::Boundaries(char* Asn, int L, char SecondStr, int (*Bound)[2]) {
 }
 
 void Stride::InitChain(CHAIN** Chain) {
-    *Chain = (CHAIN*)ckalloc(sizeof(CHAIN));
+    *Chain = (CHAIN*) ckalloc(sizeof(CHAIN));
 
     (*Chain)->NRes = 0;
     (*Chain)->NHelix = 0;
@@ -3093,13 +3093,13 @@ void Stride::InitChain(CHAIN** Chain) {
     (*Chain)->Ter = 0;
     (*Chain)->Resolution = 0.0;
 
-    (*Chain)->File = (char*)ckalloc(BUFSZ * sizeof(char));
-    (*Chain)->Rsd = (RESIDUE**)ckalloc(MAX_RES * sizeof(RESIDUE*));
-    (*Chain)->Helix = (HELIX**)ckalloc(MAX_HELIX * sizeof(HELIX*));
-    (*Chain)->Sheet = (SHEET**)ckalloc(MAX_SHEET * sizeof(SHEET*));
-    (*Chain)->Turn = (TURN**)ckalloc(MAX_TURN * sizeof(TURN*));
-    (*Chain)->AssignedTurn = (TURN**)ckalloc(MAX_TURN * sizeof(TURN*));
-    (*Chain)->SSbond = (SSBOND**)ckalloc(MAX_BOND * sizeof(SSBOND*));
+    (*Chain)->File = (char*) ckalloc(BUFSZ * sizeof(char));
+    (*Chain)->Rsd = (RESIDUE**) ckalloc(MAX_RES * sizeof(RESIDUE*));
+    (*Chain)->Helix = (HELIX**) ckalloc(MAX_HELIX * sizeof(HELIX*));
+    (*Chain)->Sheet = (SHEET**) ckalloc(MAX_SHEET * sizeof(SHEET*));
+    (*Chain)->Turn = (TURN**) ckalloc(MAX_TURN * sizeof(TURN*));
+    (*Chain)->AssignedTurn = (TURN**) ckalloc(MAX_TURN * sizeof(TURN*));
+    (*Chain)->SSbond = (SSBOND**) ckalloc(MAX_BOND * sizeof(SSBOND*));
 
     (*Chain)->Valid = STRIDE_YES;
 }
@@ -3111,7 +3111,7 @@ int Stride::SplitString(char* Buffer, char** Fields, int MaxField) {
 
     FieldCnt = 0;
     FieldFlag = 0;
-    BuffLen = (int)strlen(Buffer) - 1;
+    BuffLen = (int) strlen(Buffer) - 1;
 
     strcpy(LocalBuffer, Buffer);
 

--- a/plugins/protein/src/UncertaintyDataLoader.cpp
+++ b/plugins/protein/src/UncertaintyDataLoader.cpp
@@ -374,8 +374,8 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
 
 
                     // PDB
-                    tmpSSU = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::PDB];
-                    tmpSSSA = &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::PDB];
+                    tmpSSU = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::PDB];
+                    tmpSSSA = &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::PDB];
                     tmpSSU->Add(defaultSSU);
                     tmpSSSA->Add(defaultSSSA);
                     // Translate first letter of PDB secondary structure definition
@@ -427,8 +427,8 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
 
 
                     // STRIDE
-                    tmpSSU = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::STRIDE];
-                    tmpSSSA = &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::STRIDE];
+                    tmpSSU = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::STRIDE];
+                    tmpSSSA = &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::STRIDE];
                     tmpSSU->Add(defaultSSU);
                     tmpSSSA->Add(defaultSSSA);
                     // Translate STRIDE one letter secondary structure
@@ -470,8 +470,8 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
 
 
                     // DSSP
-                    tmpSSU = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::DSSP];
-                    tmpSSSA = &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::DSSP];
+                    tmpSSU = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::DSSP];
+                    tmpSSSA = &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::DSSP];
                     tmpSSU->Add(defaultSSU);
                     tmpSSSA->Add(defaultSSSA);
                     // Translate DSSP one letter secondary structure summary
@@ -510,8 +510,8 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
 
 
                     // PROSIGN
-                    tmpSSU = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::PROSIGN];
-                    tmpSSSA = &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::PROSIGN];
+                    tmpSSU = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::PROSIGN];
+                    tmpSSSA = &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::PROSIGN];
                     tmpSSU->Add(defaultSSU);
                     tmpSSSA->Add(defaultSSSA);
                     // Translate DSSP one letter secondary structure summary
@@ -549,8 +549,8 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
                         (static_cast<int>(UncertaintyDataCall::secStructure::NOE) - 1));
 
                     // UNCERTAINTY
-                    tmpSSU = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
-                    tmpSSSA = &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+                    tmpSSU = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
+                    tmpSSSA = &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
                     tmpSSU->Add(defaultSSU);
                     tmpSSSA->Add(defaultSSSA);
 
@@ -558,13 +558,13 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
                     // Read threshold and energy values of STRIDE
                     // std::atof converts "inf" to "inf"
                     // std::atof converts " "   to "0.0"
-                    float Th1 = (float)std::atof(line.Substring(204, 10));
-                    float Th3 = (float)std::atof(line.Substring(215, 10));
-                    float Th4 = (float)std::atof(line.Substring(226, 10));
-                    float Tb1p = (float)std::atof(line.Substring(237, 10));
-                    float Tb2p = (float)std::atof(line.Substring(248, 10));
-                    float Tb1a = (float)std::atof(line.Substring(259, 10));
-                    float Tb2a = (float)std::atof(line.Substring(207, 10));
+                    float Th1 = (float) std::atof(line.Substring(204, 10));
+                    float Th3 = (float) std::atof(line.Substring(215, 10));
+                    float Th4 = (float) std::atof(line.Substring(226, 10));
+                    float Tb1p = (float) std::atof(line.Substring(237, 10));
+                    float Tb2p = (float) std::atof(line.Substring(248, 10));
+                    float Tb1a = (float) std::atof(line.Substring(259, 10));
+                    float Tb2a = (float) std::atof(line.Substring(207, 10));
 
                     vislib::math::Vector<float, 7> tmpVec7;
                     tmpVec7[0] = (Th1 > 1.0E38f) ? (1.0E38f) : (Th1);
@@ -577,10 +577,10 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
                     this->strideStructThreshold.Add(tmpVec7);
 
                     // Read threshold and energy values of DSSP
-                    float HBondAc0 = (float)std::atof(line.Substring(411, 8));
-                    float HBondAc1 = (float)std::atof(line.Substring(422, 8));
-                    float HBondDo0 = (float)std::atof(line.Substring(433, 8));
-                    float HBondDo1 = (float)std::atof(line.Substring(444, 8));
+                    float HBondAc0 = (float) std::atof(line.Substring(411, 8));
+                    float HBondAc1 = (float) std::atof(line.Substring(422, 8));
+                    float HBondDo0 = (float) std::atof(line.Substring(433, 8));
+                    float HBondDo1 = (float) std::atof(line.Substring(444, 8));
 
                     vislib::math::Vector<float, 4> tmpVec4;
                     tmpVec4[0] = HBondAc0;
@@ -591,12 +591,12 @@ bool UncertaintyDataLoader::ReadInputFile(const std::filesystem::path& filename)
 
                     // Read threshold values of PROSIGN
                     std::string bla = line.Substring(498, 10).PeekBuffer();
-                    float alphaValue = (float)std::atof(line.Substring(498, 10));
-                    float threeTenValue = (float)std::atof(line.Substring(511, 9));
-                    float piValue = (float)std::atof(line.Substring(523, 7));
-                    float betaValue = (float)std::atof(line.Substring(533, 9));
-                    float helixThr = (float)std::atof(line.Substring(545, 11));
-                    float betaThr = (float)std::atof(line.Substring(559, 10));
+                    float alphaValue = (float) std::atof(line.Substring(498, 10));
+                    float threeTenValue = (float) std::atof(line.Substring(511, 9));
+                    float piValue = (float) std::atof(line.Substring(523, 7));
+                    float betaValue = (float) std::atof(line.Substring(533, 9));
+                    float helixThr = (float) std::atof(line.Substring(545, 11));
+                    float betaThr = (float) std::atof(line.Substring(559, 10));
 
                     vislib::math::Vector<float, 6> tmpVec6;
                     tmpVec6[0] = (alphaValue > 1.0E38f) ? (1.0E38f) : alphaValue;
@@ -865,7 +865,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
             float tah4 = this->strideStructThreshold[a][2];
 
             // Check HELIX
-            unsigned int helixStr = (unsigned int)UncertaintyDataCall::secStructure::H_ALPHA_HELIX;
+            unsigned int helixStr = (unsigned int) UncertaintyDataCall::secStructure::H_ALPHA_HELIX;
             if (a + 1 < this->pdbIndex.Count()) {
 
                 float taah1 = this->strideStructThreshold[a + 1][0];
@@ -919,7 +919,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                         }
                         if (strN == -1) { // no structure with probability > 0 ... take COIL
                             this->secStructUncertainty[strideMethod][aCnt]
-                                                      [(unsigned int)UncertaintyDataCall::secStructure::C_COIL] =
+                                                      [(unsigned int) UncertaintyDataCall::secStructure::C_COIL] =
                                 1.0f - this->secStructUncertainty[strideMethod][aCnt][helixStr];
                         } else {
                             this->secStructUncertainty[strideMethod][aCnt][strN] =
@@ -972,7 +972,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                         }
                         if (strN == -1) { // no structure with probability > 0 ... take COIL
                             this->secStructUncertainty[strideMethod][a - 1]
-                                                      [(unsigned int)UncertaintyDataCall::secStructure::C_COIL] =
+                                                      [(unsigned int) UncertaintyDataCall::secStructure::C_COIL] =
                                 1.0f - this->secStructUncertainty[strideMethod][a - 1][helixStr];
                         } else {
                             this->secStructUncertainty[strideMethod][a - 1][strN] =
@@ -1013,7 +1013,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                         }
                         if (strN == -1) { // no structure with probability > 0 ... take COIL
                             this->secStructUncertainty[strideMethod][a + 4]
-                                                      [(unsigned int)UncertaintyDataCall::secStructure::C_COIL] =
+                                                      [(unsigned int) UncertaintyDataCall::secStructure::C_COIL] =
                                 1.0f - this->secStructUncertainty[strideMethod][a + 4][helixStr];
                         } else {
                             this->secStructUncertainty[strideMethod][a + 4][strN] =
@@ -1034,8 +1034,8 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
             float tab1a = this->strideStructThreshold[a][5];
             float tab2a = this->strideStructThreshold[a][6];
 
-            unsigned int bridgeStr = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
-            unsigned int sheetStr = (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND;
+            unsigned int bridgeStr = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
+            unsigned int sheetStr = (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND;
 
             // paralllel
             if ((tab1p <= (Tbp + DeltaTbp)) && (tab2p <= (Tbp + DeltaTbp))) {
@@ -1076,7 +1076,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                 }
                 if (strN == -1) { // no structure with probability > 0 ... take COIL
                     this->secStructUncertainty[strideMethod][a]
-                                              [(unsigned int)UncertaintyDataCall::secStructure::C_COIL] =
+                                              [(unsigned int) UncertaintyDataCall::secStructure::C_COIL] =
                         1.0f - this->secStructUncertainty[strideMethod][a][bridgeStr];
                 } else {
                     this->secStructUncertainty[strideMethod][a][strN] =
@@ -1162,7 +1162,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                 }
                 if (strN == -1) { // no structure with probability > 0 ... take COIL
                     this->secStructUncertainty[strideMethod][a]
-                                              [(unsigned int)UncertaintyDataCall::secStructure::C_COIL] =
+                                              [(unsigned int) UncertaintyDataCall::secStructure::C_COIL] =
                         1.0f - this->secStructUncertainty[strideMethod][a][bridgeStr];
                 } else {
                     this->secStructUncertainty[strideMethod][a][strN] =
@@ -1266,9 +1266,9 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                                 } else if ((mCurO == strideMethod) && (mCurI == prosignMethod)) {
                                     dist = M_PrS[sCntI][sCntO];
                                 } else if (mCurO == pdbMethod) {
-                                    if ((sCntO == (unsigned int)UncertaintyDataCall::secStructure::G_310_HELIX) ||
-                                        (sCntO == (unsigned int)UncertaintyDataCall::secStructure::H_ALPHA_HELIX) ||
-                                        (sCntO == (unsigned int)UncertaintyDataCall::secStructure::I_PI_HELIX)) {
+                                    if ((sCntO == (unsigned int) UncertaintyDataCall::secStructure::G_310_HELIX) ||
+                                        (sCntO == (unsigned int) UncertaintyDataCall::secStructure::H_ALPHA_HELIX) ||
+                                        (sCntO == (unsigned int) UncertaintyDataCall::secStructure::I_PI_HELIX)) {
 
                                         if (pdbAssignmentHelix == UncertaintyDataCall::pdbAssMethod::PDB_DSSP) {
                                             if (mCurI == dsspMethod) {
@@ -1302,7 +1302,8 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                                                 (dist = M_PrP[sCntI][sCntO]);
                                             }
                                         }
-                                    } else if (sCntO == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) {
+                                    } else if (sCntO ==
+                                               (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) {
                                         if (pdbAssignmentSheet == UncertaintyDataCall::pdbAssMethod::PDB_DSSP) {
                                             if (mCurI == dsspMethod) {
                                                 (dist = 0.0f);
@@ -1347,9 +1348,9 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                                         }
                                     }
                                 } else if (mCurI == pdbMethod) {
-                                    if ((sCntI == (unsigned int)UncertaintyDataCall::secStructure::G_310_HELIX) ||
-                                        (sCntI == (unsigned int)UncertaintyDataCall::secStructure::H_ALPHA_HELIX) ||
-                                        (sCntI == (unsigned int)UncertaintyDataCall::secStructure::I_PI_HELIX)) {
+                                    if ((sCntI == (unsigned int) UncertaintyDataCall::secStructure::G_310_HELIX) ||
+                                        (sCntI == (unsigned int) UncertaintyDataCall::secStructure::H_ALPHA_HELIX) ||
+                                        (sCntI == (unsigned int) UncertaintyDataCall::secStructure::I_PI_HELIX)) {
                                         if (pdbAssignmentHelix == UncertaintyDataCall::pdbAssMethod::PDB_DSSP) {
                                             if (mCurO == dsspMethod) {
                                                 (dist = 0.0f);
@@ -1382,7 +1383,8 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                                                 (dist = M_PrP[sCntO][sCntI]);
                                             }
                                         }
-                                    } else if (sCntI == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) {
+                                    } else if (sCntI ==
+                                               (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) {
                                         if (pdbAssignmentSheet == UncertaintyDataCall::pdbAssMethod::PDB_DSSP) {
                                             if (mCurO == dsspMethod) {
                                                 (dist = 0.0f);
@@ -1453,7 +1455,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
             // Calculate reduced uncertainty ======================================
 
             unc = 0.0f;
-            float mean = 1.0f / ((float)consStrTypes);
+            float mean = 1.0f / ((float) consStrTypes);
 
             // Propability vector with maximum standard deviation
             vislib::math::Vector<float, consStrTypes> Pmax;
@@ -1468,7 +1470,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                 variance += ((Pmax[v] - mean) * (Pmax[v] - mean));
             }
             variance *= mean;
-            float stdDevMax = (float)std::sqrt((double)(variance));
+            float stdDevMax = (float) std::sqrt((double) (variance));
 
             // Calculating actual standard deviation
             variance = 0.0f;
@@ -1476,7 +1478,7 @@ bool UncertaintyDataLoader::CalculateUncertaintyExtended() {
                 variance += ((ssu[v] - mean) * (ssu[v] - mean));
             }
             variance *= mean;
-            float stdDev = (float)std::sqrt((double)(variance));
+            float stdDev = (float) std::sqrt((double) (variance));
 
             // Normalizing standard deviation and calulating uncertainty
             unc = (1.0f - (stdDev / stdDevMax));
@@ -1563,14 +1565,14 @@ bool UncertaintyDataLoader::CalculateUncertaintyAverage() {
                         ssu[j] += structFactor[curMethod][j];
                     }
                 } else {
-                    ssu[j] += ((1.0f - structFactor[curMethod][j]) / ((float)(structTypes - 1)));
+                    ssu[j] += ((1.0f - structFactor[curMethod][j]) / ((float) (structTypes - 1)));
                 }
             }
         }
 
         // Normalise structure uncertainty to [0.0,1.0]
         for (unsigned int j = 0; j < structTypes; j++) {
-            ssu[j] /= abs((float)consideredMethods);
+            ssu[j] /= abs((float) consideredMethods);
         }
 
         // Sorting structure types by their uncertainty
@@ -1608,7 +1610,7 @@ void UncertaintyDataLoader::QuickSortUncertainties(
     int j = right;
     UncertaintyDataCall::secStructure tmpStruct;
 
-    float pivot = valueArr->operator[](static_cast<int>(structArr->operator[]((int)(left + right) / 2)));
+    float pivot = valueArr->operator[](static_cast<int>(structArr->operator[]((int) (left + right) / 2)));
 
     // partition
     while (i <= j) {

--- a/plugins/protein/src/VMDDXLoader.cpp
+++ b/plugins/protein/src/VMDDXLoader.cpp
@@ -291,7 +291,7 @@ bool VMDDXLoader::loadFile(const vislib::StringA& filename) {
     // Setup data array
     this->imgdata.SetNumberOfPieces(1);
     this->imgdata.SetPointData(
-        (const char*)this->data.Peek(), min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT, "vmddata", 1, 0);
+        (const char*) this->data.Peek(), min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT, "vmddata", 1, 0);
 
     Log::DefaultLog.WriteInfo("%s: ... done (%f s)", this->ClassName(),
         (double(clock() - t) / double(CLOCKS_PER_SEC))); // DEBUG

--- a/plugins/protein/src/VTILoader.cpp
+++ b/plugins/protein/src/VTILoader.cpp
@@ -384,7 +384,7 @@ bool VTILoader::loadFile(const vislib::StringA& filename) {
 #endif
 
     // Read data file to char buffer
-    char* buffer = new char[(unsigned int)fileSize];
+    char* buffer = new char[(unsigned int) fileSize];
     if (!file.Open(this->filenameSlot.Param<core::param::FilePathParam>()->Value().native().c_str(),
             vislib::sys::File::READ_ONLY, vislib::sys::File::SHARE_EXCLUSIVE, vislib::sys::File::OPEN_ONLY))
         return false;
@@ -406,7 +406,7 @@ bool VTILoader::loadFile(const vislib::StringA& filename) {
         while (*pt_end != '>') {
             pt_end++;
         }
-        entity = vislib::StringA(pt + 1, (int)(pt_end - pt));
+        entity = vislib::StringA(pt + 1, (int) (pt_end - pt));
 
         // Parse and store relevant attributes
         if (entity.StartsWith("VTKFile")) {
@@ -574,7 +574,7 @@ void VTILoader::readDataBinary2Float(char* buffIn, float* buffOut, // TODO Other
     // TODO Decode first 8 bytes (=size of the data following in bytes)
     //pt_end +=8;
     // Decode actual data
-    Base64::Decode(pt_end, (char*)buffOut, sizeOut * sizeof(float));
+    Base64::Decode(pt_end, (char*) buffOut, sizeOut * sizeof(float));
 }
 
 
@@ -628,7 +628,7 @@ void VTILoader::loadFrame(view::AnimDataModule::Frame* frame, unsigned int idx) 
 #endif // defined(VERBOSE)
 
     // Read data file to char buffer
-    char* buffer = new char[(unsigned int)fileSize];
+    char* buffer = new char[(unsigned int) fileSize];
     file.Open(
         frameFile, vislib::sys::File::READ_ONLY, vislib::sys::File::SHARE_EXCLUSIVE, vislib::sys::File::OPEN_ONLY);
     file.Read(buffer, fileSize);
@@ -823,13 +823,13 @@ void VTILoader::loadFrame(view::AnimDataModule::Frame* frame, unsigned int idx) 
             if (f == protein_calls::VTKImageData::VTISOURCE_ASCII) {
                 data = new float[gridSize];
                 this->readDataAscii2Float(pt_end, data, gridSize);
-                fr->SetPointData((const char*)data, min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT, name,
+                fr->SetPointData((const char*) data, min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT, name,
                     1, pieceCounter - 1); // TODO Use real ID AND NUMBER OF COMPONENTS!!
             } else if (f == protein_calls::VTKImageData::VTISOURCE_BINARY) {
                 data = new float[gridSize + 1];
                 this->readDataBinary2Float(pt_end, data, gridSize);
                 const float* dataplus = data + 1;
-                fr->SetPointData((const char*)(dataplus), min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT,
+                fr->SetPointData((const char*) (dataplus), min, max, protein_calls::VTKImageData::DataArray::VTI_FLOAT,
                     name, numComponents, pieceCounter - 1); // TODO Use real ID AND NUMBER OF COMPONENTS!!
 
                 //                // DEBUG print texture values

--- a/plugins/protein/src/VTIWriter.cpp
+++ b/plugins/protein/src/VTIWriter.cpp
@@ -75,7 +75,7 @@ VTIWriter::VTIWriter()
 
     // Parameter for the output format of the data
     megamol::core::param::EnumParam* fp =
-        new megamol::core::param::EnumParam((int)protein_calls::VTKImageData::VTISOURCE_ASCII);
+        new megamol::core::param::EnumParam((int) protein_calls::VTKImageData::VTISOURCE_ASCII);
     fp->SetTypePair(protein_calls::VTKImageData::VTISOURCE_BINARY, "Binary");
     fp->SetTypePair(protein_calls::VTKImageData::VTISOURCE_ASCII, "Ascii");
     //fp->SetTypePair(VTKImageData::VTISOURCE_APPENDED, "Appended"); // TODO Not implemented yet
@@ -277,7 +277,7 @@ bool VTIWriter::writeDataAscii(
     const void* data, size_t size, std::ofstream& outfile, protein_calls::VTKImageData::DataArray::DataType t) {
     switch (t) {
     case protein_calls::VTKImageData::DataArray::VTI_FLOAT:
-        this->writeDataAsciiFloat((const float*)data, size, outfile);
+        this->writeDataAsciiFloat((const float*) data, size, outfile);
         return true;
     case protein_calls::VTKImageData::DataArray::VTI_INT:
         return true;
@@ -300,7 +300,7 @@ bool VTIWriter::writeDataBinary(
     const void* data, size_t size, std::ofstream& outfile, protein_calls::VTKImageData::DataArray::DataType t) {
     switch (t) {
     case protein_calls::VTKImageData::DataArray::VTI_FLOAT:
-        this->writeDataBinaryFloat((const float*)data, size, outfile);
+        this->writeDataBinaryFloat((const float*) data, size, outfile);
         return true;
     case protein_calls::VTKImageData::DataArray::VTI_INT:
         return true;
@@ -347,10 +347,10 @@ bool VTIWriter::writeDataBinaryFloat(const float* data, size_t size, std::ofstre
     this->buffEn.Validate((sizeFillerBytes / 3) * 4); // Buffer for encoded data
     this->buffDec.Validate(sizeBytes + 4);            // Buffer for decoded data + size
 
-    memcpy(this->buffDec.Peek(), (const char*)(&sizeBytes), 4);
+    memcpy(this->buffDec.Peek(), (const char*) (&sizeBytes), 4);
     memcpy(this->buffDec.Peek() + 4, data, sizeBytes);
 
-    Base64::Encode((const char*)this->buffDec.Peek(), this->buffEn.Peek(), sizeBytes + 4);
+    Base64::Encode((const char*) this->buffDec.Peek(), this->buffEn.Peek(), sizeBytes + 4);
     outfile.write(this->buffEn.Peek(), this->buffEn.GetCount());
 
     return true;
@@ -433,10 +433,10 @@ bool VTIWriter::writeFile(protein_calls::VTIDataCall* dc) {
     std::string digits;
     ss << dc->FrameID();
     filename.append(
-        (const char*)(this->outDirSlot.Param<core::param::StringParam>()->Value().c_str())); // Set output folder
+        (const char*) (this->outDirSlot.Param<core::param::StringParam>()->Value().c_str())); // Set output folder
     filename.append("/");
     filename.append(
-        (const char*)(this->filenamePrefixSlot.Param<core::param::StringParam>()->Value().c_str())); // Set prefix
+        (const char*) (this->filenamePrefixSlot.Param<core::param::StringParam>()->Value().c_str())); // Set prefix
     filename.append(".");
     filename.append((ss.str()).c_str());
     filename.append(".vti");
@@ -520,7 +520,7 @@ bool VTIWriter::writePiece(const protein_calls::VTIDataCall* dc, uint idx, std::
     // Loop through all data arrays in this pieces point data to write the
     for (size_t p = 0; p < dc->GetArrayCntOfPiecePointData(idx); ++p) {
         // Write either scalar, vector, or tensor data
-        size_t nComponents = dc->GetPointDataArrayNumberOfComponents((unsigned int)p, idx);
+        size_t nComponents = dc->GetPointDataArrayNumberOfComponents((unsigned int) p, idx);
         if (nComponents == 1) {
             outfile << " Scalars=\"";
         } else if (nComponents == 3) {
@@ -528,15 +528,15 @@ bool VTIWriter::writePiece(const protein_calls::VTIDataCall* dc, uint idx, std::
         } else {
             outfile << " Tensors=\"";
         }
-        printf("ID: %s\n", dc->GetPointDataArrayId((unsigned int)p, idx).PeekBuffer());
-        outfile << dc->GetPointDataArrayId((unsigned int)p, idx);
+        printf("ID: %s\n", dc->GetPointDataArrayId((unsigned int) p, idx).PeekBuffer());
+        outfile << dc->GetPointDataArrayId((unsigned int) p, idx);
         outfile << "\"";
     }
     outfile << ">" << std::endl;
     // Actual data
     for (size_t p = 0; p < dc->GetArrayCntOfPiecePointData(idx); ++p) {
         // Write data
-        this->writeDataArray(dc, true, (unsigned int)p, idx, outfile);
+        this->writeDataArray(dc, true, (unsigned int) p, idx, outfile);
     }
     // End point data
     outfile << "      </PointData>" << std::endl;
@@ -548,7 +548,7 @@ bool VTIWriter::writePiece(const protein_calls::VTIDataCall* dc, uint idx, std::
     // Loop through all data arrays in this pieces point data to write the
     for (size_t p = 0; p < dc->GetArrayCntOfPieceCellData(idx); ++p) {
         // Write either scalar, vector, or tensor data
-        size_t nComponents = dc->GetCellDataArrayNumberOfComponents((unsigned int)p, idx);
+        size_t nComponents = dc->GetCellDataArrayNumberOfComponents((unsigned int) p, idx);
         if (nComponents == 1) {
             outfile << " Scalars=\"";
         } else if (nComponents == 3) {
@@ -556,14 +556,14 @@ bool VTIWriter::writePiece(const protein_calls::VTIDataCall* dc, uint idx, std::
         } else {
             outfile << " Tensors=\"";
         }
-        outfile << dc->GetCellDataArrayId((unsigned int)p, idx);
+        outfile << dc->GetCellDataArrayId((unsigned int) p, idx);
         outfile << "\"";
     }
     outfile << ">" << std::endl;
     // Actual data
     for (size_t p = 0; p < dc->GetArrayCntOfPieceCellData(idx); ++p) {
         // Write data
-        this->writeDataArray(dc, true, (unsigned int)p, idx, outfile);
+        this->writeDataArray(dc, true, (unsigned int) p, idx, outfile);
     }
     // End cell data
     outfile << "      </CellData>" << std::endl;

--- a/plugins/protein/src/VTKLegacyDataLoaderUnstructuredGrid.cpp
+++ b/plugins/protein/src/VTKLegacyDataLoaderUnstructuredGrid.cpp
@@ -242,12 +242,12 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getData(core::Call& call) {
                 std::cout << (int)fr->PeekPointDataByName("concentration")->PeekData()[i] << std::endl;
             }*/
 
-            for (int64_t i = 0; i < (int64_t)fr->GetNumberOfPoints(); i++) {
+            for (int64_t i = 0; i < (int64_t) fr->GetNumberOfPoints(); i++) {
                 // std::cout << conPtr[i] << std::endl;
-                dataVec[(unsigned int)i * 4 + 0] = velPtr[(unsigned int)i * 3 + 0];
-                dataVec[(unsigned int)i * 4 + 1] = velPtr[(unsigned int)i * 3 + 1];
-                dataVec[(unsigned int)i * 4 + 2] = velPtr[(unsigned int)i * 3 + 2];
-                dataVec[(unsigned int)i * 4 + 3] = conPtr[(unsigned int)i];
+                dataVec[(unsigned int) i * 4 + 0] = velPtr[(unsigned int) i * 3 + 0];
+                dataVec[(unsigned int) i * 4 + 1] = velPtr[(unsigned int) i * 3 + 1];
+                dataVec[(unsigned int) i * 4 + 2] = velPtr[(unsigned int) i * 3 + 2];
+                dataVec[(unsigned int) i * 4 + 3] = conPtr[(unsigned int) i];
 
                 /*if (i > 1) {
                     std::cout << dataVec[i * 4] << " " << dataVec[i * 4 + 1] << " " << dataVec[i * 4 + 2] << " " <<
@@ -259,7 +259,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getData(core::Call& call) {
 #endif
             // Set vertex positions
             mpdc->AccessParticles(0).SetVertexData(geocalls::MultiParticleDataCall::Particles::VERTDATA_FLOAT_XYZ,
-                (const void*)(fr->GetData()->PeekPoints()));
+                (const void*) (fr->GetData()->PeekPoints()));
 
             mpdc->SetUnlocker(new VTKUnlocker(*fr));
 
@@ -295,7 +295,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getExtent(core::Call& call) {
         this->resetFrameCache();
         if (this->nFrames > 0) {
             // Set number of frames
-            this->setFrameCount((unsigned int)std::min(
+            this->setFrameCount((unsigned int) std::min(
                 static_cast<size_t>(this->maxFramesSlot.Param<core::param::IntParam>()->Value()), this->nFrames));
             // Start the loading thread
             this->initFrameCache(this->maxCacheSizeSlot.Param<core::param::IntParam>()->Value());
@@ -311,7 +311,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getExtent(core::Call& call) {
         this->maxCacheSizeSlot.ResetDirty();
         this->resetFrameCache();
         // Set number of frames
-        this->setFrameCount((unsigned int)std::min(
+        this->setFrameCount((unsigned int) std::min(
             static_cast<size_t>(this->maxFramesSlot.Param<core::param::IntParam>()->Value()), this->nFrames));
 
         // Start the loading thread
@@ -323,7 +323,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getExtent(core::Call& call) {
     if (dc != NULL) {
 
         // Set frame count
-        dc->SetFrameCount((unsigned int)std::min(
+        dc->SetFrameCount((unsigned int) std::min(
             static_cast<size_t>(this->maxFramesSlot.Param<core::param::IntParam>()->Value()), this->nFrames));
 
         dc->AccessBoundingBoxes().Clear();
@@ -334,7 +334,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::getExtent(core::Call& call) {
         geocalls::MultiParticleDataCall* mpdc = dynamic_cast<geocalls::MultiParticleDataCall*>(&call);
         if (mpdc != NULL) {
             // Set frame count
-            mpdc->SetFrameCount((unsigned int)std::min(
+            mpdc->SetFrameCount((unsigned int) std::min(
                 static_cast<size_t>(this->maxFramesSlot.Param<core::param::IntParam>()->Value()), this->nFrames));
 
             mpdc->AccessBoundingBoxes().Clear();
@@ -374,9 +374,9 @@ bool VTKLegacyDataLoaderUnstructuredGrid::loadFile(const vislib::StringA& filena
         this->filenamesDigits = b - a + 1;
 
         this->filenamesPrefix.Clear();
-        this->filenamesPrefix = filename.Substring(0, (int)a);
+        this->filenamesPrefix = filename.Substring(0, (int) a);
         this->filenamesSuffix.Clear();
-        this->filenamesSuffix = filename.Substring((int)b + 2);
+        this->filenamesSuffix = filename.Substring((int) b + 2);
 
         //        printf("DIGITS %i\n", this->filenamesDigits);
         //        printf("PREFIX %s\n", this->filenamesPrefix.PeekBuffer());
@@ -422,7 +422,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::loadFile(const vislib::StringA& filena
         this->nFrames); // DEBUG
 
     // Set number of frames
-    this->setFrameCount((unsigned int)std::min(
+    this->setFrameCount((unsigned int) std::min(
         static_cast<size_t>(this->maxFramesSlot.Param<core::param::IntParam>()->Value()), this->nFrames));
 
 
@@ -459,7 +459,7 @@ bool VTKLegacyDataLoaderUnstructuredGrid::loadFile(const vislib::StringA& filena
 #endif // defined(VERBOSE)
 
     // Read data file to char buffer
-    char* buffer = new char[(unsigned int)fileSize];
+    char* buffer = new char[(unsigned int) fileSize];
     file.Open(
         frameFile, vislib::sys::File::READ_ONLY, vislib::sys::File::SHARE_EXCLUSIVE, vislib::sys::File::OPEN_ONLY);
     file.Read(buffer, fileSize);
@@ -554,22 +554,22 @@ bool VTKLegacyDataLoaderUnstructuredGrid::loadFile(const vislib::StringA& filena
 //                                ((float*)(buffPt))[v*3+1],
 //                                ((float*)(buffPt))[v*3+2]);
 #ifdef NORMALIZE_RADIUS
-                        this->bbox.Set(((float*)(buffPt))[v * 3 + 0] /
+                        this->bbox.Set(((float*) (buffPt))[v * 3 + 0] /
                                            this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 1] /
+                            ((float*) (buffPt))[v * 3 + 1] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 2] /
+                            ((float*) (buffPt))[v * 3 + 2] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 0] /
+                            ((float*) (buffPt))[v * 3 + 0] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 1] /
+                            ((float*) (buffPt))[v * 3 + 1] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 2] /
+                            ((float*) (buffPt))[v * 3 + 2] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value());
 #else
-                        this->bbox.Set(((float*)(buffPt))[v * 3 + 0], ((float*)(buffPt))[v * 3 + 1],
-                            ((float*)(buffPt))[v * 3 + 2], ((float*)(buffPt))[v * 3 + 0], ((float*)(buffPt))[v * 3 + 1],
-                            ((float*)(buffPt))[v * 3 + 2]);
+                        this->bbox.Set(((float*) (buffPt))[v * 3 + 0], ((float*) (buffPt))[v * 3 + 1],
+                            ((float*) (buffPt))[v * 3 + 2], ((float*) (buffPt))[v * 3 + 0],
+                            ((float*) (buffPt))[v * 3 + 1], ((float*) (buffPt))[v * 3 + 2]);
 #endif
 
                         //                        printf("Bounding box %f %f %f %f %f %f\n",
@@ -582,15 +582,15 @@ bool VTKLegacyDataLoaderUnstructuredGrid::loadFile(const vislib::StringA& filena
 
                     } else {
 #ifdef NORMALIZE_RADIUS
-                        this->bbox.GrowToPoint(((float*)(buffPt))[v * 3 + 0] /
+                        this->bbox.GrowToPoint(((float*) (buffPt))[v * 3 + 0] /
                                                    this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 1] /
+                            ((float*) (buffPt))[v * 3 + 1] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value(),
-                            ((float*)(buffPt))[v * 3 + 2] /
+                            ((float*) (buffPt))[v * 3 + 2] /
                                 this->globalRadiusParam.Param<core::param::FloatParam>()->Value());
 #else
-                        this->bbox.GrowToPoint(((float*)(buffPt))[v * 3 + 0], ((float*)(buffPt))[v * 3 + 1],
-                            ((float*)(buffPt))[v * 3 + 2]);
+                        this->bbox.GrowToPoint(((float*) (buffPt))[v * 3 + 0], ((float*) (buffPt))[v * 3 + 1],
+                            ((float*) (buffPt))[v * 3 + 2]);
 #endif
                         //                        printf("VERTEX %f %f %f\n",
                         //                                ((float*)(buffPt))[v*3+0],
@@ -670,7 +670,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::loadFrame(core::view::AnimDataModule::
 #endif // defined(VERBOSE)
 
     // Read data file to char buffer
-    char* buffer = new char[(unsigned int)fileSize];
+    char* buffer = new char[(unsigned int) fileSize];
     file.Open(
         frameFile, vislib::sys::File::READ_ONLY, vislib::sys::File::SHARE_EXCLUSIVE, vislib::sys::File::OPEN_ONLY);
     file.Read(buffer, fileSize);
@@ -778,7 +778,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::readASCIIFloats(char*& buffPt, float* 
         token = this->readNextToken(buffPt);
         //        if (i%1000==0) printf("Token %i: %f\n", i, atof(token.PeekBuffer()));
         //        printf("Token %i: %f\n", i, atof(token.PeekBuffer()));
-        out[i] = (float)atof(token.PeekBuffer());
+        out[i] = (float) atof(token.PeekBuffer());
         this->seekNextToken(buffPt);
     }
 }
@@ -843,7 +843,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::readCells(char*& buffPt, core::view::A
 #ifdef SWAP_BYTES
         this->swapBytes(buffPt, 4, cellDataSize);
 #endif
-        fr->SetCellIndexData((const int*)(buffPt), cellDataSize);
+        fr->SetCellIndexData((const int*) (buffPt), cellDataSize);
     }
 
     // Increment buffer pointer
@@ -891,7 +891,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::readCellTypes(char*& buffPt, core::vie
 #ifdef SWAP_BYTES
         this->swapBytes(buffPt, 4, cellCnt);
 #endif
-        fr->SetCellTypes((const int*)(buffPt), cellCnt);
+        fr->SetCellTypes((const int*) (buffPt), cellCnt);
     }
 
     buffPt += cellCnt * sizeof(int);
@@ -996,10 +996,10 @@ void VTKLegacyDataLoaderUnstructuredGrid::readPoints(char*& buffPt, core::view::
 #endif
 #ifdef NORMALIZE_RADIUS
         for (unsigned int i = 0; i < vertexCnt * 3; i++) {
-            ((float*)(buffPt))[i] /= this->globalRadiusParam.Param<core::param::FloatParam>()->Value();
+            ((float*) (buffPt))[i] /= this->globalRadiusParam.Param<core::param::FloatParam>()->Value();
         }
 #endif
-        fr->SetPoints((const float*)(buffPt), vertexCnt);
+        fr->SetPoints((const float*) (buffPt), vertexCnt);
         // Increment buffer pointer
         buffPt += vertexCnt * 3 * sizeof(float); // TODO assumes float
     }
@@ -1054,7 +1054,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::readFieldData(
             if (t == AbstractVTKLegacyData::FLOAT) {
                 float* tempBuff = new float[nComponents * nTupel];
                 this->readASCIIFloats(buffPt, tempBuff, nComponents * nTupel);
-                fr->AddPointData((const char*)(tempBuff), nTupel, nComponents, t, fieldId);
+                fr->AddPointData((const char*) (tempBuff), nTupel, nComponents, t, fieldId);
                 delete[] tempBuff;
             } else {
                 printf("TODO\n"); // TODO?
@@ -1119,7 +1119,7 @@ void VTKLegacyDataLoaderUnstructuredGrid::readDataArray(char*& buffPt, core::vie
         if (t == AbstractVTKLegacyData::FLOAT) {
             float* tempBuff = new float[nTupels * nComponents];
             this->readASCIIFloats(buffPt, tempBuff, nTupels);
-            fr->AddPointData((const char*)(tempBuff), nTupels, nComponents, t, fieldId);
+            fr->AddPointData((const char*) (tempBuff), nTupels, nComponents, t, fieldId);
             delete[] tempBuff;
         } else {
             printf("TODO\n"); // TODO?

--- a/plugins/protein/src/VTKLegacyDataLoaderUnstructuredGrid.h
+++ b/plugins/protein/src/VTKLegacyDataLoaderUnstructuredGrid.h
@@ -370,7 +370,7 @@ private:
             //            printf("%c\n", buffPt[len1]);
             len1++;
         }
-        vislib::StringA line(buffPt, (int)len1);
+        vislib::StringA line(buffPt, (int) len1);
         return line;
     }
 
@@ -394,7 +394,7 @@ private:
             len++;
         }
         //        printf("TOKENSTR %s\n", vislib::StringA(buffPt, len).PeekBuffer());
-        return vislib::StringA(buffPt, (int)len);
+        return vislib::StringA(buffPt, (int) len);
     }
 
     /** TODO */

--- a/plugins/protein_calls/include/protein_calls/Interpol.h
+++ b/plugins/protein_calls/include/protein_calls/Interpol.h
@@ -187,12 +187,12 @@ inline T SampleFieldAtPosTrilin(float pos[3], T* field, float gridOrg[3], float 
     f[0] = (pos[0] - gridOrg[0]) / gridDelta[0];
     f[1] = (pos[1] - gridOrg[1]) / gridDelta[1];
     f[2] = (pos[2] - gridOrg[2]) / gridDelta[2];
-    c[0] = (int)(f[0]);
-    c[1] = (int)(f[1]);
-    c[2] = (int)(f[2]);
-    f[0] = f[0] - (float)c[0]; // alpha
-    f[1] = f[1] - (float)c[1]; // beta
-    f[2] = f[2] - (float)c[2]; // gamma
+    c[0] = (int) (f[0]);
+    c[1] = (int) (f[1]);
+    c[2] = (int) (f[2]);
+    f[0] = f[0] - (float) c[0]; // alpha
+    f[1] = f[1] - (float) c[1]; // beta
+    f[2] = f[2] - (float) c[2]; // gamma
 
     c[0] = std::min(std::max(c[0], int(0)), gridSize[0] - 2);
     c[1] = std::min(std::max(c[1], int(0)), gridSize[1] - 2);

--- a/plugins/protein_calls/include/protein_calls/VTKImageData.h
+++ b/plugins/protein_calls/include/protein_calls/VTKImageData.h
@@ -402,7 +402,7 @@ public:
          * @return The number of data arrays.
          */
         unsigned int GetArrayCnt() {
-            return (unsigned int)this->dataArrays.Count();
+            return (unsigned int) this->dataArrays.Count();
         }
 
         /**

--- a/plugins/protein_cuda/src/ComparativeMolSurfaceRenderer.cpp
+++ b/plugins/protein_cuda/src/ComparativeMolSurfaceRenderer.cpp
@@ -644,9 +644,9 @@ bool ComparativeMolSurfaceRenderer::computeDensityMap(
     gridXAxisLen = this->volMaxC.x - this->volOrg.x;
     gridYAxisLen = this->volMaxC.y - this->volOrg.y;
     gridZAxisLen = this->volMaxC.z - this->volOrg.z;
-    this->volDim.x = (int)ceil(gridXAxisLen / this->qsGridDelta);
-    this->volDim.y = (int)ceil(gridYAxisLen / this->qsGridDelta);
-    this->volDim.z = (int)ceil(gridZAxisLen / this->qsGridDelta);
+    this->volDim.x = (int) ceil(gridXAxisLen / this->qsGridDelta);
+    this->volDim.y = (int) ceil(gridYAxisLen / this->qsGridDelta);
+    this->volDim.z = (int) ceil(gridZAxisLen / this->qsGridDelta);
     gridXAxisLen = (this->volDim.x - 1) * this->qsGridDelta;
     gridYAxisLen = (this->volDim.y - 1) * this->qsGridDelta;
     gridZAxisLen = (this->volDim.z - 1) * this->qsGridDelta;
@@ -683,7 +683,7 @@ bool ComparativeMolSurfaceRenderer::computeDensityMap(
     int rc = cqs->calc_map(mol->AtomCount(), &this->gridDataPos.Peek()[0],
         NULL,  // Pointer to 'color' array
         false, // Do not use 'color' array
-        CUDAQuickSurf::VolTexFormat::RGB3F, (float*)&this->volOrg, (int*)&this->volDim, this->maxAtomRad,
+        CUDAQuickSurf::VolTexFormat::RGB3F, (float*) &this->volOrg, (int*) &this->volDim, this->maxAtomRad,
         this->qsRadScl, // Radius scaling
         this->qsGridDelta, this->qsIsoVal, this->qsGaussLim, false);
 
@@ -855,23 +855,25 @@ bool ComparativeMolSurfaceRenderer::fitMoleculeRMS(MolecularDataCall* mol1, Mole
                 for (uint acid = 0; acid < mol1->SecondaryStructures()[sec].AminoAcidCount(); ++acid) {
 
                     uint cAlphaIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol1->Residues()[mol1->SecondaryStructures()[sec]
-                                                                                    .FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol1->Residues()[mol1->SecondaryStructures()[sec]
+                                                                                     .FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->CAlphaIndex();
                     uint cCarbIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol1->Residues()[mol1->SecondaryStructures()[sec]
-                                                                                    .FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol1->Residues()[mol1->SecondaryStructures()[sec]
+                                                                                     .FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->CCarbIndex();
-                    uint nIdx = ((const MolecularDataCall::AminoAcid*)(mol1->Residues()[mol1->SecondaryStructures()[sec]
-                                                                                            .FirstAminoAcidIndex() +
-                                                                                        acid]))
-                                    ->NIndex();
-                    uint oIdx = ((const MolecularDataCall::AminoAcid*)(mol1->Residues()[mol1->SecondaryStructures()[sec]
-                                                                                            .FirstAminoAcidIndex() +
-                                                                                        acid]))
-                                    ->OIndex();
+                    uint nIdx =
+                        ((const MolecularDataCall::AminoAcid*) (mol1->Residues()[mol1->SecondaryStructures()[sec]
+                                                                                     .FirstAminoAcidIndex() +
+                                                                                 acid]))
+                            ->NIndex();
+                    uint oIdx =
+                        ((const MolecularDataCall::AminoAcid*) (mol1->Residues()[mol1->SecondaryStructures()[sec]
+                                                                                     .FirstAminoAcidIndex() +
+                                                                                 acid]))
+                            ->OIndex();
 
                     //                    printf("c alpha idx %u, cCarbIdx %u, o idx %u, n idx %u\n",
                     //                            cAlphaIdx, cCarbIdx, oIdx, nIdx); // DEBUG
@@ -893,20 +895,20 @@ bool ComparativeMolSurfaceRenderer::fitMoleculeRMS(MolecularDataCall* mol1, Mole
                 for (uint acid = 0; acid < secStructure.AminoAcidCount(); ++acid) {
 
                     uint cAlphaIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol2->Residues()[secStructure.FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol2->Residues()[secStructure.FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->CAlphaIndex();
                     uint cCarbIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol2->Residues()[secStructure.FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol2->Residues()[secStructure.FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->CCarbIndex();
                     uint nIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol2->Residues()[secStructure.FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol2->Residues()[secStructure.FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->NIndex();
                     uint oIdx =
-                        ((const MolecularDataCall::AminoAcid*)(mol2->Residues()[secStructure.FirstAminoAcidIndex() +
-                                                                                acid]))
+                        ((const MolecularDataCall::AminoAcid*) (mol2->Residues()[secStructure.FirstAminoAcidIndex() +
+                                                                                 acid]))
                             ->OIndex();
                     //                    printf("amino acid idx %u, c alpha idx %u, cCarbIdx %u, o idx %u, n idx %u\n", secStructure.
                     //                            FirstAminoAcidIndex()+acid, cAlphaIdx, cCarbIdx, oIdx, nIdx);
@@ -982,7 +984,7 @@ atoms instead.",
             for (size_t res = 0; res < mol1->ResidueCount(); ++res) {
                 const MolecularDataCall::Residue* residue = mol1->Residues()[res];
                 if (residue->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-                    uint cAlphaIdx = ((const MolecularDataCall::AminoAcid*)(residue))->CAlphaIndex();
+                    uint cAlphaIdx = ((const MolecularDataCall::AminoAcid*) (residue))->CAlphaIndex();
                     this->rmsPosVec1[posCnt1] = glm::make_vec3(&mol1->AtomPositions()[3 * cAlphaIdx]);
                     //                    printf("ADDING ATOM POS 1 %f %f %f\n",
                     //                            this->rmsPosVec1.Peek()[3*posCnt1+0],
@@ -1018,7 +1020,7 @@ atoms instead.",
             for (size_t res = 0; res < mol2->ResidueCount(); ++res) {
                 const MolecularDataCall::Residue* residue = mol2->Residues()[res];
                 if (residue->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-                    uint cAlphaIdx = ((const MolecularDataCall::AminoAcid*)(residue))->CAlphaIndex();
+                    uint cAlphaIdx = ((const MolecularDataCall::AminoAcid*) (residue))->CAlphaIndex();
                     this->rmsPosVec2[posCnt2] = glm::make_vec3(&mol2->AtomPositions()[3 * cAlphaIdx]);
                     //                    printf("ADDING ATOM POS 2 %f %f %f\n",
                     //                            this->rmsPosVec2.Peek()[3*posCnt2+0],
@@ -1533,11 +1535,11 @@ bool ComparativeMolSurfaceRenderer::initPotentialMap(VTIDataCall* cmd, gridParam
  */
 void ComparativeMolSurfaceRenderer::release(void) {
     if (this->cudaqsurf1 != NULL) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf1;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf1;
         delete cqs;
     }
     if (this->cudaqsurf2 != NULL) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf2;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf2;
         delete cqs;
     }
     this->deformSurf1.Release();
@@ -1705,14 +1707,14 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
     // (Re-)compute volume texture if necessary
     if (this->triggerComputeVolume) {
 
-        if (!this->computeDensityMap(mol1->AtomPositions(), mol1, (CUDAQuickSurf*)this->cudaqsurf1)) {
+        if (!this->computeDensityMap(mol1->AtomPositions(), mol1, (CUDAQuickSurf*) this->cudaqsurf1)) {
 
             Log::DefaultLog.WriteError("%s: could not compute density map #1", this->ClassName());
 
             return false;
         }
 
-        if (!this->computeDensityMap(this->atomPosFitted.Peek(), mol2, (CUDAQuickSurf*)this->cudaqsurf2)) {
+        if (!this->computeDensityMap(this->atomPosFitted.Peek(), mol2, (CUDAQuickSurf*) this->cudaqsurf2)) {
 
             Log::DefaultLog.WriteError("%s: could not compute density map #2", this->ClassName());
 
@@ -1780,7 +1782,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Get vertex positions based on the level set
         if (!this->deformSurf1.ComputeVertexPositions(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1814,7 +1816,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Build triangle mesh from vertices
         if (!this->deformSurf1.ComputeTriangles(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1833,7 +1835,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Compute vertex connectivity
         if (!this->deformSurf1.ComputeConnectivity(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1852,7 +1854,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Regularize the mesh of surface #1
         if (!this->deformSurf1.MorphToVolumeGradient(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1873,7 +1875,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Compute vertex normals
         if (!this->deformSurf1.ComputeNormals(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1911,7 +1913,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Get vertex positions based on the level set
         if (!this->deformSurf2.ComputeVertexPositions(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1928,7 +1930,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Build triangle mesh from vertices
         if (!this->deformSurf2.ComputeTriangles(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1945,7 +1947,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Compute vertex connectivity
         if (!this->deformSurf2.ComputeConnectivity(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1958,7 +1960,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
         if (!this->deformSurf2.ComputeTriangleNeighbors(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1971,7 +1973,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Compute edge list (this needs to be done before any deformation happens
         if (!this->deformSurf2.ComputeEdgeList(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -1988,7 +1990,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Regularize the mesh of surface #2
         if (!this->deformSurf2.MorphToVolumeGradient(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -2011,7 +2013,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         // Compute vertex normals
         if (!this->deformSurf2.ComputeNormals(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -2059,18 +2061,18 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
             // Morph surface #2 to shape #1 using GVF
             if (!this->deformSurfMapped.MorphToVolumeGVF(
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
                     this->deformSurf1.PeekCubeStates(), this->volDim, this->volOrg, this->volDelta, this->qsIsoVal,
                     this->interpolMode,
-                    ((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt),
+                    ((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt),
                     this->surfMappedMinDisplScl, this->surfMappedSpringStiffness, this->surfaceMappingForcesScl,
                     this->surfaceMappingExternalForcesWeightScl, this->surfMappedGVFScl, this->surfMappedGVFIt)) {
 
@@ -2086,12 +2088,12 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
             // Morph surface #2 to shape #1 using implicit molecular surface
             if (!this->deformSurfMapped.MorphToVolumeGradient(
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
                     this->volDim, this->volOrg, this->volDelta, this->qsIsoVal, this->interpolMode,
-                    ((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt),
+                    ((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt),
                     this->surfMappedMinDisplScl, this->surfMappedSpringStiffness, this->surfaceMappingForcesScl,
                     this->surfaceMappingExternalForcesWeightScl)) {
 
@@ -2107,12 +2109,12 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
             // Morph surface #2 to shape #1 using implicit molecular surface + distance field
             if (!this->deformSurfMapped.MorphToVolumeDistfield(
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
                     this->volDim, this->volOrg, this->volDelta, this->qsIsoVal, this->interpolMode,
-                    ((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt),
+                    ((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt),
                     this->surfMappedMinDisplScl, this->surfMappedSpringStiffness, this->surfaceMappingForcesScl,
                     this->surfaceMappingExternalForcesWeightScl, this->distFieldThresh)) {
 
@@ -2150,18 +2152,18 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
             if (!this->deformSurfMapped.MorphToVolumeTwoWayGVF(
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
                     this->deformSurf2.PeekCubeStates(), this->deformSurf1.PeekCubeStates(), this->volDim, this->volOrg,
                     this->volDelta, this->qsIsoVal, this->interpolMode,
-                    ((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt),
+                    ((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt),
                     this->surfMappedMinDisplScl, this->surfMappedSpringStiffness, this->surfaceMappingForcesScl,
                     this->surfaceMappingExternalForcesWeightScl, this->surfMappedGVFScl, this->surfMappedGVFIt, true,
                     true)) {
@@ -2188,7 +2190,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 #endif // VERBOSE
         // Perform subdivision with subsequent deformation to create a fine
         // target mesh enough
-        if (((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt) > 0) {
+        if (((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt) > 0) {
             int newTris;
             for (int i = 0; i < this->maxSubdivLevel; ++i) {
                 for (int j = 0; j < this->subStepLevel; ++j) {
@@ -2197,7 +2199,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
                     newTris = this->deformSurfMapped.RefineMesh(1,
 #ifndef USE_PROCEDURAL_DATA
-                        ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                        ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                         this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -2219,12 +2221,12 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                     // Morph surface #2 to shape #1 using Two-Way-GVF
                     if (!this->deformSurfMapped.MorphToVolumeTwoWayGVFSubdiv(
 #ifndef USE_PROCEDURAL_DATA
-                            ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                            ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                             this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
 #ifndef USE_PROCEDURAL_DATA
-                            ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                            ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                             this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -2244,7 +2246,7 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
         if (!this->deformSurfMapped.FlagCorruptTriangles(
 #ifndef USE_PROCEDURAL_DATA
-                ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+                ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                 this->procField1D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
@@ -2271,13 +2273,13 @@ bool ComparativeMolSurfaceRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         if (this->maxSubdivLevel > 0) {
             if (!this->deformSurfMapped.TrackPathSubdivVertices(
 #ifndef USE_PROCEDURAL_DATA
-                    ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+                    ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
 #else  //  USE_PROCEDURAL_DATA
                     this->procField2D.Peek(),
 #endif //  USE_PROCEDURAL_DATA
                     this->volDim, this->volOrg, this->volDelta, this->surfaceMappingForcesScl,
                     this->surfMappedMinDisplScl, this->qsIsoVal,
-                    ((this->cmpMode == COMPARE_1_MORPH) ? (int)(calltime) : this->surfaceMappingMaxIt))) {
+                    ((this->cmpMode == COMPARE_1_MORPH) ? (int) (calltime) : this->surfaceMappingMaxIt))) {
                 return false;
             }
         }
@@ -3701,12 +3703,12 @@ bool ComparativeMolSurfaceRenderer::initProcFieldData() {
     testField2.Set(0x00);
 
     // Copy to device array
-    if (!CudaSafeCall(cudaMemcpy(testField1.Peek(), ((CUDAQuickSurf*)this->cudaqsurf1)->getMap(),
+    if (!CudaSafeCall(cudaMemcpy(testField1.Peek(), ((CUDAQuickSurf*) this->cudaqsurf1)->getMap(),
             sizeof(float) * fieldSize, cudaMemcpyDeviceToHost))) {
         return false;
     }
     // Copy to device array
-    if (!CudaSafeCall(cudaMemcpy(testField2.Peek(), ((CUDAQuickSurf*)this->cudaqsurf2)->getMap(),
+    if (!CudaSafeCall(cudaMemcpy(testField2.Peek(), ((CUDAQuickSurf*) this->cudaqsurf2)->getMap(),
             sizeof(float) * fieldSize, cudaMemcpyDeviceToHost))) {
         return false;
     }

--- a/plugins/protein_cuda/src/CrystalStructureVolumeRenderer.cpp
+++ b/plugins/protein_cuda/src/CrystalStructureVolumeRenderer.cpp
@@ -631,9 +631,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
         gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
         gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-        gridDim[0] = (int)ceil(gridXAxis[0] / this->densGridSpacing);
-        gridDim[1] = (int)ceil(gridYAxis[1] / this->densGridSpacing);
-        gridDim[2] = (int)ceil(gridZAxis[2] / this->densGridSpacing);
+        gridDim[0] = (int) ceil(gridXAxis[0] / this->densGridSpacing);
+        gridDim[1] = (int) ceil(gridYAxis[1] / this->densGridSpacing);
+        gridDim[2] = (int) ceil(gridZAxis[2] / this->densGridSpacing);
         gridXAxis[0] = (gridDim[0] - 1) * this->densGridSpacing;
         gridYAxis[1] = (gridDim[1] - 1) * this->densGridSpacing;
         gridZAxis[2] = (gridDim[2] - 1) * this->densGridSpacing;
@@ -758,7 +758,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         //        printf("Vectors contained in density tex %u\n", dipole_cnt);
 
         // Compute uniform grid containing density map of the vectors
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
         int rc = cqs->calc_map(static_cast<long>(gridPos.Count() / 4), gridPos.PeekElements(), gridCol.PeekElements(),
             true, // Use 'color' array
@@ -779,7 +779,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         // Setup texture
 
         this->uniGridDensity.MemCpyFromDevice(cqs->getMap());
-        this->uniGridColor.MemCpyFromDevice((float3*)cqs->getColorMap());
+        this->uniGridColor.MemCpyFromDevice((float3*) cqs->getColorMap());
 
         /*for(int x = 0; x < gridDim.X(); x++) {
             for(int y = 0; y < gridDim.Y(); y++) {
@@ -858,9 +858,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -887,10 +887,10 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
     // Allocate device memory if necessary
 
     if (this->gridCurlD == NULL) {
-        checkCudaErrors(cudaMalloc((void**)&this->gridCurlD, sizeof(float) * nVoxels * 3));
+        checkCudaErrors(cudaMalloc((void**) &this->gridCurlD, sizeof(float) * nVoxels * 3));
     }
     if (this->gridCurlMagD == NULL) {
-        checkCudaErrors(cudaMalloc((void**)&this->gridCurlMagD, sizeof(float) * nVoxels));
+        checkCudaErrors(cudaMalloc((void**) &this->gridCurlMagD, sizeof(float) * nVoxels));
     }
 
     // Copy grid parameters to constant device memory
@@ -928,7 +928,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
 
     // Compute curl magnitude
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
     cudaErr = protein_cuda::CudaGetCurlMagnitude(
         cqs->getColorMap(), this->gridCurlD, this->gridCurlMagD, nVoxels, this->gridSpacing);
@@ -1008,9 +1008,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -1080,7 +1080,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
 
     // Compute uniform grid (vector field and density map)
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     int rc = cqs->calc_map(dataCnt, &gridDataPos[0], &gridData[0],
         true, // Use seperate 'color' array
         CUDAQuickSurf::VolTexFormat::RGB3F, gridOrg.PeekComponents(), gridDim.PeekComponents(),
@@ -1099,7 +1099,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
 
     // Copy data from device to host
 
-    this->uniGridVecField.MemCpyFromDevice((float3*)(cqs->getColorMap()));
+    this->uniGridVecField.MemCpyFromDevice((float3*) (cqs->getColorMap()));
 
     // DEBUG
     /*for(int x = 0; x < this->uniGridVecField.GetGridDim().X(); x++) {
@@ -1253,7 +1253,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::create(void) {
     using namespace vislib_gl::graphics::gl;
 
     // Init random number generator
-    srand((unsigned)time(0));
+    srand((unsigned) time(0));
 
     // Create quicksurf object
     if (!this->cudaqsurf) {
@@ -1442,9 +1442,9 @@ void protein_cuda::CrystalStructureVolumeRenderer::FilterVecField(
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -1590,7 +1590,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::InitLIC() {
     for (int x = 0; x < this->licRandBuffSize; x++) {
         for (int y = 0; y < this->licRandBuffSize; y++) {
             for (int z = 0; z < this->licRandBuffSize; z++) {
-                float randVal = (float)rand() / float(RAND_MAX);
+                float randVal = (float) rand() / float(RAND_MAX);
                 /*if(randVal > 0.5f)
                     this->licRandBuff.SetAt(x, y, z, 1.0f);
                 else
@@ -1644,7 +1644,7 @@ void protein_cuda::CrystalStructureVolumeRenderer::release(void) {
     this->rcShaderDebug.reset();
     this->pplShader.reset();
     if (this->cudaqsurf != NULL) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         delete cqs;
     }
 }
@@ -1919,9 +1919,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::Render(mmstd_gl::CallRender3D
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -2814,9 +2814,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::RenderIsoSurfMC() {
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->densGridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->densGridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->densGridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->densGridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->densGridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->densGridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->densGridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->densGridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->densGridSpacing;
@@ -2879,14 +2879,14 @@ bool protein_cuda::CrystalStructureVolumeRenderer::RenderIsoSurfMC() {
         if (this->mcNormOut != NULL)
             delete[] this->mcNormOut;
         // Allocate memory
-        checkCudaErrors(cudaMalloc((void**)&this->mcVertOut_D, nVerticesMC * sizeof(float3)));
-        checkCudaErrors(cudaMalloc((void**)&this->mcNormOut_D, nVerticesMC * sizeof(float3)));
+        checkCudaErrors(cudaMalloc((void**) &this->mcVertOut_D, nVerticesMC * sizeof(float3)));
+        checkCudaErrors(cudaMalloc((void**) &this->mcNormOut_D, nVerticesMC * sizeof(float3)));
         this->mcVertOut = new float[nVerticesMC * 3];
         this->mcNormOut = new float[nVerticesMC * 3];
         printf("(Re)allocating of memory done.");
     }
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
     // Setup
     if (!this->cudaMC->Initialize(gridDimAlt)) {
@@ -2894,12 +2894,12 @@ bool protein_cuda::CrystalStructureVolumeRenderer::RenderIsoSurfMC() {
     }
     if (!this->cudaMC->SetVolumeData(
             //this->gridCurlMagD,
-            cqs->getMap(), (float3*)nullptr, gridDimAlt, gridOrgAlt, gridBBox, true)) {
+            cqs->getMap(), (float3*) nullptr, gridDimAlt, gridOrgAlt, gridBBox, true)) {
         return false;
     }
     this->cudaMC->SetSubVolume(subVolStart, subVolEnd);
     this->cudaMC->SetIsovalue(this->volIsoVal);
-    this->cudaMC->computeIsosurface(this->mcVertOut_D, this->mcNormOut_D, (float3*)nullptr, nVerticesMC);
+    this->cudaMC->computeIsosurface(this->mcVertOut_D, this->mcNormOut_D, (float3*) nullptr, nVerticesMC);
     this->cudaMC->Cleanup();
 
     //printf("Number of vertices %u\n", this->cudaMC->GetVertexCount());
@@ -3267,7 +3267,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::SetupAtomColors(const protein
 
     this->atomColor.SetCount(dc->GetAtomCnt() * 3);
 #pragma omp parallel for
-    for (int at = 0; at < (int)dc->GetAtomCnt(); at++) {
+    for (int at = 0; at < (int) dc->GetAtomCnt(); at++) {
         if (dc->GetAtomType()[at] == protein_calls::CrystalStructureDataCall::BA) { // Green
             this->atomColor[at * 3 + 0] = 0.0f;
             this->atomColor[at * 3 + 1] = 0.6f;

--- a/plugins/protein_cuda/src/CudaDevArr.h
+++ b/plugins/protein_cuda/src/CudaDevArr.h
@@ -88,7 +88,7 @@ public:
      */
     inline cudaError_t Release() {
         if (this->pt_D != NULL) {
-            CudaSafeCall(cudaFree((void*)(this->pt_D)));
+            CudaSafeCall(cudaFree((void*) (this->pt_D)));
         }
         this->size = 0;
         this->count = 0;
@@ -118,7 +118,7 @@ public:
 
         if ((this->pt_D == NULL) || (sizeNew > this->size)) {
             this->Release();
-            CudaSafeCall(cudaMalloc((void**)&this->pt_D, sizeof(T) * sizeNew));
+            CudaSafeCall(cudaMalloc((void**) &this->pt_D, sizeof(T) * sizeNew));
             //            printf("Allocated at %p\n", &this->pt_D);
             this->size = sizeNew;
         }

--- a/plugins/protein_cuda/src/DataWriter.cpp
+++ b/plugins/protein_cuda/src/DataWriter.cpp
@@ -158,9 +158,9 @@ bool protein_cuda::DataWriter::PutStatistics(unsigned int frameIdx0, unsigned in
     this->xaxis[0] = maxcoord[0] - mincoord[0];
     this->yaxis[1] = maxcoord[1] - mincoord[1];
     this->zaxis[2] = maxcoord[2] - mincoord[2];
-    this->numvoxels[0] = (int)ceil(this->xaxis[0] / gridspacing);
-    this->numvoxels[1] = (int)ceil(this->yaxis[1] / gridspacing);
-    this->numvoxels[2] = (int)ceil(this->zaxis[2] / gridspacing);
+    this->numvoxels[0] = (int) ceil(this->xaxis[0] / gridspacing);
+    this->numvoxels[1] = (int) ceil(this->yaxis[1] / gridspacing);
+    this->numvoxels[2] = (int) ceil(this->zaxis[2] / gridspacing);
     this->xaxis[0] = (this->numvoxels[0] - 1) * gridspacing;
     this->yaxis[1] = (this->numvoxels[1] - 1) * gridspacing;
     this->zaxis[2] = (this->numvoxels[2] - 1) * gridspacing;
@@ -202,7 +202,7 @@ bool protein_cuda::DataWriter::PutStatistics(unsigned int frameIdx0, unsigned in
         }
 
         // Copy data from device to host
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         checkCudaErrors(cudaMemcpy(griddata, cqs->getColorMap(),
             this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] * 3 * sizeof(float), cudaMemcpyDeviceToHost));
 
@@ -373,9 +373,9 @@ bool protein_cuda::DataWriter::WriteDipoleToVTI(unsigned int frameIdx0, unsigned
     this->xaxis[0] = maxcoord[0] - mincoord[0];
     this->yaxis[1] = maxcoord[1] - mincoord[1];
     this->zaxis[2] = maxcoord[2] - mincoord[2];
-    this->numvoxels[0] = (int)ceil(this->xaxis[0] / gridspacing);
-    this->numvoxels[1] = (int)ceil(this->yaxis[1] / gridspacing);
-    this->numvoxels[2] = (int)ceil(this->zaxis[2] / gridspacing);
+    this->numvoxels[0] = (int) ceil(this->xaxis[0] / gridspacing);
+    this->numvoxels[1] = (int) ceil(this->yaxis[1] / gridspacing);
+    this->numvoxels[2] = (int) ceil(this->zaxis[2] / gridspacing);
     this->xaxis[0] = (this->numvoxels[0] - 1) * gridspacing;
     this->yaxis[1] = (this->numvoxels[1] - 1) * gridspacing;
     this->zaxis[2] = (this->numvoxels[2] - 1) * gridspacing;
@@ -404,7 +404,7 @@ bool protein_cuda::DataWriter::WriteDipoleToVTI(unsigned int frameIdx0, unsigned
 
         // Copy data from device to host
 
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         checkCudaErrors(cudaMemcpy(griddata, cqs->getColorMap(),
             this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] * 3 * sizeof(float), cudaMemcpyDeviceToHost));
 
@@ -459,9 +459,9 @@ bool protein_cuda::DataWriter::WriteTiDisplVTI(unsigned int frameIdx0, unsigned 
     this->xaxis[0] = maxcoord[0] - mincoord[0];
     this->yaxis[1] = maxcoord[1] - mincoord[1];
     this->zaxis[2] = maxcoord[2] - mincoord[2];
-    this->numvoxels[0] = (int)ceil(this->xaxis[0] / gridspacing);
-    this->numvoxels[1] = (int)ceil(this->yaxis[1] / gridspacing);
-    this->numvoxels[2] = (int)ceil(this->zaxis[2] / gridspacing);
+    this->numvoxels[0] = (int) ceil(this->xaxis[0] / gridspacing);
+    this->numvoxels[1] = (int) ceil(this->yaxis[1] / gridspacing);
+    this->numvoxels[2] = (int) ceil(this->zaxis[2] / gridspacing);
     this->xaxis[0] = (this->numvoxels[0] - 1) * gridspacing;
     this->yaxis[1] = (this->numvoxels[1] - 1) * gridspacing;
     this->zaxis[2] = (this->numvoxels[2] - 1) * gridspacing;
@@ -490,7 +490,7 @@ bool protein_cuda::DataWriter::WriteTiDisplVTI(unsigned int frameIdx0, unsigned 
 
         // Copy data from device to host
 
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         checkCudaErrors(cudaMemcpy(griddata, cqs->getColorMap(),
             this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] * 3 * sizeof(float), cudaMemcpyDeviceToHost));
 
@@ -523,8 +523,8 @@ bool protein_cuda::DataWriter::CalcMapDipoleAvg(protein_calls::CrystalStructureD
 
     float* xyzr = NULL;
     float* color = NULL;
-    xyzr = (float*)malloc(dc->GetCellCnt() * sizeof(float) * 4);
-    color = (float*)malloc(dc->GetCellCnt() * sizeof(float) * 4);
+    xyzr = (float*) malloc(dc->GetCellCnt() * sizeof(float) * 4);
+    color = (float*) malloc(dc->GetCellCnt() * sizeof(float) * 4);
     if (this->frameData0 == NULL) {
         this->frameData0 = new float[dc->GetAtomCnt() * 7];
     }
@@ -660,7 +660,7 @@ bool protein_cuda::DataWriter::CalcMapDipoleAvg(protein_calls::CrystalStructureD
     //} // DEBUG
 
     // compute both density map and floating point color texture map
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     int rc = cqs->calc_map(dc->GetCellCnt(), &xyzr[0], &color[0], true, CUDAQuickSurf::VolTexFormat::RGB3F,
         this->origin, this->numvoxels,
         2.5f, // Max radius
@@ -688,7 +688,7 @@ bool protein_cuda::DataWriter::CalcMapTiDisplAvg(protein_calls::CrystalStructure
     float radscale, float gridspacing, float isoval) {
 
     float* xyzr = NULL;
-    xyzr = (float*)malloc(dc->GetCellCnt() * sizeof(float) * 4);
+    xyzr = (float*) malloc(dc->GetCellCnt() * sizeof(float) * 4);
     if (this->frameData0 == NULL) {
         this->frameData0 = new float[dc->GetAtomCnt() * 7];
     }
@@ -786,7 +786,7 @@ bool protein_cuda::DataWriter::CalcMapTiDisplAvg(protein_calls::CrystalStructure
 
 
     // compute both density map and floating point color texture map
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     int rc = cqs->calc_map(dc->GetCellCnt(), &xyzr[0], &this->addedTiDispl[0], true, CUDAQuickSurf::VolTexFormat::RGB3F,
         this->origin, this->numvoxels,
         2.5f, // Max radius
@@ -874,7 +874,7 @@ void protein_cuda::DataWriter::release(void) {
     if (this->addedPos != NULL)
         delete[] this->addedPos;
     if (this->cudaqsurf) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         delete cqs;
     }
 }
@@ -909,7 +909,7 @@ bool protein_cuda::DataWriter::writeFrame2VTKLegacy(
             << std::endl; // TODO Don't hardcode this
     outfile << "POINT_DATA " << this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] << std::endl;
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     float* testArr = new float[this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] * 3];
     checkCudaErrors(cudaMemcpy(testArr, cqs->getColorMap(),
         this->numvoxels[0] * this->numvoxels[1] * this->numvoxels[2] * 3 * sizeof(float), cudaMemcpyDeviceToHost));
@@ -1335,7 +1335,7 @@ bool protein_cuda::DataWriter::WriteFrameFileBinAvg(protein_calls::CrystalStruct
         }
         dc->Unlock();
     }
-    outStr.write((char*)(buff), NATOMS * 3 * sizeof(float));
+    outStr.write((char*) (buff), NATOMS * 3 * sizeof(float));
 
     for (unsigned int w = 1; w + avgOffset - 1 < dc->FrameCount(); w++) {
 
@@ -1369,7 +1369,7 @@ bool protein_cuda::DataWriter::WriteFrameFileBinAvg(protein_calls::CrystalStruct
         }
         dc->Unlock();
 
-        outStr.write((char*)(buff), NATOMS * 3 * sizeof(float)); // Write to file
+        outStr.write((char*) (buff), NATOMS * 3 * sizeof(float)); // Write to file
     }
 
     delete[] buff;
@@ -1458,7 +1458,7 @@ bool protein_cuda::DataWriter::ReadTiDispl(protein_calls::CrystalStructureDataCa
     float* buff = new float[dc->GetCellCnt() * 6];
     unsigned int frame = 0;
     while (inStr.good()) {
-        inStr.read((char*)buff, dc->GetCellCnt() * 24);
+        inStr.read((char*) buff, dc->GetCellCnt() * 24);
         for (int cnt = 0; cnt < 125000; cnt++) {
             printf("FRAME %u pos %f %f %f vec %f %f %f\n", frame, buff[cnt * 6 + 0], buff[cnt * 6 + 1],
                 buff[cnt * 6 + 2], buff[cnt * 6 + 3], buff[cnt * 6 + 4], buff[cnt * 6 + 5]);
@@ -1495,7 +1495,7 @@ bool protein_cuda::DataWriter::ReadTiODipole(protein_calls::CrystalStructureData
     float* buff = new float[dc->GetCellCnt() * 6];
     unsigned int frame = 0;
     while (inStr.good()) {
-        inStr.read((char*)buff, dc->GetCellCnt() * 24);
+        inStr.read((char*) buff, dc->GetCellCnt() * 24);
         for (int cnt = 0; cnt <= 124999; cnt++) {
             printf("FRAME %u pos %f %f %f vec %f %f %f\n", frame, buff[cnt * 6 + 0], buff[cnt * 6 + 1],
                 buff[cnt * 6 + 2], buff[cnt * 6 + 3], buff[cnt * 6 + 4], buff[cnt * 6 + 5]);
@@ -1635,7 +1635,7 @@ bool protein_cuda::DataWriter::WriteTiDispl(protein_calls::CrystalStructureDataC
             break;
         }
 
-        for (int cnt = 0; cnt < (int)dc->GetCellCnt(); cnt++) {
+        for (int cnt = 0; cnt < (int) dc->GetCellCnt(); cnt++) {
             buff[cnt * 6 + 0] = dc->GetAtomPos()[3 * dc->GetCells()[idxSorted[cnt]] + 0];
             buff[cnt * 6 + 1] = dc->GetAtomPos()[3 * dc->GetCells()[idxSorted[cnt]] + 1];
             buff[cnt * 6 + 2] = dc->GetAtomPos()[3 * dc->GetCells()[idxSorted[cnt]] + 2];
@@ -1646,7 +1646,7 @@ bool protein_cuda::DataWriter::WriteTiDispl(protein_calls::CrystalStructureDataC
 
         dc->Unlock();
         printf("Writing frame %u ...\n", fr);
-        outStr.write((char*)buff, 24 * dc->GetCellCnt());
+        outStr.write((char*) buff, 24 * dc->GetCellCnt());
     }
     outStr.close();
 
@@ -1842,7 +1842,7 @@ bool protein_cuda::DataWriter::WriteTiODipole(protein_calls::CrystalStructureDat
         }
 
 #pragma omp parallel for
-        for (int cnt = 0; cnt < (int)dc->GetCellCnt(); cnt++) {
+        for (int cnt = 0; cnt < (int) dc->GetCellCnt(); cnt++) {
             buff[cnt * 6 + 0] = dc->GetAtomPos()[3 * dc->GetCells()[15 * idxSorted[cnt] + 14] + 0];
             buff[cnt * 6 + 1] = dc->GetAtomPos()[3 * dc->GetCells()[15 * idxSorted[cnt] + 14] + 1];
             buff[cnt * 6 + 2] = dc->GetAtomPos()[3 * dc->GetCells()[15 * idxSorted[cnt] + 14] + 2];
@@ -1855,7 +1855,7 @@ bool protein_cuda::DataWriter::WriteTiODipole(protein_calls::CrystalStructureDat
 
         dc->Unlock();
         printf("Writing frame %u ...\n", fr);
-        outStr.write((char*)buff, 24 * dc->GetCellCnt());
+        outStr.write((char*) buff, 24 * dc->GetCellCnt());
     }
     outStr.close();
 
@@ -1896,14 +1896,14 @@ void protein_cuda::DataWriter::PutVelocity() {
 
     // Get atom info
     int* atomInfo = new int[7 * 625000];
-    atomTypesStr.read((char*)atomInfo, 625000 * 28);
+    atomTypesStr.read((char*) atomInfo, 625000 * 28);
     atomTypesStr.close();
 
     // Loop through all frames
     float* buff = new float[625000 * 3];
     unsigned int frame = 0;
     while (inStr.good()) {
-        inStr.read((char*)buff, 625000 * 12);
+        inStr.read((char*) buff, 625000 * 12);
 
         float avgMag = 0.0;
         unsigned int avgCnt = 0;

--- a/plugins/protein_cuda/src/HostArr.h
+++ b/plugins/protein_cuda/src/HostArr.h
@@ -82,7 +82,7 @@ public:
      * @param c The byte value
      */
     void Set(char c) {
-        memset((char*)(this->pt), c, this->GetSize() * sizeof(T));
+        memset((char*) (this->pt), c, this->GetSize() * sizeof(T));
     }
 
     /**
@@ -95,7 +95,7 @@ public:
         if ((this->pt == nullptr) || (sizeNew > this->size)) {
             this->Release();
             //this->pt = new T[sizeNew];
-            this->pt = (T*)malloc(sizeNew * sizeof(T));
+            this->pt = (T*) malloc(sizeNew * sizeof(T));
             this->size = sizeNew;
         }
         this->count = sizeNew;

--- a/plugins/protein_cuda/src/Inform.cpp
+++ b/plugins/protein_cuda/src/Inform.cpp
@@ -181,7 +181,7 @@ Inform& Inform::operator<<(double d) {
     return *this;
 }
 
-Inform& Inform::operator<<(Inform& (*f)(Inform&)) {
+Inform& Inform::operator<<(Inform& (*f)(Inform&) ) {
     return f(*this);
 }
 

--- a/plugins/protein_cuda/src/Inform.h
+++ b/plugins/protein_cuda/src/Inform.h
@@ -67,7 +67,7 @@ public:
 #endif
 
     Inform& operator<<(double);
-    Inform& operator<<(Inform& (*f)(Inform&));
+    Inform& operator<<(Inform& (*f)(Inform&) );
 
     void mute() {
         muted = 1;

--- a/plugins/protein_cuda/src/LIC.cpp
+++ b/plugins/protein_cuda/src/LIC.cpp
@@ -37,7 +37,7 @@ bool protein_cuda::LIC::CalcLicX(UniGrid3D<float3>& grid, UniGrid3D<float>& rand
                                                                       (grid.GetGridDim().X() * grid.GetGridStepSize()) *
                                                                       grid.GetGridDim().X());
     //printf("Grid x coord in unigrid space %i\n", gridCoordX); // DEBUG
-    gridCoordX *= static_cast<int>((float)(licDim.X()) / (float)(grid.GetGridDim().X()));
+    gridCoordX *= static_cast<int>((float) (licDim.X()) / (float) (grid.GetGridDim().X()));
     //printf("Grid x coord in lic tex space %i\n", gridCoordX); // DEBUG
 
     //float minStreamLines = 3.0f;
@@ -237,7 +237,7 @@ bool protein_cuda::LIC::CalcLicY(UniGrid3D<float3>& grid, UniGrid3D<float>& rand
     int gridCoordY = static_cast<int>(licBuffY.GetGridOrg().Y() - grid.GetGridOrg().Y() /
                                                                       (grid.GetGridDim().Y() * grid.GetGridStepSize()) *
                                                                       grid.GetGridDim().Y());
-    gridCoordY *= static_cast<int>(((float)(licDim.Y()) / (float)(grid.GetGridDim().Y())));
+    gridCoordY *= static_cast<int>(((float) (licDim.Y()) / (float) (grid.GetGridDim().Y())));
 
     //float minStreamLines = 3.0f;
     int length = static_cast<int>(streamLen);
@@ -439,7 +439,7 @@ bool protein_cuda::LIC::CalcLicZ(UniGrid3D<float3>& grid, UniGrid3D<float>& rand
     int gridCoordZ = static_cast<int>(licBuffZ.GetGridOrg().Z() - grid.GetGridOrg().Z() /
                                                                       (grid.GetGridDim().Z() * grid.GetGridStepSize()) *
                                                                       grid.GetGridDim().Z());
-    gridCoordZ *= static_cast<int>((float)(licDim.Z()) / (float)(grid.GetGridDim().Z()));
+    gridCoordZ *= static_cast<int>((float) (licDim.Z()) / (float) (grid.GetGridDim().Z()));
 
     //float minStreamLines = 3.0f;
     int length = static_cast<int>(streamLen);
@@ -631,9 +631,9 @@ vislib::math::Vector<float, 3> protein_cuda::LIC::sampleUniGrid(
 
     // Nearest neighbour sampling
     vislib::math::Vector<unsigned int, 3> p(
-        (unsigned int)(pos.X() * ((float)grid.GetGridDim().X() / (float)licDim.X())),
-        (unsigned int)(pos.Y() * ((float)grid.GetGridDim().Y() / (float)licDim.Y())),
-        (unsigned int)(pos.Z() * ((float)grid.GetGridDim().Z() / (float)licDim.Z())));
+        (unsigned int) (pos.X() * ((float) grid.GetGridDim().X() / (float) licDim.X())),
+        (unsigned int) (pos.Y() * ((float) grid.GetGridDim().Y() / (float) licDim.Y())),
+        (unsigned int) (pos.Z() * ((float) grid.GetGridDim().Z() / (float) licDim.Z())));
 
     //printf("==== unigrid dimensions: %u %u %u\n", grid.GetGridDim().X(), grid.GetGridDim().Y(), grid.GetGridDim().Z()); // DEBUG
     //printf("==== sampling at pos: %u %u %u\n", p.X(), p.Y(), p.Z()); // DEBUG

--- a/plugins/protein_cuda/src/MolecularAOShader.cpp
+++ b/plugins/protein_cuda/src/MolecularAOShader.cpp
@@ -93,7 +93,7 @@ float* MolecularAOShader::createVolume(class megamol::protein_calls::MolecularDa
 
     // Compute AO Factors for ech atom.
 #pragma omp parallel for
-    for (i = 0; i < (int)mol.AtomCount(); i++) {
+    for (i = 0; i < (int) mol.AtomCount(); i++) {
         int x = static_cast<int>(((mol.AtomPositions()[i * 3 + 0] - minOSx) / rangeOSx) * static_cast<float>(sx));
         if (x < 0)
             x = 0;
@@ -160,7 +160,7 @@ float* MolecularAOShader::createVolumeDebug(class megamol::protein_calls::Molecu
         (rangeOSx / static_cast<float>(sx)) * (rangeOSy / static_cast<float>(sy)) * (rangeOSz / static_cast<float>(sz));
 
     // Compute AO Factors for ech atom.
-    for (i = 0; i < (int)mol.AtomCount(); i++) {
+    for (i = 0; i < (int) mol.AtomCount(); i++) {
         int x = static_cast<int>(((mol.AtomPositions()[i * 3 + 0] - minOSx) / rangeOSx) * static_cast<float>(sx));
         if (x < 0)
             x = 0;

--- a/plugins/protein_cuda/src/MoleculeCBCudaRenderer.cpp
+++ b/plugins/protein_cuda/src/MoleculeCBCudaRenderer.cpp
@@ -231,7 +231,7 @@ void MoleculeCBCudaRenderer::ContourBuildupCuda(MolecularDataCall* mol) {
 
     // map OpenGL buffer object for writing from CUDA
     float* atomPosPtr;
-    cudaGLMapBufferObject((void**)&atomPosPtr, buffers_[static_cast<int>(Buffers::ATOM_POS)]->getName());
+    cudaGLMapBufferObject((void**) &atomPosPtr, buffers_[static_cast<int>(Buffers::ATOM_POS)]->getName());
 
     // calculate grid hash
     calcHash(m_dGridParticleHash, m_dGridParticleIndex,
@@ -271,10 +271,10 @@ void MoleculeCBCudaRenderer::ContourBuildupCuda(MolecularDataCall* mol) {
     uint numSC = 0;
     uint lastSC = 0;
     checkCudaErrors(
-        cudaMemcpy((void*)&numSC, (void*)(m_dSmallCircleVisibleScan + (this->numAtoms * this->atomNeighborCount) - 1),
+        cudaMemcpy((void*) &numSC, (void*) (m_dSmallCircleVisibleScan + (this->numAtoms * this->atomNeighborCount) - 1),
             sizeof(uint), cudaMemcpyDeviceToHost));
     checkCudaErrors(
-        cudaMemcpy((void*)&lastSC, (void*)(m_dSmallCircleVisible + (this->numAtoms * this->atomNeighborCount) - 1),
+        cudaMemcpy((void*) &lastSC, (void*) (m_dSmallCircleVisible + (this->numAtoms * this->atomNeighborCount) - 1),
             sizeof(uint), cudaMemcpyDeviceToHost));
     numSC += lastSC;
 
@@ -284,10 +284,10 @@ void MoleculeCBCudaRenderer::ContourBuildupCuda(MolecularDataCall* mol) {
     uint numProbes = 0;
     uint lastProbeCnt = 0;
     checkCudaErrors(
-        cudaMemcpy((void*)&numProbes, (void*)(m_dArcCountScan + (this->numAtoms * this->atomNeighborCount) - 1),
+        cudaMemcpy((void*) &numProbes, (void*) (m_dArcCountScan + (this->numAtoms * this->atomNeighborCount) - 1),
             sizeof(uint), cudaMemcpyDeviceToHost));
-    checkCudaErrors(cudaMemcpy((void*)&lastProbeCnt,
-        (void*)(m_dArcCount + (this->numAtoms * this->atomNeighborCount) - 1), sizeof(uint), cudaMemcpyDeviceToHost));
+    checkCudaErrors(cudaMemcpy((void*) &lastProbeCnt,
+        (void*) (m_dArcCount + (this->numAtoms * this->atomNeighborCount) - 1), sizeof(uint), cudaMemcpyDeviceToHost));
     numProbes += lastProbeCnt;
 
     // resize torus buffer objects
@@ -319,22 +319,22 @@ void MoleculeCBCudaRenderer::ContourBuildupCuda(MolecularDataCall* mol) {
 
     // map probe buffer object for writing from CUDA
     float* probePosPtr;
-    cudaGLMapBufferObject((void**)&probePosPtr, buffers_[static_cast<int>(Buffers::PROBE_POS)]->getName());
+    cudaGLMapBufferObject((void**) &probePosPtr, buffers_[static_cast<int>(Buffers::PROBE_POS)]->getName());
 
     // map spherical triangle buffer objects for writing from CUDA
     float *sphereTriaVec1Ptr, *sphereTriaVec2Ptr, *sphereTriaVec3Ptr;
     cudaGLMapBufferObject(
-        (void**)&sphereTriaVec1Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_1)]->getName());
+        (void**) &sphereTriaVec1Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_1)]->getName());
     cudaGLMapBufferObject(
-        (void**)&sphereTriaVec2Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_2)]->getName());
+        (void**) &sphereTriaVec2Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_2)]->getName());
     cudaGLMapBufferObject(
-        (void**)&sphereTriaVec3Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_3)]->getName());
+        (void**) &sphereTriaVec3Ptr, buffers_[static_cast<int>(Buffers::SPHERE_TRIA_VEC_3)]->getName());
 
     // map torus buffer objects for writing from CUDA
     float *torusPosPtr, *torusVSPtr, *torusAxisPtr;
-    cudaGLMapBufferObject((void**)&torusPosPtr, buffers_[static_cast<int>(Buffers::TORUS_POS)]->getName());
-    cudaGLMapBufferObject((void**)&torusVSPtr, buffers_[static_cast<int>(Buffers::TORUS_VS)]->getName());
-    cudaGLMapBufferObject((void**)&torusAxisPtr, buffers_[static_cast<int>(Buffers::TORUS_AXIS)]->getName());
+    cudaGLMapBufferObject((void**) &torusPosPtr, buffers_[static_cast<int>(Buffers::TORUS_POS)]->getName());
+    cudaGLMapBufferObject((void**) &torusVSPtr, buffers_[static_cast<int>(Buffers::TORUS_VS)]->getName());
+    cudaGLMapBufferObject((void**) &torusAxisPtr, buffers_[static_cast<int>(Buffers::TORUS_AXIS)]->getName());
 
     // compute vertex buffer objects for probe positions
     writeProbePositionsCB(probePosPtr, sphereTriaVec1Ptr, sphereTriaVec2Ptr, sphereTriaVec3Ptr, torusPosPtr, torusVSPtr,
@@ -376,10 +376,10 @@ void MoleculeCBCudaRenderer::ContourBuildupCuda(MolecularDataCall* mol) {
 
     // map texture coordinate buffer object for writing from CUDA
     float* texCoordPtr;
-    cudaGLMapBufferObject((void**)&texCoordPtr, buffers_[static_cast<int>(Buffers::TEX_COORD)]->getName());
+    cudaGLMapBufferObject((void**) &texCoordPtr, buffers_[static_cast<int>(Buffers::TEX_COORD)]->getName());
     // map singularity texture buffer object for writing from CUDA
     float* singTexPtr;
-    cudaGLMapBufferObject((void**)&singTexPtr, buffers_[static_cast<int>(Buffers::SING_TEX)]->getName());
+    cudaGLMapBufferObject((void**) &singTexPtr, buffers_[static_cast<int>(Buffers::SING_TEX)]->getName());
 
     // find all intersecting probes for each probe and write them to a texture
     writeSingularityTextureCB(texCoordPtr, singTexPtr, m_dSortedProbePos, m_dGridProbeIndex, m_dCellStart, m_dCellEnd,
@@ -570,7 +570,7 @@ bool MoleculeCBCudaRenderer::initCuda(MolecularDataCall* mol, uint gridDim, mmst
     // allocate GPU data
     unsigned int memSize = sizeof(float) * 4 * this->numAtoms;
     // array for atom positions
-    allocateArray((void**)&m_dPos, memSize);
+    allocateArray((void**) &m_dPos, memSize);
     //cudaMalloc(  (void**)&m_dPos, memSize);
     //cudaError e;
     //e = cudaGetLastError();
@@ -581,38 +581,38 @@ bool MoleculeCBCudaRenderer::initCuda(MolecularDataCall* mol, uint gridDim, mmst
     //megamol::core::utility::log::Log::DefaultLog.WriteMsg( megamol::core::utility::log::Log::LEVEL_ERROR,
     //    "Free GPU Memory: %i / %i (MB)", free / ( 1024 * 1024), total / ( 1024 * 1024));
     // array for sorted atom positions
-    allocateArray((void**)&m_dSortedPos, memSize);
+    allocateArray((void**) &m_dSortedPos, memSize);
     // array for sorted atom positions
-    allocateArray((void**)&m_dSortedProbePos, memSize * this->atomNeighborCount);
+    allocateArray((void**) &m_dSortedProbePos, memSize * this->atomNeighborCount);
     // array for the counted number of atoms
-    allocateArray((void**)&m_dNeighborCount, this->numAtoms * sizeof(uint));
+    allocateArray((void**) &m_dNeighborCount, this->numAtoms * sizeof(uint));
     // array for the neighbor atoms
-    allocateArray((void**)&m_dNeighbors, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dNeighbors, this->numAtoms * this->atomNeighborCount * sizeof(uint));
     // array for the small circles
-    allocateArray((void**)&m_dSmallCircles, this->numAtoms * this->atomNeighborCount * 4 * sizeof(float));
+    allocateArray((void**) &m_dSmallCircles, this->numAtoms * this->atomNeighborCount * 4 * sizeof(float));
     // array for the small circle visibility
-    allocateArray((void**)&m_dSmallCircleVisible, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dSmallCircleVisible, this->numAtoms * this->atomNeighborCount * sizeof(uint));
     // array for the small circle visibility prefix sum
-    allocateArray((void**)&m_dSmallCircleVisibleScan, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dSmallCircleVisibleScan, this->numAtoms * this->atomNeighborCount * sizeof(uint));
     // array for the arcs
     allocateArray(
-        (void**)&m_dArcs, this->numAtoms * this->atomNeighborCount * this->atomNeighborCount * 4 * sizeof(float));
+        (void**) &m_dArcs, this->numAtoms * this->atomNeighborCount * this->atomNeighborCount * 4 * sizeof(float));
     // array for the arcs
     allocateArray(
-        (void**)&m_dArcIdxK, this->numAtoms * this->atomNeighborCount * this->atomNeighborCount * sizeof(uint));
+        (void**) &m_dArcIdxK, this->numAtoms * this->atomNeighborCount * this->atomNeighborCount * sizeof(uint));
     // array for the arc count
-    allocateArray((void**)&m_dArcCount, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dArcCount, this->numAtoms * this->atomNeighborCount * sizeof(uint));
     // array for the arc count scan (prefix sum)
-    allocateArray((void**)&m_dArcCountScan, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dArcCountScan, this->numAtoms * this->atomNeighborCount * sizeof(uint));
 
-    allocateArray((void**)&m_dGridParticleHash, this->numAtoms * sizeof(uint));
-    allocateArray((void**)&m_dGridParticleIndex, this->numAtoms * sizeof(uint));
+    allocateArray((void**) &m_dGridParticleHash, this->numAtoms * sizeof(uint));
+    allocateArray((void**) &m_dGridParticleIndex, this->numAtoms * sizeof(uint));
 
-    allocateArray((void**)&m_dGridProbeHash, this->numAtoms * this->atomNeighborCount * sizeof(uint));
-    allocateArray((void**)&m_dGridProbeIndex, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dGridProbeHash, this->numAtoms * this->atomNeighborCount * sizeof(uint));
+    allocateArray((void**) &m_dGridProbeIndex, this->numAtoms * this->atomNeighborCount * sizeof(uint));
 
-    allocateArray((void**)&m_dCellStart, this->numGridCells * sizeof(uint));
-    allocateArray((void**)&m_dCellEnd, this->numGridCells * sizeof(uint));
+    allocateArray((void**) &m_dCellStart, this->numGridCells * sizeof(uint));
+    allocateArray((void**) &m_dCellEnd, this->numGridCells * sizeof(uint));
 
     // clear all buffers
     for (auto& e : buffers_) {

--- a/plugins/protein_cuda/src/PotentialCalculator.cpp
+++ b/plugins/protein_cuda/src/PotentialCalculator.cpp
@@ -272,9 +272,9 @@ void PotentialCalculator::initGridParams(gridParams& grid, MolecularDataCall* dc
     gridXAxisLen = grid.maxC[0] - grid.minC[0];
     gridYAxisLen = grid.maxC[1] - grid.minC[1];
     gridZAxisLen = grid.maxC[2] - grid.minC[2];
-    grid.size[0] = (int)ceil(gridXAxisLen / grid.delta[0]);
-    grid.size[1] = (int)ceil(gridYAxisLen / grid.delta[1]);
-    grid.size[2] = (int)ceil(gridZAxisLen / grid.delta[2]);
+    grid.size[0] = (int) ceil(gridXAxisLen / grid.delta[0]);
+    grid.size[1] = (int) ceil(gridYAxisLen / grid.delta[1]);
+    grid.size[2] = (int) ceil(gridZAxisLen / grid.delta[2]);
 
     //    // FFT needs the grid to be a power of two
     //    if (this->computationalMethod == GPU_POISSON_SOLVER) {
@@ -340,12 +340,12 @@ bool PotentialCalculator::computeChargeDistribution(const MolecularDataCall* mol
     //    }
 
     // Compute uniform grid
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     int rc = cqs->calc_map(mol->AtomCount(),
         &this->particlePos.Peek()[0],     // Pointer to 'particle positions
         &this->particleCharges.Peek()[0], // Pointer to 'color' array
         true,                             // Do not use 'color' array
-        CUDAQuickSurf::VolTexFormat::RGB3F, (float*)&this->chargesGrid.minC[0], (int*)&this->chargesGrid.size[0],
+        CUDAQuickSurf::VolTexFormat::RGB3F, (float*) &this->chargesGrid.minC[0], (int*) &this->chargesGrid.size[0],
         this->maxParticleRad,
         5.0f, // Radius scale
         this->chargesGrid.delta[0],
@@ -357,7 +357,7 @@ bool PotentialCalculator::computeChargeDistribution(const MolecularDataCall* mol
         return false;
     }
 
-    CudaSafeCall(cudaMemcpy((void*)this->chargesBuff.Peek(), (const void*)cqs->getColorMap(),
+    CudaSafeCall(cudaMemcpy((void*) this->chargesBuff.Peek(), (const void*) cqs->getColorMap(),
         sizeof(float) * this->chargesBuff.GetCount(), cudaMemcpyDeviceToHost));
 
     // Set charges
@@ -575,7 +575,7 @@ void PotentialCalculator::release(void) {
     this->particleCharges.Release();
     this->chargesBuff.Release();
     if (this->cudaqsurf != NULL) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         delete cqs;
     }
     cudaDeviceReset();

--- a/plugins/protein_cuda/src/SecStructRenderer2D.cpp
+++ b/plugins/protein_cuda/src/SecStructRenderer2D.cpp
@@ -278,7 +278,7 @@ bool SecStructRenderer2D::GetExtents(mmstd_gl::CallRender2DGL& call) {
 
                     // is the current residue really an aminoacid?
                     if (mdc->Residues()[aaIdx]->Identifier() == MolecularDataCall::Residue::AMINOACID) {
-                        acid = (MolecularDataCall::AminoAcid*)(mdc->Residues()[aaIdx]);
+                        acid = (MolecularDataCall::AminoAcid*) (mdc->Residues()[aaIdx]);
                     } else {
                         continue;
                     }

--- a/plugins/protein_cuda/src/StreamlineRenderer.cpp
+++ b/plugins/protein_cuda/src/StreamlineRenderer.cpp
@@ -260,7 +260,7 @@ bool StreamlineRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
         // Integrate streamlines
         if (!this->strLines.IntegrateRK4(this->seedPoints.PeekElements(), this->streamlineStep,
-                (float*)vtiCall->GetPointDataByIdx(1, 0), // TODO Do not hardcode array
+                (float*) vtiCall->GetPointDataByIdx(1, 0), // TODO Do not hardcode array
                 make_int3(vtiCall->GetGridsize().GetX(), vtiCall->GetGridsize().GetY(), vtiCall->GetGridsize().GetZ()),
                 make_float3(vtiCall->GetOrigin().GetX(), vtiCall->GetOrigin().GetY(), vtiCall->GetOrigin().GetZ()),
                 make_float3(
@@ -270,7 +270,7 @@ bool StreamlineRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
         // Sample the density field to the alpha component
         if (!this->strLines.SampleScalarFieldToAlpha(
-                (float*)vtiCall->GetPointDataByIdx(0, 0), // TODO do not hardcode array
+                (float*) vtiCall->GetPointDataByIdx(0, 0), // TODO do not hardcode array
                 make_int3(vtiCall->GetGridsize().GetX(), vtiCall->GetGridsize().GetY(), vtiCall->GetGridsize().GetZ()),
                 make_float3(vtiCall->GetOrigin().GetX(), vtiCall->GetOrigin().GetY(), vtiCall->GetOrigin().GetZ()),
                 make_float3(
@@ -283,7 +283,7 @@ bool StreamlineRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         //            return false;
         //        }
 
-        if (!this->strLines.SampleVecFieldToRGB((float*)vtiCall->GetPointDataByIdx(1, 0), // TODO do not hardcode array
+        if (!this->strLines.SampleVecFieldToRGB((float*) vtiCall->GetPointDataByIdx(1, 0), // TODO do not hardcode array
                 make_int3(vtiCall->GetGridsize().GetX(), vtiCall->GetGridsize().GetY(), vtiCall->GetGridsize().GetZ()),
                 make_float3(vtiCall->GetOrigin().GetX(), vtiCall->GetOrigin().GetY(), vtiCall->GetOrigin().GetZ()),
                 make_float3(
@@ -358,7 +358,7 @@ void StreamlineRenderer::genSeedPoints(protein_calls::VTIDataCall* vti, float zC
         //printf("Random pos %f %f %f\n", pos.GetX(), pos.GetY(), pos.GetZ());
 
         float sample = this->sampleFieldAtPosTrilin(
-            vti, make_float3(pos.GetX(), pos.GetY(), pos.GetZ()), (float*)vti->GetPointDataByIdx(0, 0));
+            vti, make_float3(pos.GetX(), pos.GetY(), pos.GetZ()), (float*) vti->GetPointDataByIdx(0, 0));
 
         // Sample density value
         //if (vislib::math::Abs(sample - isoval) < 0.05) {
@@ -391,12 +391,12 @@ float StreamlineRenderer::sampleFieldAtPosTrilin(protein_calls::VTIDataCall* vti
     f.x = (pos.x - gridOrg_D.x) / gridDelta_D.x;
     f.y = (pos.y - gridOrg_D.y) / gridDelta_D.y;
     f.z = (pos.z - gridOrg_D.z) / gridDelta_D.z;
-    c.x = (int)(f.x);
-    c.y = (int)(f.y);
-    c.z = (int)(f.z);
-    f.x = f.x - (float)c.x; // alpha
-    f.y = f.y - (float)c.y; // beta
-    f.z = f.z - (float)c.z; // gamma
+    c.x = (int) (f.x);
+    c.y = (int) (f.y);
+    c.z = (int) (f.z);
+    f.x = f.x - (float) c.x; // alpha
+    f.y = f.y - (float) c.y; // beta
+    f.z = f.z - (float) c.z; // gamma
 
     c.x = vislib::math::Clamp(c.x, int(0), gridSize_D.x - 2);
     c.y = vislib::math::Clamp(c.y, int(0), gridSize_D.y - 2);

--- a/plugins/protein_cuda/src/VolumeMeshRenderer.cpp
+++ b/plugins/protein_cuda/src/VolumeMeshRenderer.cpp
@@ -377,7 +377,7 @@ bool VolumeMeshRenderer::create(void) {
  */
 void VolumeMeshRenderer::release(void) {
     if (cudaqsurf) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) cudaqsurf;
         delete cqs;
     }
     wkf_timer_destroy(timer);
@@ -652,7 +652,7 @@ bool VolumeMeshRenderer::Render(mmstd_gl::CallRender3DGL& call) {
     cudaDeviceSynchronize(); // Paranoia
 
     // store CUDA density map size
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) cudaqsurf;
     uint3 hVolSize;
     hVolSize.x = numvoxels[0];
     hVolSize.y = numvoxels[1];
@@ -1218,7 +1218,7 @@ void VolumeMeshRenderer::SortTriangleMesh() {
 
     // sort everything
     SortTrianglesDevice(
-        this->vertexCount / 3, (float4x3*)vertices, (float4x3*)verticesCopy, (float4x3*)colors, (float4x3*)normals);
+        this->vertexCount / 3, (float4x3*) vertices, (float4x3*) verticesCopy, (float4x3*) colors, (float4x3*) normals);
 
     // Unmap VBOs.
     CUDA_VERIFY(cudaGraphicsUnmapResources(1, &positionResource, 0));
@@ -1266,7 +1266,7 @@ bool VolumeMeshRenderer::UpdateMesh(float* densityMap, vislib::math::Vector<floa
     cudaMemcpy3DParms copyParams = {0};
     copyParams.dstArray = this->aoVolume;
     copyParams.dstPos = make_cudaPos(1, 1, 1);
-    copyParams.srcPtr = make_cudaPitchedPtr((void*)aoVolumeHost, aoVolumeHostExtent.width * sizeof(float),
+    copyParams.srcPtr = make_cudaPitchedPtr((void*) aoVolumeHost, aoVolumeHostExtent.width * sizeof(float),
         aoVolumeHostExtent.width, aoVolumeHostExtent.height);
     copyParams.extent = aoVolumeHostExtent;
     copyParams.kind = cudaMemcpyHostToDevice;
@@ -2354,9 +2354,9 @@ bool VolumeMeshRenderer::UpdateMesh(float* densityMap, vislib::math::Vector<floa
         // TODO compute the center line of this feature
         perf.SetMark();
         clg[fCnt - 1] = new CenterLineGenerator();
-        clg[fCnt - 1]->SetTriangleMesh(this->featureVertexCntNew, (float*)this->featureTriangleVerticesHost,
-            this->edgeCount, (unsigned int*)this->featureTriangleEdgesHost,
-            (unsigned int*)this->featureTriangleEdgeCountHost);
+        clg[fCnt - 1]->SetTriangleMesh(this->featureVertexCntNew, (float*) this->featureTriangleVerticesHost,
+            this->edgeCount, (unsigned int*) this->featureTriangleEdgesHost,
+            (unsigned int*) this->featureTriangleEdgeCountHost);
         //printf( "Time to prepare center line data for feature %3i (%5i tria): %.5f\n", fCnt, fLength, ( double( clock() - t) / double( CLOCKS_PER_SEC) ));
         if (!clg[fCnt - 1]->freeEdgeRing.empty() && !clg[fCnt - 1]->freeEdgeRing[0].empty()) {
             for (auto edge : clEdges[fCnt - 1]) {
@@ -2391,7 +2391,7 @@ bool VolumeMeshRenderer::UpdateMesh(float* densityMap, vislib::math::Vector<floa
     cudaMemcpy(this->vertexColors, colors, this->vertexCount * 4 * sizeof(float), cudaMemcpyDeviceToHost);
     float ifac = this->cmWeightParam.Param<param::FloatParam>()->Value();
 #pragma omp parallel for
-    for (int i = 0; i < (int)this->vertexCount; i++) {
+    for (int i = 0; i < (int) this->vertexCount; i++) {
         int atomIdx = this->neighborAtomOfVertex[i];
         if (atomIdx < 0) {
             // ERROR no nearest atom found (color magenta)
@@ -2653,10 +2653,10 @@ void VolumeMeshRenderer::ValidateCubeMemory() {
         CUDA_VERIFY(cudaMalloc3DArray(&this->aoVolume, &cd, aoVolumeExtent));
         // Emulate cudaMemset3D for cudaArrays.
         float* zeroArray =
-            (float*)calloc(aoVolumeExtent.width * aoVolumeExtent.height * aoVolumeExtent.depth, sizeof(float));
+            (float*) calloc(aoVolumeExtent.width * aoVolumeExtent.height * aoVolumeExtent.depth, sizeof(float));
         cudaMemcpy3DParms copyParams = {0};
         copyParams.srcPtr = make_cudaPitchedPtr(
-            (void*)zeroArray, aoVolumeExtent.width * sizeof(float), aoVolumeExtent.width, aoVolumeExtent.height);
+            (void*) zeroArray, aoVolumeExtent.width * sizeof(float), aoVolumeExtent.width, aoVolumeExtent.height);
         copyParams.dstArray = this->aoVolume;
         copyParams.extent = aoVolumeExtent;
         copyParams.kind = cudaMemcpyHostToDevice;
@@ -2932,9 +2932,9 @@ int VolumeMeshRenderer::calcMap(MolecularDataCall* mol, float* posInter, int qua
     xaxis[0] = maxcoord[0] - mincoord[0];
     yaxis[1] = maxcoord[1] - mincoord[1];
     zaxis[2] = maxcoord[2] - mincoord[2];
-    numvoxels[0] = (int)ceil(xaxis[0] / gridspacing);
-    numvoxels[1] = (int)ceil(yaxis[1] / gridspacing);
-    numvoxels[2] = (int)ceil(zaxis[2] / gridspacing);
+    numvoxels[0] = (int) ceil(xaxis[0] / gridspacing);
+    numvoxels[1] = (int) ceil(yaxis[1] / gridspacing);
+    numvoxels[2] = (int) ceil(zaxis[2] / gridspacing);
 
     // recalc the grid dimensions from rounded/padded voxel counts
     xaxis[0] = (numvoxels[0] - 1) * gridspacing;
@@ -2963,9 +2963,9 @@ int VolumeMeshRenderer::calcMap(MolecularDataCall* mol, float* posInter, int qua
     int ind = 0;
     int ind4 = 0;
     int ind1 = 0;
-    xyzr = (float*)malloc(mol->AtomCount() * sizeof(float) * 4);
+    xyzr = (float*) malloc(mol->AtomCount() * sizeof(float) * 4);
     if (useCol) {
-        colors = (float*)malloc(mol->AtomCount() * sizeof(float) * 4);
+        colors = (float*) malloc(mol->AtomCount() * sizeof(float) * 4);
 
         // build compacted lists of atom coordinates, radii, and colors
         for (i = 0; i < mol->AtomCount(); i++) {
@@ -3022,7 +3022,7 @@ int VolumeMeshRenderer::calcMap(MolecularDataCall* mol, float* posInter, int qua
 
     pretime = wkf_timer_timenow(timer);
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) cudaqsurf;
 
     // compute both density map and floating point color texture map
     //int rc = cqs->calc_surf( mol->AtomCount(), &xyzr[0],

--- a/plugins/protein_cuda/src/helper_includes/helper_cuda.h
+++ b/plugins/protein_cuda/src/helper_includes/helper_cuda.h
@@ -987,7 +987,7 @@ inline void __getLastCudaError(const char* errorMessage, const char* file, const
     cudaError_t err = cudaGetLastError();
 
     if (cudaSuccess != err) {
-        fprintf(stderr, "%s(%i) : getLastCudaError() CUDA error : %s : (%d) %s.\n", file, line, errorMessage, (int)err,
+        fprintf(stderr, "%s(%i) : getLastCudaError() CUDA error : %s : (%d) %s.\n", file, line, errorMessage, (int) err,
             cudaGetErrorString(err));
         DEVICE_RESET
         exit(EXIT_FAILURE);
@@ -1001,7 +1001,7 @@ inline void __getLastCudaError(const char* errorMessage, const char* file, const
 
 // Float To Int conversion
 inline int ftoi(float value) {
-    return (value >= 0 ? (int)(value + 0.5) : (int)(value - 0.5));
+    return (value >= 0 ? (int) (value + 0.5) : (int) (value - 0.5));
 }
 
 // Beginning of GPU Architecture definitions
@@ -1140,7 +1140,7 @@ inline int gpuGetMaxGflopsDeviceId() {
             }
 
             unsigned long long compute_perf =
-                (unsigned long long)deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
+                (unsigned long long) deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
 
             if (compute_perf > max_compute_perf) {
                 // If we find GPU with SM major > 2, search only these

--- a/plugins/protein_cuda/src/helper_includes/helper_cuda_gl.h
+++ b/plugins/protein_cuda/src/helper_includes/helper_cuda_gl.h
@@ -92,8 +92,8 @@ inline int findCudaGLDevice(int argc, const char** argv) {
     int devID = 0;
 
     // If the command-line has a device number specified, use it
-    if (checkCmdLineFlag(argc, (const char**)argv, "device")) {
-        devID = gpuGLDeviceInit(argc, (const char**)argv);
+    if (checkCmdLineFlag(argc, (const char**) argv, "device")) {
+        devID = gpuGLDeviceInit(argc, (const char**) argv);
 
         if (devID < 0) {
             printf("no CUDA capable devices found, exiting...\n");

--- a/plugins/protein_cuda/src/helper_includes/helper_image.h
+++ b/plugins/protein_cuda/src/helper_includes/helper_image.h
@@ -176,7 +176,7 @@ inline bool __loadPPM(
             std::cerr << "__LoadPPM() : Invalid image dimensions." << std::endl;
         }
     } else {
-        *data = (unsigned char*)malloc(sizeof(unsigned char) * width * height * *channels);
+        *data = (unsigned char*) malloc(sizeof(unsigned char) * width * height * *channels);
         *w = width;
         *h = height;
     }
@@ -205,7 +205,7 @@ inline bool sdkLoadPGM(const char* file, T** data, unsigned int* w, unsigned int
     // initialize mem if necessary
     // the correct size is checked / set in loadPGMc()
     if (NULL == *data) {
-        *data = (T*)malloc(sizeof(T) * size);
+        *data = (T*) malloc(sizeof(T) * size);
     }
 
     // copy and cast data
@@ -226,7 +226,7 @@ inline bool sdkLoadPPM4(const char* file, T** data, unsigned int* w, unsigned in
         int size = *w * *h;
         // keep the original pointer
         unsigned char* idata_orig = idata;
-        *data = (T*)malloc(sizeof(T) * size * 4);
+        *data = (T*) malloc(sizeof(T) * size * 4);
         unsigned char* ptr = *data;
 
         for (int i = 0; i < size; i++) {
@@ -286,7 +286,7 @@ inline bool __savePPM(const char* file, unsigned char* data, unsigned int w, uns
 template<class T>
 inline bool sdkSavePGM(const char* file, T* data, unsigned int w, unsigned int h) {
     unsigned int size = w * h;
-    unsigned char* idata = (unsigned char*)malloc(sizeof(unsigned char) * size);
+    unsigned char* idata = (unsigned char*) malloc(sizeof(unsigned char) * size);
 
     std::transform(data, data + size, idata, ConverterToUByte<T>());
 
@@ -302,7 +302,7 @@ inline bool sdkSavePGM(const char* file, T* data, unsigned int w, unsigned int h
 inline bool sdkSavePPM4ub(const char* file, unsigned char* data, unsigned int w, unsigned int h) {
     // strip 4th component
     int size = w * h;
-    unsigned char* ndata = (unsigned char*)malloc(sizeof(unsigned char) * size * 3);
+    unsigned char* ndata = (unsigned char*) malloc(sizeof(unsigned char) * size * 3);
     unsigned char* ptr = ndata;
 
     for (int i = 0; i < size; i++) {
@@ -361,14 +361,14 @@ inline bool sdkReadFile(const char* filename, T** data, unsigned int* len, bool 
         if (*len != data_read.size()) {
             std::cerr << "sdkReadFile() : Initialized memory given but "
                       << "size  mismatch with signal read "
-                      << "(data read / data init = " << (unsigned int)data_read.size() << " / " << *len << ")"
+                      << "(data read / data init = " << (unsigned int) data_read.size() << " / " << *len << ")"
                       << std::endl;
 
             return false;
         }
     } else {
         // allocate storage for the data read
-        *data = (T*)malloc(sizeof(T) * data_read.size());
+        *data = (T*) malloc(sizeof(T) * data_read.size());
         // store signal size
         *len = static_cast<unsigned int>(data_read.size());
     }
@@ -404,7 +404,7 @@ inline bool sdkReadFileBlocks(
 
     // check if the given handle is already initialized
     // allocate storage for the data read
-    data[block_num] = (T*)malloc(block_size);
+    data[block_num] = (T*) malloc(block_size);
 
     // read all data elements
     fseek(fh, block_num * block_size, SEEK_SET);
@@ -494,7 +494,7 @@ inline bool compareData(
     unsigned int error_count = 0;
 
     for (unsigned int i = 0; i < len; ++i) {
-        float diff = (float)reference[i] - (float)data[i];
+        float diff = (float) reference[i] - (float) data[i];
         bool comp = (diff <= epsilon) && (diff >= -epsilon);
         result &= comp;
 
@@ -517,7 +517,7 @@ inline bool compareData(
         return (result) ? true : false;
     } else {
         if (error_count) {
-            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float)error_count * 100 / (float)len, error_count);
+            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float) error_count * 100 / (float) len, error_count);
         }
 
         return (len * threshold > error_count) ? true : false;
@@ -543,12 +543,12 @@ inline bool compareDataAsFloatThreshold(
     assert(epsilon >= 0);
 
     // If we set epsilon to be 0, let's set a minimum threshold
-    float max_error = MAX((float)epsilon, __MIN_EPSILON_ERROR);
+    float max_error = MAX((float) epsilon, __MIN_EPSILON_ERROR);
     int error_count = 0;
     bool result = true;
 
     for (unsigned int i = 0; i < len; ++i) {
-        float diff = fabs((float)reference[i] - (float)data[i]);
+        float diff = fabs((float) reference[i] - (float) data[i]);
         bool comp = (diff < max_error);
         result &= comp;
 
@@ -577,7 +577,7 @@ inline bool compareDataAsFloatThreshold(
         return (error_count == 0) ? true : false;
     } else {
         if (error_count) {
-            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float)error_count * 100 / (float)len, error_count);
+            printf("%4.2f(%%) of bytes mismatched (count=%d)\n", (float) error_count * 100 / (float) len, error_count);
         }
 
         return ((len * threshold > error_count) ? true : false);
@@ -629,16 +629,16 @@ inline bool sdkCompareBin2BinUint(const char* src_file, const char* ref_file, un
         }
 
         if (src_fp && ref_fp) {
-            src_buffer = (unsigned int*)malloc(nelements * sizeof(unsigned int));
-            ref_buffer = (unsigned int*)malloc(nelements * sizeof(unsigned int));
+            src_buffer = (unsigned int*) malloc(nelements * sizeof(unsigned int));
+            ref_buffer = (unsigned int*) malloc(nelements * sizeof(unsigned int));
 
             fsize = fread(src_buffer, nelements, sizeof(unsigned int), src_fp);
             fsize = fread(ref_buffer, nelements, sizeof(unsigned int), ref_fp);
 
             printf("> compareBin2Bin <unsigned int> nelements=%d, epsilon=%4.2f, threshold=%4.2f\n", nelements, epsilon,
                 threshold);
-            printf("   src_file <%s>, size=%d bytes\n", src_file, (int)fsize);
-            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int)fsize);
+            printf("   src_file <%s>, size=%d bytes\n", src_file, (int) fsize);
+            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int) fsize);
 
             if (!compareData<unsigned int, float>(ref_buffer, src_buffer, nelements, epsilon, threshold)) {
                 error_count++;
@@ -663,7 +663,7 @@ inline bool sdkCompareBin2BinUint(const char* src_file, const char* ref_file, un
     if (error_count == 0) {
         printf("  OK\n");
     } else {
-        printf("  FAILURE: %d errors...\n", (unsigned int)error_count);
+        printf("  FAILURE: %d errors...\n", (unsigned int) error_count);
     }
 
     return (error_count == 0); // returns true if all pixels pass
@@ -705,16 +705,16 @@ inline bool sdkCompareBin2BinFloat(const char* src_file, const char* ref_file, u
         }
 
         if (src_fp && ref_fp) {
-            src_buffer = (float*)malloc(nelements * sizeof(float));
-            ref_buffer = (float*)malloc(nelements * sizeof(float));
+            src_buffer = (float*) malloc(nelements * sizeof(float));
+            ref_buffer = (float*) malloc(nelements * sizeof(float));
 
             fsize = fread(src_buffer, nelements, sizeof(float), src_fp);
             fsize = fread(ref_buffer, nelements, sizeof(float), ref_fp);
 
             printf("> compareBin2Bin <float> nelements=%d, epsilon=%4.2f, threshold=%4.2f\n", nelements, epsilon,
                 threshold);
-            printf("   src_file <%s>, size=%d bytes\n", src_file, (int)fsize);
-            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int)fsize);
+            printf("   src_file <%s>, size=%d bytes\n", src_file, (int) fsize);
+            printf("   ref_file <%s>, size=%d bytes\n", ref_file_path, (int) fsize);
 
             if (!compareDataAsFloatThreshold<float, float>(ref_buffer, src_buffer, nelements, epsilon, threshold)) {
                 error_count++;
@@ -739,7 +739,7 @@ inline bool sdkCompareBin2BinFloat(const char* src_file, const char* ref_file, u
     if (error_count == 0) {
         printf("  OK\n");
     } else {
-        printf("  FAILURE: %d errors...\n", (unsigned int)error_count);
+        printf("  FAILURE: %d errors...\n", (unsigned int) error_count);
     }
 
     return (error_count == 0); // returns true if all pixels pass
@@ -795,7 +795,7 @@ inline bool sdkLoadPPM4ub(const char* file, unsigned char** data, unsigned int* 
         int size = *w * *h;
         // keep the original pointer
         unsigned char* idata_orig = idata;
-        *data = (unsigned char*)malloc(sizeof(unsigned char) * size * 4);
+        *data = (unsigned char*) malloc(sizeof(unsigned char) * size * 4);
         unsigned char* ptr = *data;
 
         for (int i = 0; i < size; i++) {

--- a/plugins/protein_cuda/src/helper_includes/helper_string.h
+++ b/plugins/protein_cuda/src/helper_includes/helper_string.h
@@ -84,7 +84,7 @@ inline int stringRemoveDelimiter(char delimiter, const char* string) {
         string_start++;
     }
 
-    if (string_start >= (int)strlen(string) - 1) {
+    if (string_start >= (int) strlen(string) - 1) {
         return 0;
     }
 
@@ -92,7 +92,7 @@ inline int stringRemoveDelimiter(char delimiter, const char* string) {
 }
 
 inline int getFileExtension(char* filename, char** extension) {
-    int string_length = (int)strlen(filename);
+    int string_length = (int) strlen(filename);
 
     while (filename[string_length--] != '.') {
         if (string_length == 0)
@@ -120,9 +120,9 @@ inline bool checkCmdLineFlag(const int argc, const char** argv, const char* stri
             const char* string_argv = &argv[i][string_start];
 
             const char* equal_pos = strchr(string_argv, '=');
-            int argv_length = (int)(equal_pos == 0 ? strlen(string_argv) : equal_pos - string_argv);
+            int argv_length = (int) (equal_pos == 0 ? strlen(string_argv) : equal_pos - string_argv);
 
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (length == argv_length && !STRNCASECMP(string_argv, string_ref, length)) {
                 bFound = true;
@@ -143,12 +143,12 @@ inline bool getCmdLineArgumentValue(const int argc, const char** argv, const cha
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
-                    *value = (T)atoi(&string_argv[length + auto_inc]);
+                    *value = (T) atoi(&string_argv[length + auto_inc]);
                 }
 
                 bFound = true;
@@ -168,10 +168,10 @@ inline int getCmdLineArgumentInt(const int argc, const char** argv, const char* 
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
                     value = atoi(&string_argv[length + auto_inc]);
                 } else {
@@ -199,12 +199,12 @@ inline float getCmdLineArgumentFloat(const int argc, const char** argv, const ch
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
             const char* string_argv = &argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
-                if (length + 1 <= (int)strlen(string_argv)) {
+                if (length + 1 <= (int) strlen(string_argv)) {
                     int auto_inc = (string_argv[length] == '=') ? 1 : 0;
-                    value = (float)atof(&string_argv[length + auto_inc]);
+                    value = (float) atof(&string_argv[length + auto_inc]);
                 } else {
                     value = 0.f;
                 }
@@ -228,8 +228,8 @@ inline bool getCmdLineArgumentString(const int argc, const char** argv, const ch
     if (argc >= 1) {
         for (int i = 1; i < argc; i++) {
             int string_start = stringRemoveDelimiter('-', argv[i]);
-            char* string_argv = (char*)&argv[i][string_start];
-            int length = (int)strlen(string_ref);
+            char* string_argv = (char*) &argv[i][string_start];
+            int length = (int) strlen(string_ref);
 
             if (!STRNCASECMP(string_argv, string_ref, length)) {
                 *string_retval = &string_argv[length + 1];
@@ -460,7 +460,7 @@ inline char* sdkFindFilePath(const char* filename, const char* executable_path) 
             fclose(fp);
             // File found
             // returning an allocated array here for backwards compatibility reasons
-            char* file_path = (char*)malloc(path.length() + 1);
+            char* file_path = (char*) malloc(path.length() + 1);
             STRCPY(file_path, path.length() + 1, path.c_str());
             return file_path;
         }

--- a/plugins/protein_cuda/src/helper_includes/helper_timer.h
+++ b/plugins/protein_cuda/src/helper_includes/helper_timer.h
@@ -79,10 +79,10 @@ public:
             LARGE_INTEGER temp;
 
             // get the tick frequency from the OS
-            QueryPerformanceFrequency((LARGE_INTEGER*)&temp);
+            QueryPerformanceFrequency((LARGE_INTEGER*) &temp);
 
             // convert to type in which it is needed
-            freq = ((double)temp.QuadPart) / 1000.0;
+            freq = ((double) temp.QuadPart) / 1000.0;
 
             // rememeber query
             freq_set = true;
@@ -145,7 +145,7 @@ private:
 //! Start time measurement
 ////////////////////////////////////////////////////////////////////////////////
 inline void StopWatchWin::start() {
-    QueryPerformanceCounter((LARGE_INTEGER*)&start_time);
+    QueryPerformanceCounter((LARGE_INTEGER*) &start_time);
     running = true;
 }
 
@@ -154,8 +154,8 @@ inline void StopWatchWin::start() {
 //! variable. Also increment the number of times this clock has been run.
 ////////////////////////////////////////////////////////////////////////////////
 inline void StopWatchWin::stop() {
-    QueryPerformanceCounter((LARGE_INTEGER*)&end_time);
-    diff_time = (float)(((double)end_time.QuadPart - (double)start_time.QuadPart) / freq);
+    QueryPerformanceCounter((LARGE_INTEGER*) &end_time);
+    diff_time = (float) (((double) end_time.QuadPart - (double) start_time.QuadPart) / freq);
 
     total_time += diff_time;
     clock_sessions++;
@@ -172,7 +172,7 @@ inline void StopWatchWin::reset() {
     clock_sessions = 0;
 
     if (running) {
-        QueryPerformanceCounter((LARGE_INTEGER*)&start_time);
+        QueryPerformanceCounter((LARGE_INTEGER*) &start_time);
     }
 }
 
@@ -189,8 +189,8 @@ inline float StopWatchWin::getTime() {
 
     if (running) {
         LARGE_INTEGER temp;
-        QueryPerformanceCounter((LARGE_INTEGER*)&temp);
-        retval += (float)(((double)(temp.QuadPart - start_time.QuadPart)) / freq);
+        QueryPerformanceCounter((LARGE_INTEGER*) &temp);
+        retval += (float) (((double) (temp.QuadPart - start_time.QuadPart)) / freq);
     }
 
     return retval;
@@ -330,7 +330,7 @@ inline float StopWatchLinux::getDiffTime() {
     gettimeofday(&t_time, 0);
 
     // time difference in milli-seconds
-    return (float)(1000.0 * (t_time.tv_sec - start_time.tv_sec) + (0.001 * (t_time.tv_usec - start_time.tv_usec)));
+    return (float) (1000.0 * (t_time.tv_sec - start_time.tv_sec) + (0.001 * (t_time.tv_usec - start_time.tv_usec)));
 }
 #endif // WIN32
 
@@ -345,9 +345,9 @@ inline float StopWatchLinux::getDiffTime() {
 inline bool sdkCreateTimer(StopWatchInterface** timer_interface) {
     //printf("sdkCreateTimer called object %08x\n", (void *)*timer_interface);
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-    *timer_interface = (StopWatchInterface*)new StopWatchWin();
+    *timer_interface = (StopWatchInterface*) new StopWatchWin();
 #else
-    *timer_interface = (StopWatchInterface*)new StopWatchLinux();
+    *timer_interface = (StopWatchInterface*) new StopWatchLinux();
 #endif
     return (*timer_interface != NULL) ? true : false;
 }

--- a/plugins/protein_cuda/src/quicksurf/WKFThreads.cpp
+++ b/plugins/protein_cuda/src/quicksurf/WKFThreads.cpp
@@ -252,7 +252,7 @@ int wkf_thread_numprocessors(void) {
 //static void wkf_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd) {
 static void wkf_cpuid(unsigned int eax, unsigned int ecx, unsigned int* abcd) {
 #if defined(_MSC_VER)
-    __cpuidex((int*)abcd, eax, ecx);
+    __cpuidex((int*) abcd, eax, ecx);
 #else
                                  //  uint32_t ebx, edx;
     unsigned int ebx = 0, edx = 0;
@@ -287,7 +287,7 @@ static unsigned long long wkf_xgetbv(unsigned int index) {
 #else
     unsigned int eax = 0, edx = 0;
     __asm__ __volatile__("xgetbv;" : "=a"(eax), "=d"(edx) : "c"(index));
-    return ((unsigned long long)edx << 32) | eax;
+    return ((unsigned long long) edx << 32) | eax;
 #endif
 }
 #endif
@@ -377,9 +377,9 @@ int wkf_cpu_capability_flags(wkf_cpu_caps_t* cpucaps) {
         int logicalcores = (cpuinfo[1] >> 16) && 0xFF;
         int physicalcores = logicalcores;
         char vendor[16] = {0};
-        ((unsigned*)vendor)[0] = vendcpuinfo[1];
-        ((unsigned*)vendor)[1] = vendcpuinfo[3];
-        ((unsigned*)vendor)[2] = vendcpuinfo[2];
+        ((unsigned*) vendor)[0] = vendcpuinfo[1];
+        ((unsigned*) vendor)[1] = vendcpuinfo[3];
+        ((unsigned*) vendor)[2] = vendcpuinfo[2];
 
         /* hmm, not quite right yet */
         if (!strcmp(vendor, "GenuineIntel")) {
@@ -548,7 +548,7 @@ int* wkf_cpu_affinitylist(int* cpuaffinitycount) {
 
     /* build affinity list */
     if (affinitycount > 0) {
-        affinitylist = (int*)malloc(affinitycount * sizeof(int));
+        affinitylist = (int*) malloc(affinitycount * sizeof(int));
         if (affinitylist == NULL)
             return NULL;
 
@@ -657,7 +657,7 @@ int wkf_thread_create(wkf_thread_t* thr, void* fctn(void*), void* arg) {
 #ifdef WKFTHREADS
 #ifdef _MSC_VER
     DWORD tid; /* thread id, msvc only */
-    *thr = CreateThread(NULL, 8192, (LPTHREAD_START_ROUTINE)fctn, arg, 0, &tid);
+    *thr = CreateThread(NULL, 8192, (LPTHREAD_START_ROUTINE) fctn, arg, 0, &tid);
     if (*thr == NULL) {
         status = -1;
     }
@@ -675,18 +675,18 @@ int wkf_thread_create(wkf_thread_t* thr, void* fctn(void*), void* arg) {
         pthread_attr_t attr;
         pthread_attr_init(&attr);
         pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
-        status = pthread_create(thr, &attr, (WKFTHREAD_START_ROUTINE)fctn, arg);
+        status = pthread_create(thr, &attr, (WKFTHREAD_START_ROUTINE) fctn, arg);
         pthread_attr_destroy(&attr);
     }
 #elif defined(__PARAGON__)
     status = pthread_create(thr, pthread_attr_default, fctn, arg);
 #else
-    status = pthread_create(thr, NULL, (WKFTHREAD_START_ROUTINE)fctn, arg);
+    status = pthread_create(thr, NULL, (WKFTHREAD_START_ROUTINE) fctn, arg);
 #endif
 #endif /* USEPOSIXTHREADS */
 
 #ifdef USEUITHREADS
-    status = thr_create(NULL, 0, (WKFTHREAD_START_ROUTINE)fctn, arg, 0, thr);
+    status = thr_create(NULL, 0, (WKFTHREAD_START_ROUTINE) fctn, arg, 0, thr);
 #endif /* USEUITHREADS */
 #endif /* WKFTHREADS */
 
@@ -1361,7 +1361,7 @@ int wkf_rwlock_unlock(wkf_rwlock_t* rwp) {
  * Simple counting barrier primitive
  */
 wkf_barrier_t* wkf_thread_barrier_init(int n_clients) {
-    wkf_barrier_t* barrier = (wkf_barrier_t*)malloc(sizeof(wkf_barrier_t));
+    wkf_barrier_t* barrier = (wkf_barrier_t*) malloc(sizeof(wkf_barrier_t));
 
 #ifdef WKFTHREADS
     if (barrier != NULL) {
@@ -1567,7 +1567,7 @@ int wkf_tilestack_init(wkf_tilestack_t* s, int size) {
 
     if (size > 0) {
         s->size = size;
-        s->s = (wkf_tasktile_t*)malloc(s->size * sizeof(wkf_tasktile_t));
+        s->s = (wkf_tasktile_t*) malloc(s->size * sizeof(wkf_tasktile_t));
     } else {
         s->size = 0;
         s->s = NULL;
@@ -1592,7 +1592,7 @@ int wkf_tilestack_compact(wkf_tilestack_t* s) {
 #endif
     if (s->size > (s->top + 1)) {
         int newsize = s->top + 1;
-        wkf_tasktile_t* tmp = (wkf_tasktile_t*)realloc(s->s, newsize * sizeof(wkf_tasktile_t));
+        wkf_tasktile_t* tmp = (wkf_tasktile_t*) realloc(s->s, newsize * sizeof(wkf_tasktile_t));
         if (tmp == NULL) {
 #if defined(WKFTHREADS)
             wkf_mutex_unlock(&s->mtx);
@@ -1617,7 +1617,7 @@ int wkf_tilestack_push(wkf_tilestack_t* s, const wkf_tasktile_t* t) {
     s->top++;
     if (s->top >= s->size) {
         int newsize = s->size + s->growthrate;
-        wkf_tasktile_t* tmp = (wkf_tasktile_t*)realloc(s->s, newsize * sizeof(wkf_tasktile_t));
+        wkf_tasktile_t* tmp = (wkf_tasktile_t*) realloc(s->s, newsize * sizeof(wkf_tasktile_t));
         if (tmp == NULL) {
             s->top--;
 #if defined(WKFTHREADS)
@@ -1805,8 +1805,8 @@ int wkf_shared_iterator_getfatalerror(wkf_shared_iterator_t* it) {
  */
 static void* wkf_threadpool_workerproc(void* voidparms) {
     void* (*fctn)(void*);
-    wkf_threadpool_workerdata_t* workerdata = (wkf_threadpool_workerdata_t*)voidparms;
-    wkf_threadpool_t* thrpool = (wkf_threadpool_t*)workerdata->thrpool;
+    wkf_threadpool_workerdata_t* workerdata = (wkf_threadpool_workerdata_t*) voidparms;
+    wkf_threadpool_t* thrpool = (wkf_threadpool_t*) workerdata->thrpool;
 
     while ((fctn = wkf_thread_run_barrier(&thrpool->runbar, NULL, NULL, &workerdata->parms)) != NULL) {
         (*fctn)(workerdata);
@@ -1825,7 +1825,7 @@ static void* wkf_threadpool_workersync(void* voidparms) {
 wkf_threadpool_t* wkf_threadpool_create(int workercount, int* devlist) {
     int i;
     wkf_threadpool_t* thrpool = NULL;
-    thrpool = (wkf_threadpool_t*)malloc(sizeof(wkf_threadpool_t));
+    thrpool = (wkf_threadpool_t*) malloc(sizeof(wkf_threadpool_t));
     if (thrpool == NULL)
         return NULL;
 
@@ -1837,7 +1837,7 @@ wkf_threadpool_t* wkf_threadpool_create(int workercount, int* devlist) {
 
     /* if caller provides a device list, use it, otherwise we assume */
     /* all workers are CPU cores */
-    thrpool->devlist = (int*)malloc(sizeof(int) * workercount);
+    thrpool->devlist = (int*) malloc(sizeof(int) * workercount);
     if (devlist == NULL) {
         for (i = 0; i < workercount; i++)
             thrpool->devlist[i] = -1; /* mark as a CPU core */
@@ -1856,8 +1856,8 @@ wkf_threadpool_t* wkf_threadpool_create(int workercount, int* devlist) {
     wkf_thread_run_barrier_init(&thrpool->runbar, workercount + 1);
 
     /* allocate and initialize thread pool */
-    thrpool->threads = (wkf_thread_t*)malloc(sizeof(wkf_thread_t) * workercount);
-    thrpool->workerdata = (wkf_threadpool_workerdata_t*)malloc(sizeof(wkf_threadpool_workerdata_t) * workercount);
+    thrpool->threads = (wkf_thread_t*) malloc(sizeof(wkf_thread_t) * workercount);
+    thrpool->workerdata = (wkf_threadpool_workerdata_t*) malloc(sizeof(wkf_threadpool_workerdata_t) * workercount);
     memset(thrpool->workerdata, 0, sizeof(wkf_threadpool_workerdata_t) * workercount);
 
     /* setup per-worker data */
@@ -1957,7 +1957,7 @@ int wkf_threadpool_get_workercount(wkf_threadpool_t* thrpool) {
 
 /** worker thread can call this to get its ID and number of peers */
 int wkf_threadpool_worker_getid(void* voiddata, int* threadid, int* threadcount) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     if (threadid != NULL)
         *threadid = worker->threadid;
 
@@ -1970,7 +1970,7 @@ int wkf_threadpool_worker_getid(void* voiddata, int* threadid, int* threadcount)
 
 /** worker thread can call this to get its CPU/GPU device ID */
 int wkf_threadpool_worker_getdevid(void* voiddata, int* devid) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     if (devid != NULL)
         *devid = worker->devid;
 
@@ -1985,7 +1985,7 @@ int wkf_threadpool_worker_getdevid(void* voiddata, int* devid) {
  * device initialization process
  */
 int wkf_threadpool_worker_setdevspeed(void* voiddata, float speed) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     worker->devspeed = speed;
     return 0;
 }
@@ -1996,7 +1996,7 @@ int wkf_threadpool_worker_setdevspeed(void* voiddata, float speed) {
  * as determined by the SM/core count and clock rate
  */
 int wkf_threadpool_worker_getdevspeed(void* voiddata, float* speed) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     if (speed != NULL)
         *speed = worker->devspeed;
     return 0;
@@ -2008,10 +2008,10 @@ int wkf_threadpool_worker_getdevspeed(void* voiddata, float* speed) {
  * as determined by the SM/core count and clock rate
  */
 int wkf_threadpool_worker_devscaletile(void* voiddata, int* tilesize) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     if (tilesize != NULL) {
         int scaledtilesize;
-        scaledtilesize = (int)(worker->devspeed * ((float)(*tilesize)));
+        scaledtilesize = (int) (worker->devspeed * ((float) (*tilesize)));
         if (scaledtilesize < 1)
             scaledtilesize = 1;
 
@@ -2024,7 +2024,7 @@ int wkf_threadpool_worker_devscaletile(void* voiddata, int* tilesize) {
 
 /** worker thread can call this to get its client data pointer */
 int wkf_threadpool_worker_getdata(void* voiddata, void** clientdata) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voiddata;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voiddata;
     if (clientdata != NULL)
         *clientdata = worker->parms;
 
@@ -2043,7 +2043,7 @@ int wkf_threadpool_sched_dynamic(wkf_threadpool_t* thrpool, wkf_tasktile_t* tile
 /** iterate the shared iterator over the requested half-open interval */
 int wkf_threadpool_next_tile(void* voidparms, int reqsize, wkf_tasktile_t* tile) {
     int rc;
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voidparms;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voidparms;
     rc = wkf_shared_iterator_next_tile(worker->iter, reqsize, tile);
     if (rc == WKF_SCHED_DONE) {
         /* if the error stack is empty, then we're done, otherwise pop */
@@ -2061,14 +2061,14 @@ int wkf_threadpool_next_tile(void* voidparms, int reqsize, wkf_tasktile_t* tile)
  * already taken from the scheduler
  */
 int wkf_threadpool_tile_failed(void* voidparms, wkf_tasktile_t* tile) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voidparms;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voidparms;
     return wkf_tilestack_push(worker->errorstack, tile);
 }
 
 
 /* worker thread calls this to indicate that an unrecoverable error occured */
 int wkf_threadpool_setfatalerror(void* voidparms) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voidparms;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voidparms;
     wkf_shared_iterator_setfatalerror(worker->iter);
     return 0;
 }
@@ -2076,7 +2076,7 @@ int wkf_threadpool_setfatalerror(void* voidparms) {
 
 /* worker thread calls this to indicate that an unrecoverable error occured */
 int wkf_threadpool_getfatalerror(void* voidparms) {
-    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*)voidparms;
+    wkf_threadpool_workerdata_t* worker = (wkf_threadpool_workerdata_t*) voidparms;
     /* query error status for return to caller */
     return wkf_shared_iterator_getfatalerror(worker->iter);
 }
@@ -2100,12 +2100,12 @@ int wkf_threadlaunch(int numprocs, void* clientdata, void* fctn(void*), wkf_task
         return -1;
 
     /* allocate array of threads */
-    threads = (wkf_thread_t*)calloc(numprocs * sizeof(wkf_thread_t), 1);
+    threads = (wkf_thread_t*) calloc(numprocs * sizeof(wkf_thread_t), 1);
     if (threads == NULL)
         return -1;
 
     /* allocate and initialize array of thread parameters */
-    parms = (wkf_threadlaunch_t*)malloc(numprocs * sizeof(wkf_threadlaunch_t));
+    parms = (wkf_threadlaunch_t*) malloc(numprocs * sizeof(wkf_threadlaunch_t));
     if (parms == NULL) {
         free(threads);
         return -1;
@@ -2127,7 +2127,7 @@ int wkf_threadlaunch(int numprocs, void* clientdata, void* fctn(void*), wkf_task
         /*     will just be using the same device anyway */
         /*     Ideally we shouldn't need to do this....  */
         /* single thread does all of the work */
-        fctn((void*)&parms[0]);
+        fctn((void*) &parms[0]);
     } else {
         /* spawn child threads to do the work */
         for (i = 0; i < numprocs; i++) {
@@ -2141,7 +2141,7 @@ int wkf_threadlaunch(int numprocs, void* clientdata, void* fctn(void*), wkf_task
     }
 #else
     /* single thread does all of the work */
-    fctn((void*)&parms[0]);
+    fctn((void*) &parms[0]);
 #endif
 
     /* free threads/parms */
@@ -2160,7 +2160,7 @@ int wkf_threadlaunch(int numprocs, void* clientdata, void* fctn(void*), wkf_task
 
 /** worker thread can call this to get its ID and number of peers */
 int wkf_threadlaunch_getid(void* voidparms, int* threadid, int* threadcount) {
-    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*)voidparms;
+    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*) voidparms;
     if (threadid != NULL)
         *threadid = worker->threadid;
 
@@ -2173,7 +2173,7 @@ int wkf_threadlaunch_getid(void* voidparms, int* threadid, int* threadcount) {
 
 /** worker thread can call this to get its client data pointer */
 int wkf_threadlaunch_getdata(void* voidparms, void** clientdata) {
-    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*)voidparms;
+    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*) voidparms;
     if (clientdata != NULL)
         *clientdata = worker->clientdata;
 
@@ -2183,14 +2183,14 @@ int wkf_threadlaunch_getdata(void* voidparms, void** clientdata) {
 
 /** iterate the shared iterator over the requested half-open interval */
 int wkf_threadlaunch_next_tile(void* voidparms, int reqsize, wkf_tasktile_t* tile) {
-    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*)voidparms;
+    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*) voidparms;
     return wkf_shared_iterator_next_tile(worker->iter, reqsize, tile);
 }
 
 
 /** worker thread calls this to indicate that an unrecoverable error occured */
 int wkf_threadlaunch_setfatalerror(void* voidparms) {
-    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*)voidparms;
+    wkf_threadlaunch_t* worker = (wkf_threadlaunch_t*) voidparms;
     return wkf_shared_iterator_setfatalerror(worker->iter);
 }
 

--- a/plugins/protein_cuda/src/quicksurf/WKFUtils.cpp
+++ b/plugins/protein_cuda/src/quicksurf/WKFUtils.cpp
@@ -94,35 +94,35 @@ typedef struct {
 } wkf_timer;
 
 void wkf_timer_start(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     t->starttime = GetTickCount();
 }
 
 void wkf_timer_stop(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     t->endtime = GetTickCount();
 }
 
 double wkf_timer_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
 
-    ttime = ((double)(t->endtime - t->starttime)) / 1000.0;
+    ttime = ((double) (t->endtime - t->starttime)) / 1000.0;
 
     return ttime;
 }
 
 double wkf_timer_start_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
-    ttime = ((double)(t->starttime)) / 1000.0;
+    ttime = ((double) (t->starttime)) / 1000.0;
     return ttime;
 }
 
 double wkf_timer_stop_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
-    ttime = ((double)(t->endtime)) / 1000.0;
+    ttime = ((double) (t->endtime)) / 1000.0;
     return ttime;
 }
 
@@ -135,34 +135,34 @@ typedef struct {
 } wkf_timer;
 
 void wkf_timer_start(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     gettimeofday(&t->starttime, &t->tz);
 }
 
 void wkf_timer_stop(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     gettimeofday(&t->endtime, &t->tz);
 }
 
 double wkf_timer_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
-    ttime = ((double)(t->endtime.tv_sec - t->starttime.tv_sec)) +
-            ((double)(t->endtime.tv_usec - t->starttime.tv_usec)) / 1000000.0;
+    ttime = ((double) (t->endtime.tv_sec - t->starttime.tv_sec)) +
+            ((double) (t->endtime.tv_usec - t->starttime.tv_usec)) / 1000000.0;
     return ttime;
 }
 
 double wkf_timer_start_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
-    ttime = ((double)t->starttime.tv_sec) + ((double)t->starttime.tv_usec) / 1000000.0;
+    ttime = ((double) t->starttime.tv_sec) + ((double) t->starttime.tv_usec) / 1000000.0;
     return ttime;
 }
 
 double wkf_timer_stop_time(wkf_timerhandle v) {
-    wkf_timer* t = (wkf_timer*)v;
+    wkf_timer* t = (wkf_timer*) v;
     double ttime;
-    ttime = ((double)t->endtime.tv_sec) + ((double)t->endtime.tv_usec) / 1000000.0;
+    ttime = ((double) t->endtime.tv_sec) + ((double) t->endtime.tv_usec) / 1000000.0;
     return ttime;
 }
 
@@ -171,7 +171,7 @@ double wkf_timer_stop_time(wkf_timerhandle v) {
 // system independent routines to create and destroy timers
 wkf_timerhandle wkf_timer_create(void) {
     wkf_timer* t;
-    t = (wkf_timer*)malloc(sizeof(wkf_timer));
+    t = (wkf_timer*) malloc(sizeof(wkf_timer));
     memset(t, 0, sizeof(wkf_timer));
     return t;
 }
@@ -188,7 +188,7 @@ double wkf_timer_timenow(wkf_timerhandle v) {
 /// initialize status message timer
 wkfmsgtimer* wkf_msg_timer_create(double updatetime) {
     wkfmsgtimer* mt;
-    mt = (wkfmsgtimer*)malloc(sizeof(wkfmsgtimer));
+    mt = (wkfmsgtimer*) malloc(sizeof(wkfmsgtimer));
     if (mt != NULL) {
         mt->timer = wkf_timer_create();
         mt->updatetime = updatetime;

--- a/plugins/protein_cuda/src/quicksurf/utilities.cpp
+++ b/plugins/protein_cuda/src/quicksurf/utilities.cpp
@@ -221,7 +221,7 @@ char* str_tokenize(const char* newcmd, int* argc, char* argv[]) {
         argv[*argc] = strtok(NULL, " ,;\t\n");
     }
 
-    return (*argc > 0 ? argv[0] : (char*)NULL);
+    return (*argc > 0 ? argv[0] : (char*) NULL);
 }
 
 
@@ -239,7 +239,7 @@ double time_of_day(void) {
     struct timezone tz;
 
     gettimeofday(&tm, &tz);
-    return ((double)(tm.tv_sec) + (double)(tm.tv_usec) / 1000000.0);
+    return ((double) (tm.tv_sec) + (double) (tm.tv_usec) / 1000000.0);
 #endif
 }
 
@@ -264,7 +264,7 @@ int vmd_check_stdin(void) {
 #if !defined(ARCH_AIX3)
     ret = select(16, &readvec, NULL, NULL, &timeout);
 #else
-    ret = select(16, (int*)(&readvec), NULL, NULL, &timeout);
+    ret = select(16, (int*) (&readvec), NULL, NULL, &timeout);
 #endif
 
     if (ret == -1) {        // got an error
@@ -285,7 +285,7 @@ char* vmd_username(void) {
     char username[1024];
     unsigned long size = 1023;
 
-    if (GetUserName((char*)&username, &size)) {
+    if (GetUserName((char*) &username, &size)) {
         return stringdup(username);
     } else {
         return stringdup("Windows User");
@@ -393,7 +393,7 @@ float angle(const float* a, const float* b) {
     cross_prod(ab, a, b);
     float psin = sqrtf(dot_prod(ab, ab));
     float pcos = dot_prod(a, b);
-    return 57.2958f * (float)atan2(psin, pcos);
+    return 57.2958f * (float) atan2(psin, pcos);
 }
 
 
@@ -414,7 +414,7 @@ float dihedral(const float* a1, const float* a2, const float* a3, const float* a
 
     // atan2f would be faster, but we'll have to workaround the lack
     // of existence on some platforms.
-    return 57.2958f * (float)atan2(psin, pcos);
+    return 57.2958f * (float) atan2(psin, pcos);
 }
 
 // compute the distance between points a & b
@@ -567,7 +567,7 @@ long vmd_get_total_physmem_mb(void) {
                 return -1;
             pos += 9; /* skip tag */
             ;
-            return strtol(pos, (char**)NULL, 10) / 1024L;
+            return strtol(pos, (char**) NULL, 10) / 1024L;
         }
     }
     return -1;
@@ -623,19 +623,19 @@ long vmd_get_avail_physmem_mb(void) {
             if (pos != NULL) {
                 pos += 8; /* skip tag */
                 ;
-                val += strtol(pos, (char**)NULL, 10);
+                val += strtol(pos, (char**) NULL, 10);
             }
             pos = strstr(meminfobuf, "Buffers:");
             if (pos != NULL) {
                 pos += 8; /* skip tag */
                 ;
-                val += strtol(pos, (char**)NULL, 10);
+                val += strtol(pos, (char**) NULL, 10);
             }
             pos = strstr(meminfobuf, "Cached:");
             if (pos != NULL) {
                 pos += 8; /* skip tag */
                 ;
-                val += strtol(pos, (char**)NULL, 10);
+                val += strtol(pos, (char**) NULL, 10);
             }
             return val / 1024L;
         } else {
@@ -676,10 +676,10 @@ long vmd_get_avail_physmem_mb(void) {
 /// return integer percentage of physical memory available
 long vmd_get_avail_physmem_percent(void) {
     double total, avail;
-    total = (double)vmd_get_total_physmem_mb();
-    avail = (double)vmd_get_avail_physmem_mb();
+    total = (double) vmd_get_total_physmem_mb();
+    avail = (double) vmd_get_avail_physmem_mb();
     if (total > 0.0 && avail >= 0.0)
-        return (long)(avail / (total / 100.0));
+        return (long) (avail / (total / 100.0));
 
     return -1; /* return an error */
 }
@@ -687,9 +687,9 @@ long vmd_get_avail_physmem_percent(void) {
 
 // returns minimum distance for Poisson disk sampler
 float correction(int nrays) {
-    float N = (float)nrays;
+    float N = (float) nrays;
     float eightPi = VMD_PIF * 8.0f;
-    float denom = (float)(N * (3.0f * sqrtf(3)));
+    float denom = (float) (N * (3.0f * sqrtf(3)));
     float ans = sqrtf(eightPi / denom);
     float minD = sqrtf((ans * ans) + powf(((VMD_PIF / 6.0f) * ans), 2));
 
@@ -721,7 +721,7 @@ float arcdistance(float lambda1, float lambda2, float phi1, float phi2) {
     sincosf(lambda2, &sl2, &cl2);
     sincosf(phi2, &sp2, &cp2);
 
-    float cos_Ang = (float)(((cl1 * sp1) * (cl2 * sp2)) + ((sl1 * sp1) * (sl2 * sp2)) + (cp1 * cp2));
+    float cos_Ang = (float) (((cl1 * sp1) * (cl2 * sp2)) + ((sl1 * sp1) * (sl2 * sp2)) + (cp1 * cp2));
 
     return acosf(cos_Ang);
 }
@@ -742,11 +742,11 @@ int k_candidates(int k, int nrays, int idx, int testpt, float minD, float* candi
 
     float dp, dl;
     for (int i = 0; i < k; i++) {
-        dl = (float)(lambda1 - (minLambda + ((float)(RAND_MAX_INV * vmd_random())) * minLambda));
-        dp = (float)(phi1 - (minPhi + ((float)(RAND_MAX_INV * vmd_random())) * minPhi));
+        dl = (float) (lambda1 - (minLambda + ((float) (RAND_MAX_INV * vmd_random())) * minLambda));
+        dp = (float) (phi1 - (minPhi + ((float) (RAND_MAX_INV * vmd_random())) * minPhi));
 
-        candidates[i * 2 + 0] = (float)(lambda1 + (dl));
-        candidates[i * 2 + 1] = (float)(phi1 + (dp));
+        candidates[i * 2 + 0] = (float) (lambda1 + (dl));
+        candidates[i * 2 + 1] = (float) (phi1 + (dp));
     }
 
     for (int j = 0; j < k; j++) {
@@ -807,8 +807,8 @@ int poisson_sample_on_sphere(float* population, int N, int k, int verbose) {
     int numactive = N;
 
     vmd_srandom(512346);
-    population[0] = (float)((RAND_MAX_INV * vmd_random()) * VMD_TWOPI);
-    population[1] = (float)((RAND_MAX_INV * vmd_random()) * VMD_PI);
+    population[0] = (float) ((RAND_MAX_INV * vmd_random()) * VMD_TWOPI);
+    population[1] = (float) ((RAND_MAX_INV * vmd_random()) * VMD_PI);
     popul++; //for consistency -- popul incremented after each addition
 
     while (converged == 0) {

--- a/plugins/protein_cuda/src/quicksurf/utilities.h
+++ b/plugins/protein_cuda/src/quicksurf/utilities.h
@@ -225,9 +225,9 @@ inline void vec_scale(float* a, float b, const float* c) {
 
 /// a = b*c
 inline void vec_scale(float* a, float b, const double* c) {
-    a[0] = b * (float)c[0];
-    a[1] = b * (float)c[1];
-    a[2] = b * (float)c[2];
+    a[0] = b * (float) c[0];
+    a[1] = b * (float) c[1];
+    a[2] = b * (float) c[2];
 }
 
 /// a = -b

--- a/plugins/protein_gl/src/CartoonTessellationRenderer.cpp
+++ b/plugins/protein_gl/src/CartoonTessellationRenderer.cpp
@@ -207,7 +207,7 @@ void CartoonTessellationRenderer::getBytesAndStride(MolecularDataCall& mol, unsi
     vertBytes = 0;
     colBytes = 0;
     // colBytes = std::max(colBytes, 3 * 4U);
-    vertBytes = std::max(vertBytes, (unsigned int)sizeof(CAlpha));
+    vertBytes = std::max(vertBytes, (unsigned int) sizeof(CAlpha));
 
     colStride = 0;
     colStride = colStride < colBytes ? colBytes : colStride;
@@ -401,7 +401,7 @@ bool CartoonTessellationRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
                 // is the current residue really an aminoacid?
                 if (mol->Residues()[aaIdx]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                    acid = (MolecularDataCall::AminoAcid*)(mol->Residues()[aaIdx]);
+                    acid = (MolecularDataCall::AminoAcid*) (mol->Residues()[aaIdx]);
                 else
                     continue;
 
@@ -417,7 +417,7 @@ bool CartoonTessellationRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                 calpha.dir[2] = mol->AtomPositions()[3 * acid->OIndex() + 2] - calpha.pos[2];
 
                 auto type = mol->SecondaryStructures()[secIdx].Type();
-                calpha.type = (int)type;
+                calpha.type = (int) type;
                 molSizes[molIdx]++;
 
                 // TODO do this on GPU?
@@ -532,7 +532,7 @@ bool CartoonTessellationRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
             UINT64 numVerts, vertCounter;
             numVerts = this->bufSize / vertStride;
-            const char* currVert = (const char*)(this->positionsCa[i].data());
+            const char* currVert = (const char*) (this->positionsCa[i].data());
             const char* currCol = 0;
             vertCounter = 0;
             while (vertCounter < this->positionsCa[i].size() / 4) {
@@ -540,14 +540,14 @@ bool CartoonTessellationRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                 const char* whence = currVert;
                 UINT64 vertsThisTime = std::min(this->positionsCa[i].size() / 4 - vertCounter, numVerts);
                 this->waitSignal(fences[currBuf]);
-                memcpy(mem, whence, (size_t)vertsThisTime * vertStride);
+                memcpy(mem, whence, (size_t) vertsThisTime * vertStride);
                 glFlushMappedNamedBufferRangeEXT(
-                    theSingleBuffer, bufSize * currBuf, (GLsizeiptr)vertsThisTime * vertStride);
+                    theSingleBuffer, bufSize * currBuf, (GLsizeiptr) vertsThisTime * vertStride);
 
                 glBindBufferRange(
                     GL_SHADER_STORAGE_BUFFER, SSBObindingPoint, this->theSingleBuffer, bufSize * currBuf, bufSize);
                 glPatchParameteri(GL_PATCH_VERTICES, 1);
-                glDrawArrays(GL_PATCHES, 0, (GLsizei)vertsThisTime - 3);
+                glDrawArrays(GL_PATCHES, 0, (GLsizei) vertsThisTime - 3);
                 this->queueSignal(fences[currBuf]);
 
                 currBuf = (currBuf + 1) % this->numBuffers;
@@ -599,23 +599,23 @@ bool CartoonTessellationRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         numVerts = this->bufSize / vertStride;
         UINT64 stride = 0;
 
-        for (int i = 0; i < (int)molSizes.size(); i++) {
+        for (int i = 0; i < (int) molSizes.size(); i++) {
             UINT64 vertCounter = 0;
             while (vertCounter < molSizes[i]) {
-                const char* currVert = (const char*)(&mainchain[(unsigned int)vertCounter + (unsigned int)stride]);
+                const char* currVert = (const char*) (&mainchain[(unsigned int) vertCounter + (unsigned int) stride]);
                 void* mem = static_cast<char*>(this->theSingleMappedMem) + bufSize * currBuf;
                 const char* whence = currVert;
                 UINT64 vertsThisTime = std::min(molSizes[i] - vertCounter, numVerts);
                 this->waitSignal(fences[currBuf]);
-                memcpy(mem, whence, (size_t)vertsThisTime * vertStride);
+                memcpy(mem, whence, (size_t) vertsThisTime * vertStride);
                 glFlushMappedNamedBufferRangeEXT(
-                    theSingleBuffer, bufSize * currBuf, (GLsizeiptr)vertsThisTime * vertStride);
+                    theSingleBuffer, bufSize * currBuf, (GLsizeiptr) vertsThisTime * vertStride);
                 cartoonShader_->setUniform("instanceOffset", 0);
 
                 glBindBufferRange(
                     GL_SHADER_STORAGE_BUFFER, SSBObindingPoint, this->theSingleBuffer, bufSize * currBuf, bufSize);
                 glPatchParameteri(GL_PATCH_VERTICES, 1);
-                glDrawArrays(GL_PATCHES, 0, (GLsizei)(vertsThisTime - 3));
+                glDrawArrays(GL_PATCHES, 0, (GLsizei) (vertsThisTime - 3));
                 this->queueSignal(fences[currBuf]);
 
                 currBuf = (currBuf + 1) % this->numBuffers;

--- a/plugins/protein_gl/src/DiagramRenderer.cpp
+++ b/plugins/protein_gl/src/DiagramRenderer.cpp
@@ -200,7 +200,7 @@ bool DiagramRenderer::CalcExtents() {
     this->yRange.SetSecond(-FLT_MAX);
     bool drawCategorical = this->drawCategoricalParam.Param<param::EnumParam>()->Value() != 0;
     if (autoFit) {
-        for (int s = 0; s < (int)diagram->GetSeriesCount(); s++) {
+        for (int s = 0; s < (int) diagram->GetSeriesCount(); s++) {
             protein_calls::DiagramCall::DiagramSeries* ds = diagram->GetSeries(s);
             const protein_calls::DiagramCall::DiagramMappable* dm = ds->GetMappable();
             if (seriesVisible[s] && isCategoricalMappable(dm) == drawCategorical) {
@@ -320,7 +320,7 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
                 bool drawCategorical = this->drawCategoricalParam.Param<param::EnumParam>()->Value() != 0;
                 vislib::Array<int> visibleSeries;
                 visibleSeries.SetCapacityIncrement(10);
-                for (int i = 0; i < (int)diagram->GetSeriesCount(); i++) {
+                for (int i = 0; i < (int) diagram->GetSeriesCount(); i++) {
                     if (isCategoricalMappable(diagram->GetSeries(i)->GetMappable()) == drawCategorical) {
                         visibleSeries.Add(i);
                     }
@@ -345,10 +345,10 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
                 if (type == DIAGRAM_TYPE_LINE || type == DIAGRAM_TYPE_LINE_STACKED ||
                     type == DIAGRAM_TYPE_LINE_STACKED_NORMALIZED) {
 
-                    for (int i = 0; i < (int)preparedData->Count(); i++) {
+                    for (int i = 0; i < (int) preparedData->Count(); i++) {
                         int leftNeighbor = -1;
                         int rightNeighbor = -1;
-                        for (int j = 0; j < (int)(*preparedData)[i]->Count(); j++) {
+                        for (int j = 0; j < (int) (*preparedData)[i]->Count(); j++) {
                             if ((*(*preparedData)[i])[j] != NULL) {
                                 if ((*(*preparedData)[i])[j]->GetX() > mouse.GetX()) {
                                     break;
@@ -386,8 +386,8 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
                 } else if (type == DIAGRAM_TYPE_COLUMN || type == DIAGRAM_TYPE_COLUMN_STACKED ||
                            type == DIAGRAM_TYPE_COLUMN_STACKED_NORMALIZED) {
 
-                    for (int i = 0; i < (int)preparedData->Count(); i++) {
-                        for (int j = 0; j < (int)(*preparedData)[i]->Count(); j++) {
+                    for (int i = 0; i < (int) preparedData->Count(); i++) {
+                        for (int j = 0; j < (int) (*preparedData)[i]->Count(); j++) {
                             if ((*(*preparedData)[i])[j] == NULL) {
                                 continue;
                             }
@@ -415,7 +415,7 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
     // propagate selection to selection module
     if (selectionCall != NULL) {
         vislib::Array<int> selectedSeriesIndices;
-        for (int x = 0; x < (int)this->diagram->GetSeriesCount(); x++) {
+        for (int x = 0; x < (int) this->diagram->GetSeriesCount(); x++) {
             if (this->diagram->GetSeries(x) == this->selectedSeries) {
                 selectedSeriesIndices.Add(x);
                 break;
@@ -428,7 +428,7 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
     // propagate visibility to hidden module
     if (hiddenCall != NULL) {
         vislib::Array<int> hiddenSeriesIndices;
-        for (int x = 0; x < (int)this->diagram->GetSeriesCount(); x++) {
+        for (int x = 0; x < (int) this->diagram->GetSeriesCount(); x++) {
             if (!seriesVisible[x]) {
                 hiddenSeriesIndices.Add(x);
             }
@@ -440,11 +440,11 @@ bool DiagramRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
     // hovering
     hoveredMarker = NULL;
     if (preparedData != NULL) {
-        for (int s = 0; s < (int)preparedData->Count(); s++) {
+        for (int s = 0; s < (int) preparedData->Count(); s++) {
             float markerSize = fontSize;
-            for (int i = 0; i < (int)preparedSeries[s]->GetMarkerCount(); i++) {
+            for (int i = 0; i < (int) preparedSeries[s]->GetMarkerCount(); i++) {
                 const protein_calls::DiagramCall::DiagramMarker* m = preparedSeries[s]->GetMarker(i);
-                for (int j = 0; j < (int)this->markerTextures.Count(); j++) {
+                for (int j = 0; j < (int) this->markerTextures.Count(); j++) {
                     if (markerTextures[j].First() == m->GetType()) {
                         markerTextures[j].Second()->Bind();
                         // TODO FIXME BUG WTF does this happen anyway
@@ -488,7 +488,7 @@ bool DiagramRenderer::onCrosshairToggleButton(param::ParamSlot& p) {
  */
 bool DiagramRenderer::onShowAllButton(param::ParamSlot& p) {
     if (this->diagram != NULL) {
-        for (int i = 0; i < (int)this->diagram->GetSeriesCount(); i++) {
+        for (int i = 0; i < (int) this->diagram->GetSeriesCount(); i++) {
             // this->diagram->GetSeries(i)->SetVisible(true);
             seriesVisible[i] = true;
         }
@@ -502,7 +502,7 @@ bool DiagramRenderer::onShowAllButton(param::ParamSlot& p) {
  */
 bool DiagramRenderer::onHideAllButton(param::ParamSlot& p) {
     if (this->diagram != NULL) {
-        for (int i = 0; i < (int)this->diagram->GetSeriesCount(); i++) {
+        for (int i = 0; i < (int) this->diagram->GetSeriesCount(); i++) {
             // this->diagram->GetSeries(i)->SetVisible(false);
             seriesVisible[i] = false;
         }
@@ -598,7 +598,7 @@ bool DiagramRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         vislib::StringA tmpString;
         float y;
         if (drawLog) {
-            y = (float)pow(10, hoverPoint.GetY() * log10(yRange.Second() - yRange.First())) + yRange.First();
+            y = (float) pow(10, hoverPoint.GetY() * log10(yRange.Second() - yRange.First())) + yRange.First();
         } else {
             y = hoverPoint.GetY() * (yRange.Second() - yRange.First()) + yRange.First();
         }
@@ -615,7 +615,7 @@ bool DiagramRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     }
 
     if (this->showGuidesParam.Param<param::BoolParam>()->Value()) {
-        for (int i = 0; i < (int)diagram->GetGuideCount(); i++) {
+        for (int i = 0; i < (int) diagram->GetGuideCount(); i++) {
             protein_calls::DiagramCall::DiagramGuide* g = diagram->GetGuide(i);
             ::glDisable(GL_BLEND);
             ::glDisable(GL_DEPTH_TEST);
@@ -699,7 +699,7 @@ void DiagramRenderer::drawYAxis() {
 
         for (int i = startExp; i <= destExp; i++) {
             yTickText[i] = vislib::StringA::EMPTY;
-            float yVal = (float)pow(10, static_cast<float>(i));
+            float yVal = (float) pow(10, static_cast<float>(i));
             yTickText[i].Format("%.2f", yVal);
             yTicks[i] = log10(yVal - yRange.First()) / log10(yRange.Second() - yRange.First());
         }
@@ -762,7 +762,7 @@ void DiagramRenderer::drawXAxis(XAxisTypes xType) {
         //    }
         //}
         // numXTicks++;
-        numXTicks = (int)xValues.Count();
+        numXTicks = (int) xValues.Count();
     } break;
     case DIAGRAM_XAXIS_CATEGORICAL:
         numXTicks = static_cast<int>(categories.Count() + 1);
@@ -796,7 +796,7 @@ void DiagramRenderer::drawXAxis(XAxisTypes xType) {
             break;
         case DIAGRAM_XAXIS_CATEGORICAL: {
             float wMax = 0.0f;
-            for (int i = 0; i < (int)categories.Count(); i++) {
+            for (int i = 0; i < (int) categories.Count(); i++) {
                 float w = theFont.LineWidth(fontSize, categories[i].PeekBuffer());
                 if (w > wMax) {
                     wMax = w;
@@ -867,7 +867,7 @@ void DiagramRenderer::drawLegend() {
     legendOffset = theFont.LineWidth(fontSize, s) + fontSize; // 3.0f * fontSize;
     bool drawCategorical = this->drawCategoricalParam.Param<param::EnumParam>()->Value() != 0;
     int cnt = 0;
-    for (int s = 0; s < (int)diagram->GetSeriesCount(); s++) {
+    for (int s = 0; s < (int) diagram->GetSeriesCount(); s++) {
         protein_calls::DiagramCall::DiagramSeries* ds = diagram->GetSeries(s);
         if (isCategoricalMappable(ds->GetMappable()) == drawCategorical) {
             float w = theFont.LineWidth(fontSize, ds->GetName());
@@ -890,7 +890,7 @@ void DiagramRenderer::drawLegend() {
     ::glVertex3f(-legendOffset, 1.0f, decorationDepth);
     ::glEnd();
     cnt = 0;
-    for (int s = 0; s < (int)diagram->GetSeriesCount(); s++) {
+    for (int s = 0; s < (int) diagram->GetSeriesCount(); s++) {
         protein_calls::DiagramCall::DiagramSeries* ds = diagram->GetSeries(s);
         if (isCategoricalMappable(ds->GetMappable()) == drawCategorical) {
             if (selectedSeries == NULL || *selectedSeries == *ds) {
@@ -964,7 +964,7 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
     float maxStackedY = -FLT_MAX;
     float x, y, z, tempX;
     // find "broadest" series as well as all distinct abscissa values (for stacking)
-    for (int s = 0; s < (int)diagram->GetSeriesCount(); s++) {
+    for (int s = 0; s < (int) diagram->GetSeriesCount(); s++) {
         protein_calls::DiagramCall::DiagramSeries* ds = diagram->GetSeries(s);
         const protein_calls::DiagramCall::DiagramMappable* dm = ds->GetMappable();
         if (dm->GetDataCount() > maxCount) {
@@ -996,7 +996,7 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
     }
     xValues.Sort(&floatComp);
     maxYValues.SetCount(xValues.Count());
-    for (int i = 0; i < (int)maxYValues.Count(); i++) {
+    for (int i = 0; i < (int) maxYValues.Count(); i++) {
         maxYValues[i] = 0.0f;
     }
     // there is a difference between not finding an x value and having a hole which is explicitly returned as NULL
@@ -1004,7 +1004,7 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
 
 #if 1
     int cntSeries = 0;
-    for (int s = 0; s < (int)diagram->GetSeriesCount(); s++) {
+    for (int s = 0; s < (int) diagram->GetSeriesCount(); s++) {
         protein_calls::DiagramCall::DiagramSeries* ds = diagram->GetSeries(s);
         const protein_calls::DiagramCall::DiagramMappable* dm = ds->GetMappable();
         if (!seriesVisible[s] || isCategoricalMappable(dm) != drawCategorical) {
@@ -1012,7 +1012,7 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
         }
         cntSeries++;
         localXIndexToGlobal[cntSeries - 1].SetCount(dm->GetDataCount());
-        if ((int)preparedData->Count() < cntSeries) {
+        if ((int) preparedData->Count() < cntSeries) {
             preparedData->Append(new vislib::PtrArray<vislib::math::Point<float, 3>>());
             preparedSeries.Append(ds);
             (*preparedData)[preparedData->Count() - 1]->SetCount(xValues.Count());
@@ -1139,9 +1139,9 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
 
     // now we could directly stack and normalize
     if (stack) {
-        for (int i = 0; i < (int)xValues.Count(); i++) {
+        for (int i = 0; i < (int) xValues.Count(); i++) {
             float sum = 0.0f;
-            for (int s = 0; s < (int)preparedData->Count(); s++) {
+            for (int s = 0; s < (int) preparedData->Count(); s++) {
                 if ((*(*preparedData)[s])[i] != NULL) {
                     float y = (*(*preparedData)[s])[i]->GetY();
                     (*(*preparedData)[s])[i]->SetZ(sum);
@@ -1157,8 +1157,8 @@ void DiagramRenderer::prepareData(bool stack, bool normalize, bool drawCategoric
     }
     float norm = yRange.Second() - yRange.First();
     norm = drawLog ? log10(norm) : norm;
-    for (int i = 0; i < (int)xValues.Count(); i++) {
-        for (int s = 0; s < (int)preparedData->Count(); s++) {
+    for (int i = 0; i < (int) xValues.Count(); i++) {
+        for (int s = 0; s < (int) preparedData->Count(); s++) {
             if ((*(*preparedData)[s])[i] != NULL) {
                 float y = (*(*preparedData)[s])[i]->GetY();
                 float z = (*(*preparedData)[s])[i]->GetZ();
@@ -1194,9 +1194,9 @@ void DiagramRenderer::dump() {
     vislib::sys::BufferedFile bf;
     bf.Open("dumm.stat", vislib::sys::BufferedFile::WRITE_ONLY, vislib::sys::BufferedFile::SHARE_READ,
         vislib::sys::BufferedFile::CREATE_OVERWRITE);
-    for (int i = 0; i < (int)(*preparedData)[0]->Count(); i++) {
+    for (int i = 0; i < (int) (*preparedData)[0]->Count(); i++) {
         vislib::sys::WriteFormattedLineToFile(bf, "## Frame %u\n", i);
-        for (int s = 0; s < (int)preparedData->Count(); s++) {
+        for (int s = 0; s < (int) preparedData->Count(); s++) {
             if ((*(*preparedData)[s])[i] != NULL) {
                 vislib::sys::WriteFormattedLineToFile(bf, "#C %u %u\n", s + 1,
                     static_cast<int>(vislib::math::Min(
@@ -1204,21 +1204,21 @@ void DiagramRenderer::dump() {
             }
         }
     }
-    for (int s = 0; s < (int)preparedData->Count(); s++) {
-        for (int i = 0; i < (int)preparedSeries[s]->GetMarkerCount(); i++) {
+    for (int s = 0; s < (int) preparedData->Count(); s++) {
+        for (int i = 0; i < (int) preparedSeries[s]->GetMarkerCount(); i++) {
             // WARNING s is synchronized to global series counter since no series that cannot be drawn are added for
             // proteins For the rest of the universe THIS IS WRONG
             const protein_calls::DiagramCall::DiagramMarker* m = preparedSeries[s]->GetMarker(i);
             if (m->GetType() == protein_calls::DiagramCall::DIAGRAM_MARKER_MERGE && m->GetUserData() != NULL) {
                 vislib::Array<int>* partners = reinterpret_cast<vislib::Array<int>*>(m->GetUserData());
-                for (int p = 0; p < (int)partners->Count(); p++) {
+                for (int p = 0; p < (int) partners->Count(); p++) {
                     int idx = localXIndexToGlobal[s][m->GetIndex()];
                     vislib::sys::WriteFormattedLineToFile(
                         bf, "#F %u[%u]=>%u[%u] %u\n", (*partners)[p] + 1, idx - 1, s + 1, idx, 3);
                 }
             } else if (m->GetType() == protein_calls::DiagramCall::DIAGRAM_MARKER_SPLIT && m->GetUserData() != NULL) {
                 vislib::Array<int>* partners = reinterpret_cast<vislib::Array<int>*>(m->GetUserData());
-                for (int p = 0; p < (int)partners->Count(); p++) {
+                for (int p = 0; p < (int) partners->Count(); p++) {
                     // Log::DefaultLog.WriteInfo( "#F %u[%u]=>%u[%u] %u", s + 1, m->GetIndex(),
                     // (*partners)[p] + 1, m->GetIndex() + 1, 3);
                     int idx = localXIndexToGlobal[s][m->GetIndex()];
@@ -1272,7 +1272,7 @@ void DiagramRenderer::drawLineDiagram() {
         drawMode = GL_LINE_STRIP;
         ::glDisable(GL_BLEND);
     }
-    for (int s = 0; s < (int)preparedData->Count(); s++) {
+    for (int s = 0; s < (int) preparedData->Count(); s++) {
         if ((*preparedData)[s]->Count() < 2) {
             continue;
         }
@@ -1282,7 +1282,7 @@ void DiagramRenderer::drawLineDiagram() {
         } else {
             ::glColor4fv(unselectedColor.PeekComponents());
         }
-        for (int i = 0; i < (int)(*preparedData)[s]->Count(); i++) {
+        for (int i = 0; i < (int) (*preparedData)[s]->Count(); i++) {
             if ((*(*preparedData)[s])[i] != NULL) {
                 ::glVertex2f((*(*preparedData)[s])[i]->GetX() * aspect, (*(*preparedData)[s])[i]->GetY());
                 if (drawMode == GL_TRIANGLE_STRIP) {
@@ -1304,12 +1304,12 @@ void DiagramRenderer::drawLineDiagram() {
 
     int showMarkers = this->showMarkersParam.Param<param::EnumParam>()->Value();
     if (showMarkers != DIAGRAM_MARKERS_SHOW_NONE) {
-        for (int s = 0; s < (int)preparedData->Count(); s++) {
+        for (int s = 0; s < (int) preparedData->Count(); s++) {
             if (showMarkers == DIAGRAM_MARKERS_SHOW_ALL || preparedSeries[s] == selectedSeries) {
                 float markerSize = fontSize;
-                for (int i = 0; i < (int)preparedSeries[s]->GetMarkerCount(); i++) {
+                for (int i = 0; i < (int) preparedSeries[s]->GetMarkerCount(); i++) {
                     const protein_calls::DiagramCall::DiagramMarker* m = preparedSeries[s]->GetMarker(i);
-                    for (int j = 0; j < (int)this->markerTextures.Count(); j++) {
+                    for (int j = 0; j < (int) this->markerTextures.Count(); j++) {
                         if (markerTextures[j].First() == m->GetType()) {
                             int idx = localXIndexToGlobal[s][m->GetIndex()];
                             if ((*(*preparedData)[s])[idx] == NULL) {
@@ -1391,9 +1391,9 @@ void DiagramRenderer::drawColumnDiagram() {
     } else {
         drawMode = GL_LINE_STRIP;
     }
-    for (int s = 0; s < (int)preparedData->Count(); s++) {
+    for (int s = 0; s < (int) preparedData->Count(); s++) {
         float x, y, y1;
-        for (int i = 0; i < (int)(*preparedData)[s]->Count(); i++) {
+        for (int i = 0; i < (int) (*preparedData)[s]->Count(); i++) {
             if ((*(*preparedData)[s])[i] == NULL) {
                 continue;
             }

--- a/plugins/protein_gl/src/GLSLVolumeRenderer.cpp
+++ b/plugins/protein_gl/src/GLSLVolumeRenderer.cpp
@@ -636,10 +636,10 @@ void protein_gl::GLSLVolumeRenderer::ParameterRefresh(mmstd_gl::CallRender3DGL* 
     }
 
     // get current clip plane normal
-    vislib::math::Vector<float, 3> cp0n((float)this->volClipPlane[0].PeekComponents()[0],
-        (float)this->volClipPlane[0].PeekComponents()[1], (float)this->volClipPlane[0].PeekComponents()[2]);
+    vislib::math::Vector<float, 3> cp0n((float) this->volClipPlane[0].PeekComponents()[0],
+        (float) this->volClipPlane[0].PeekComponents()[1], (float) this->volClipPlane[0].PeekComponents()[2]);
     // get current clip plane distance
-    float cp0d = (float)this->volClipPlane[0].PeekComponents()[3];
+    float cp0d = (float) this->volClipPlane[0].PeekComponents()[3];
 
     // check clip plane normal parameter
     if (this->volClipPlane0NormParam.IsDirty()) {
@@ -1262,7 +1262,7 @@ void GLSLVolumeRenderer::drawClippedPolygon(vislib::math::Cuboid<float> bounding
 
     // check for each clip plane
     float vcpd;
-    for (int i = 0; i < (int)this->volClipPlane.Count(); ++i) {
+    for (int i = 0; i < (int) this->volClipPlane.Count(); ++i) {
         slices.setupSingleSlice(this->volClipPlane[i].PeekComponents(), position.PeekComponents());
         float d = 0.0f;
         vcpd = static_cast<float>(this->volClipPlane[i].PeekComponents()[3]);

--- a/plugins/protein_gl/src/MoleculeCartoonRenderer.cpp
+++ b/plugins/protein_gl/src/MoleculeCartoonRenderer.cpp
@@ -901,7 +901,7 @@ void MoleculeCartoonRenderer::RenderCartoonHybrid(const MolecularDataCall* mol, 
                     bSplineSecStruct[cntChain].push_back(mol->SecondaryStructures()[cntS].Type());
                     // get the index of the C-alpha atom
                     if (mol->Residues()[cntAA]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                        aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA]);
+                        aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA]);
                     else
                         continue;
                     idx = aminoacid->CAlphaIndex();
@@ -1298,7 +1298,7 @@ void MoleculeCartoonRenderer::RenderCartoonCPU(const MolecularDataCall* mol, flo
 
                     // get the index of the C-alpha atom
                     if (mol->Residues()[cntAA]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                        aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA]);
+                        aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA]);
                     else
                         continue;
 
@@ -2028,7 +2028,7 @@ void MoleculeCartoonRenderer::RenderCartoonLineCPU(const MolecularDataCall* mol,
                     bSplineSecStruct[cntChain].push_back(mol->SecondaryStructures()[cntS].Type());
                     // get the index of the C-alpha atom
                     if (mol->Residues()[cntAA]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                        aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA]);
+                        aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA]);
                     else
                         continue;
                     idx = aminoacid->CAlphaIndex();
@@ -2143,7 +2143,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPU(const MolecularDataCall* mol, flo
                 glBegin(GL_LINES_ADJACENCY_EXT);
 
                 // vertex 1
-                aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA]);
+                aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA]);
                 idx = aminoacid->CAlphaIndex();
                 v1.SetX(atomPos[idx * 3 + 0]);
                 v1.SetY(atomPos[idx * 3 + 1]);
@@ -2163,7 +2163,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPU(const MolecularDataCall* mol, flo
                 else
                     flip = 1.0;
                 n1 *= flip;
-                aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA + 2]);
+                aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA + 2]);
                 idx = aminoacid->CAlphaIndex();
                 glSecondaryColor3f(
                     this->atomColorTable[idx].x, this->atomColorTable[idx].y, this->atomColorTable[idx].z);
@@ -2171,7 +2171,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPU(const MolecularDataCall* mol, flo
                 glVertex3fv(v1.PeekComponents());
 
                 // vertex 2
-                aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA + 1]);
+                aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA + 1]);
                 idx = aminoacid->CAlphaIndex();
                 v2.SetX(atomPos[idx * 3 + 0]);
                 v2.SetY(atomPos[idx * 3 + 1]);
@@ -2196,7 +2196,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPU(const MolecularDataCall* mol, flo
                 glVertex3fv(v2.PeekComponents());
 
                 // vertex 3
-                aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA + 2]);
+                aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA + 2]);
                 idx = aminoacid->CAlphaIndex();
                 v3.SetX(atomPos[idx * 3 + 0]);
                 v3.SetY(atomPos[idx * 3 + 1]);
@@ -2220,7 +2220,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPU(const MolecularDataCall* mol, flo
                 glVertex3fv(v3.PeekComponents());
 
                 // vertex 4
-                aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA + 3]);
+                aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA + 3]);
                 idx = aminoacid->CAlphaIndex();
                 v4.SetX(atomPos[idx * 3 + 0]);
                 v4.SetY(atomPos[idx * 3 + 1]);
@@ -2321,7 +2321,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPUTubeOnly(const MolecularDataCall* 
                     bSplineSecStruct[cntChain].push_back(mol->SecondaryStructures()[cntS].Type());
                     // get the index of the C-alpha atom
                     if (mol->Residues()[cntAA]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                        aminoacid = (MolecularDataCall::AminoAcid*)(mol->Residues()[cntAA]);
+                        aminoacid = (MolecularDataCall::AminoAcid*) (mol->Residues()[cntAA]);
                     else
                         continue;
                     idx = aminoacid->CAlphaIndex();
@@ -2381,7 +2381,7 @@ void MoleculeCartoonRenderer::RenderCartoonGPUTubeOnly(const MolecularDataCall* 
         // --- START store the vertices, colors and parameters ---
         this->totalCountTube = 0;
         for (unsigned int i = 0; i < bSplineCoords.size(); i++) {
-            this->totalCountTube += (unsigned int)bSplineCoords[i].size();
+            this->totalCountTube += (unsigned int) bSplineCoords[i].size();
         }
 
         if (this->vertTube)

--- a/plugins/protein_gl/src/MoleculeSESRenderer.cpp
+++ b/plugins/protein_gl/src/MoleculeSESRenderer.cpp
@@ -656,7 +656,7 @@ void MoleculeSESRenderer::RenderSESGpuRaycasting(const MolecularDataCall* mol) {
             torusShader_->setUniform("mvpinverse", mvpinverse_);
             torusShader_->setUniform("mvptransposed", mvptranspose_);
 
-            glDrawArrays(GL_POINTS, 0, ((unsigned int)this->torusVertexArray[cntRS].Count()) / 3);
+            glDrawArrays(GL_POINTS, 0, ((unsigned int) this->torusVertexArray[cntRS].Count()) / 3);
 
             glUseProgram(0);
             glBindVertexArray(0);
@@ -701,7 +701,7 @@ void MoleculeSESRenderer::RenderSESGpuRaycasting(const MolecularDataCall* mol) {
             sphericalTriangleShader_->setUniform("camUp", up);
             sphericalTriangleShader_->setUniform("zValues", nearplane, farplane);
             sphericalTriangleShader_->setUniform(
-                "texOffset", 1.0f / (float)this->singTexWidth[cntRS], 1.0f / (float)this->singTexHeight[cntRS]);
+                "texOffset", 1.0f / (float) this->singTexWidth[cntRS], 1.0f / (float) this->singTexHeight[cntRS]);
             sphericalTriangleShader_->setUniform("view", view_);
             sphericalTriangleShader_->setUniform("proj", proj_);
             sphericalTriangleShader_->setUniform("viewInverse", invview_);
@@ -709,7 +709,7 @@ void MoleculeSESRenderer::RenderSESGpuRaycasting(const MolecularDataCall* mol) {
             sphericalTriangleShader_->setUniform("mvpinverse", mvpinverse_);
             sphericalTriangleShader_->setUniform("mvptransposed", mvptranspose_);
 
-            glDrawArrays(GL_POINTS, 0, ((unsigned int)this->sphericTriaVertexArray[cntRS].Count()) / 4);
+            glDrawArrays(GL_POINTS, 0, ((unsigned int) this->sphericTriaVertexArray[cntRS].Count()) / 4);
 
             // disable spherical triangle shader
             glUseProgram(0);
@@ -742,7 +742,7 @@ void MoleculeSESRenderer::RenderSESGpuRaycasting(const MolecularDataCall* mol) {
         sphereShader_->setUniform("mvpinverse", mvpinverse_);
         sphereShader_->setUniform("mvptransposed", mvptranspose_);
 
-        glDrawArrays(GL_POINTS, 0, ((unsigned int)this->sphereVertexArray[cntRS].Count()) / 4);
+        glDrawArrays(GL_POINTS, 0, ((unsigned int) this->sphereVertexArray[cntRS].Count()) / 4);
 
         // disable sphere shader
         glUseProgram(0);
@@ -831,23 +831,23 @@ void MoleculeSESRenderer::ComputeRaycastingArrays() {
             this->sphericTriaVec3[cntRS][i * 4 + 3] = dualProbeRad * dualProbeRad;
             // store number of cutting probes and texture coordinates for each edge
             this->sphericTriaTexCoord1[cntRS][i * 3 + 0] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->cuttingProbes.size();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->cuttingProbes.size();
             this->sphericTriaTexCoord1[cntRS][i * 3 + 1] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->GetTexCoordX();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->GetTexCoordX();
             this->sphericTriaTexCoord1[cntRS][i * 3 + 2] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->GetTexCoordY();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge1()->GetTexCoordY();
             this->sphericTriaTexCoord2[cntRS][i * 3 + 0] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->cuttingProbes.size();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->cuttingProbes.size();
             this->sphericTriaTexCoord2[cntRS][i * 3 + 1] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->GetTexCoordX();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->GetTexCoordX();
             this->sphericTriaTexCoord2[cntRS][i * 3 + 2] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->GetTexCoordY();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge2()->GetTexCoordY();
             this->sphericTriaTexCoord3[cntRS][i * 3 + 0] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->cuttingProbes.size();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->cuttingProbes.size();
             this->sphericTriaTexCoord3[cntRS][i * 3 + 1] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->GetTexCoordX();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->GetTexCoordX();
             this->sphericTriaTexCoord3[cntRS][i * 3 + 2] =
-                (float)this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->GetTexCoordY();
+                (float) this->reducedSurface[cntRS]->GetRSFace(i)->GetEdge3()->GetTexCoordY();
             // colors
             this->sphericTriaColors[cntRS][i * 3 + 0] =
                 CodeColor(&this->atomColorTable[this->reducedSurface[cntRS]->GetRSFace(i)->GetVertex1()->GetIndex()].x);
@@ -1105,23 +1105,23 @@ void MoleculeSESRenderer::ComputeRaycastingArrays(unsigned int idxRS) {
         this->sphericTriaVec3[idxRS][i * 4 + 3] = dualProbeRad * dualProbeRad;
         // store number of cutting probes and texture coordinates for each edge
         this->sphericTriaTexCoord1[idxRS][i * 3 + 0] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->cuttingProbes.size();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->cuttingProbes.size();
         this->sphericTriaTexCoord1[idxRS][i * 3 + 1] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->GetTexCoordX();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->GetTexCoordX();
         this->sphericTriaTexCoord1[idxRS][i * 3 + 2] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->GetTexCoordY();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge1()->GetTexCoordY();
         this->sphericTriaTexCoord2[idxRS][i * 3 + 0] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->cuttingProbes.size();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->cuttingProbes.size();
         this->sphericTriaTexCoord2[idxRS][i * 3 + 1] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->GetTexCoordX();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->GetTexCoordX();
         this->sphericTriaTexCoord2[idxRS][i * 3 + 2] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->GetTexCoordY();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge2()->GetTexCoordY();
         this->sphericTriaTexCoord3[idxRS][i * 3 + 0] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->cuttingProbes.size();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->cuttingProbes.size();
         this->sphericTriaTexCoord3[idxRS][i * 3 + 1] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->GetTexCoordX();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->GetTexCoordX();
         this->sphericTriaTexCoord3[idxRS][i * 3 + 2] =
-            (float)this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->GetTexCoordY();
+            (float) this->reducedSurface[idxRS]->GetRSFace(i)->GetEdge3()->GetTexCoordY();
         // colors
         this->sphericTriaColors[idxRS][i * 3 + 0] =
             CodeColor(&this->atomColorTable[this->reducedSurface[idxRS]->GetRSFace(i)->GetVertex1()->GetIndex()].x);
@@ -1286,9 +1286,9 @@ void MoleculeSESRenderer::ComputeRaycastingArrays(unsigned int idxRS) {
  * code a rgb-color into one float
  */
 float MoleculeSESRenderer::CodeColor(const float* col) const {
-    return float((int)(col[0] * 255.0f) * 1000000 // red
-                 + (int)(col[1] * 255.0f) * 1000  // green
-                 + (int)(col[2] * 255.0f));       // blue
+    return float((int) (col[0] * 255.0f) * 1000000 // red
+                 + (int) (col[1] * 255.0f) * 1000  // green
+                 + (int) (col[2] * 255.0f));       // blue
 }
 
 
@@ -1300,12 +1300,12 @@ vislib::math::Vector<float, 3> MoleculeSESRenderer::DecodeColor(int codedColor) 
     vislib::math::Vector<float, 3> color;
     float red, green;
     if (col >= 1000000)
-        red = floor((float)col / 1000000.0f);
+        red = floor((float) col / 1000000.0f);
     else
         red = 0.0;
     col = col - int(red * 1000000.0f);
     if (col > 1000)
-        green = floor((float)col / 1000.0f);
+        green = floor((float) col / 1000.0f);
     else
         green = 0.0;
     col = col - int(green * 1000.0f);
@@ -1330,7 +1330,7 @@ void MoleculeSESRenderer::CreateSingularityTextures() {
     // check if the singularity texture has the right size
     if (this->reducedSurface.size() != this->singularityTexture.size()) {
         // store old singularity texture size
-        unsigned int singTexSizeOld = (unsigned int)this->singularityTexture.size();
+        unsigned int singTexSizeOld = (unsigned int) this->singularityTexture.size();
         // resize singularity texture to fit the number of reduced surfaces
         this->singularityTexture.resize(this->reducedSurface.size());
         // generate a new texture for each new singularity texture
@@ -1351,10 +1351,10 @@ void MoleculeSESRenderer::CreateSingularityTextures() {
 
     for (cntRS = 0; cntRS < this->reducedSurface.size(); ++cntRS) {
         // set width and height of texture
-        if ((unsigned int)texSize < this->reducedSurface[cntRS]->GetCutRSEdgesCount()) {
+        if ((unsigned int) texSize < this->reducedSurface[cntRS]->GetCutRSEdgesCount()) {
             this->singTexHeight[cntRS] = texSize;
             this->singTexWidth[cntRS] =
-                numProbes * (int)ceil(double(this->reducedSurface[cntRS]->GetCutRSEdgesCount()) / (double)texSize);
+                numProbes * (int) ceil(double(this->reducedSurface[cntRS]->GetCutRSEdgesCount()) / (double) texSize);
         } else {
             this->singTexHeight[cntRS] = this->reducedSurface[cntRS]->GetCutRSEdgesCount();
             this->singTexWidth[cntRS] = numProbes;
@@ -1447,10 +1447,10 @@ void MoleculeSESRenderer::CreateSingularityTexture(unsigned int idxRS) {
     unsigned int numProbes = 16;
 
     // set width and height of texture
-    if ((unsigned int)texSize < this->reducedSurface[idxRS]->GetCutRSEdgesCount()) {
+    if ((unsigned int) texSize < this->reducedSurface[idxRS]->GetCutRSEdgesCount()) {
         this->singTexHeight[idxRS] = texSize;
         this->singTexWidth[idxRS] =
-            numProbes * (int)ceil(double(this->reducedSurface[idxRS]->GetCutRSEdgesCount()) / (double)texSize);
+            numProbes * (int) ceil(double(this->reducedSurface[idxRS]->GetCutRSEdgesCount()) / (double) texSize);
     } else {
         this->singTexHeight[idxRS] = this->reducedSurface[idxRS]->GetCutRSEdgesCount();
         this->singTexWidth[idxRS] = numProbes;

--- a/plugins/protein_gl/src/RamachandranPlot.cpp
+++ b/plugins/protein_gl/src/RamachandranPlot.cpp
@@ -400,7 +400,7 @@ void RamachandranPlot::computeDihedralAngles(protein_calls::MolecularDataCall& m
             protein_calls::MolecularDataCall::AminoAcid* acid = nullptr;
 
             if (mol.Residues()[aaIdx]->Identifier() == protein_calls::MolecularDataCall::Residue::AMINOACID) {
-                acid = (protein_calls::MolecularDataCall::AminoAcid*)(mol.Residues()[aaIdx]);
+                acid = (protein_calls::MolecularDataCall::AminoAcid*) (mol.Residues()[aaIdx]);
             } else {
                 angles_[aaIdx].x = -1000.0f;
                 angles_[aaIdx].y = -1000.0f;
@@ -422,7 +422,7 @@ void RamachandranPlot::computeDihedralAngles(protein_calls::MolecularDataCall& m
                 // we have no prevCPos
                 phi = -1000.0f;
             } else {
-                acid = (protein_calls::MolecularDataCall::AminoAcid*)(mol.Residues()[aaIdx - 1]);
+                acid = (protein_calls::MolecularDataCall::AminoAcid*) (mol.Residues()[aaIdx - 1]);
                 if (acid != nullptr) {
                     prevCPos = glm::make_vec3(&mol.AtomPositions()[acid->CCarbIndex() * 3]);
                 } else {
@@ -434,7 +434,7 @@ void RamachandranPlot::computeDihedralAngles(protein_calls::MolecularDataCall& m
                 // we have no nextNPos
                 psi = -1000.0f;
             } else {
-                acid = (protein_calls::MolecularDataCall::AminoAcid*)(mol.Residues()[aaIdx + 1]);
+                acid = (protein_calls::MolecularDataCall::AminoAcid*) (mol.Residues()[aaIdx + 1]);
                 if (acid != nullptr) {
                     nextNPos = glm::make_vec3(&mol.AtomPositions()[acid->NIndex() * 3]);
                 } else {

--- a/plugins/protein_gl/src/SequenceRenderer.cpp
+++ b/plugins/protein_gl/src/SequenceRenderer.cpp
@@ -198,7 +198,7 @@ bool SequenceRenderer::GetExtents(mmstd_gl::CallRender2DGL& call) {
 
     // prepare the data
     if (!this->dataPrepared) {
-        unsigned int oldRowHeight = (unsigned int)this->rowHeight;
+        unsigned int oldRowHeight = (unsigned int) this->rowHeight;
         this->dataPrepared = this->PrepareData(mol, bs);
         if (oldRowHeight != this->rowHeight) {
             this->dataPrepared = this->PrepareData(mol, bs);
@@ -412,7 +412,7 @@ bool SequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
         // labeling
         for (unsigned int i = 0; i < this->aminoAcidStrings.size(); i++) {
-            for (unsigned int j = 0; j < (unsigned int)this->aminoAcidStrings[i].size(); j++) {
+            for (unsigned int j = 0; j < (unsigned int) this->aminoAcidStrings[i].size(); j++) {
                 // draw the one-letter amino acid code
                 font_.DrawString(mvp, fgColor, static_cast<float>(j) + 0.5f,
                     -(static_cast<float>(i) * this->rowHeight + 1.5f), 1.0f, false,
@@ -543,7 +543,7 @@ bool SequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         // render mouse hover
         if (this->mousePos.x > -1.0f && this->mousePos.x < static_cast<float>(this->resCols) &&
             this->mousePos.y > 0.0f && this->mousePos.y < static_cast<float>(this->resRows + 1) &&
-            this->mousePosResIdx > -1 && this->mousePosResIdx < (int)this->resCount) {
+            this->mousePosResIdx > -1 && this->mousePosResIdx < (int) this->resCount) {
             positions = {glm::vec2(this->mousePos.x, -this->rowHeight * (this->mousePos.y - 1.0f)),
                 glm::vec2(this->mousePos.x, -this->rowHeight * (this->mousePos.y) + 0.5f),
                 glm::vec2(this->mousePos.x + 1.0f, -this->rowHeight * (this->mousePos.y) + 0.5f),
@@ -605,7 +605,7 @@ bool SequenceRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
     // left click
     if (flags & view::MOUSEFLAG_BUTTON_LEFT_DOWN) {
         if (flags & view::MOUSEFLAG_MODKEY_ALT_DOWN) {
-            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int)this->resCount) {
+            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int) this->resCount) {
                 if (!this->leftMouseDown) {
                     this->initialClickSelection = !this->selection[this->mousePosResIdx];
                 }
@@ -613,7 +613,7 @@ bool SequenceRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
             }
             consumeEvent = true;
         } else {
-            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int)this->resCount) {
+            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int) this->resCount) {
                 this->selection[this->mousePosResIdx] = !this->selection[this->mousePosResIdx];
             }
         }

--- a/plugins/protein_gl/src/SplitMergeRenderer.cpp
+++ b/plugins/protein_gl/src/SplitMergeRenderer.cpp
@@ -123,7 +123,7 @@ void SplitMergeRenderer::calcExtents() {
 
     float minX = FLT_MAX, maxX = -FLT_MAX, minY = FLT_MAX, maxY = -FLT_MAX;
 
-    for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+    for (int i = 0; i < (int) sortedSeries.Count(); i++) {
         protein_calls::SplitMergeCall::SplitMergeMappable* smm = diagram->GetSeries(sortedSeries[i])->GetMappable();
         vislib::Pair<float, float> p = smm->GetAbscissaRange();
         if (p.First() < minX) {
@@ -170,7 +170,7 @@ bool SplitMergeRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
                 if (x > bounds.Left() && x < bounds.Right() && y > bounds.Bottom() && y < bounds.Top()) {
                     float tmp = (y - 1) / -seriesSpacing;
                     int series = static_cast<int>(tmp);
-                    if (series >= 0 && series < (int)sortedSeries.Count() && (tmp - static_cast<int>(tmp)) < 0.5f) {
+                    if (series >= 0 && series < (int) sortedSeries.Count() && (tmp - static_cast<int>(tmp)) < 0.5f) {
                         // Log::DefaultLog.WriteInfo( "I hit series %s",
                         // diagram->GetSeries(sortedSeries[series])->GetName());
                         consumeEvent = true;
@@ -183,7 +183,7 @@ bool SplitMergeRenderer::MouseEvent(float x, float y, view::MouseFlags flags) {
                 // propagate selection to selection module
                 if (selectionCall != NULL) {
                     vislib::Array<int> selectedSeriesIndices;
-                    for (int x = 0; x < (int)this->diagram->GetSeriesCount(); x++) {
+                    for (int x = 0; x < (int) this->diagram->GetSeriesCount(); x++) {
                         if (this->diagram->GetSeries(x) == this->selectedSeries) {
                             selectedSeriesIndices.Add(x);
                             break;
@@ -288,7 +288,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     sortedSeries.Clear();
     // sortedSeriesInverse.SetCount(diagram->GetSeriesCount());
 
-    for (int i = 0; i < (int)diagram->GetSeriesCount(); i++) {
+    for (int i = 0; i < (int) diagram->GetSeriesCount(); i++) {
         sortedSeries.Add(i);
         // sortedSeriesInverse[i] = i;
         selectionLevel[i] = 0;
@@ -307,7 +307,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 #endif
 
     if (this->visibilityFromSelection.Param<param::BoolParam>()->Value()) {
-        for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+        for (int i = 0; i < (int) sortedSeries.Count(); i++) {
             if (diagram->GetSeries(sortedSeries[i]) == selectedSeries) {
                 selectionLevel[sortedSeries[i]]++;
             }
@@ -315,7 +315,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         // BUG TODO FIXME WTF
         // WARNING PROPAGATION SLIPS! YOU NEED DOUBLE BUFFERING (selectionLevel) FOR THIS TO WORK!!!
         for (int i = 0; i < this->numVisibilityPropagationRounds.Param<param::IntParam>()->Value(); i++) {
-            for (int t = 0; t < (int)diagram->GetTransitionCount(); t++) {
+            for (int t = 0; t < (int) diagram->GetTransitionCount(); t++) {
                 protein_calls::SplitMergeCall::SplitMergeTransition* smt = diagram->GetTransition(t);
                 if (selectionLevel[smt->SourceSeries()] > 0) {
                     selectionLevel[smt->DestinationSeries()]++;
@@ -325,7 +325,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                 }
             }
         }
-        for (int i = (int)sortedSeries.Count() - 1; i >= 0; i--) {
+        for (int i = (int) sortedSeries.Count() - 1; i >= 0; i--) {
             if (selectionLevel[sortedSeries[i]] == 0) {
                 seriesVisible[sortedSeries[i]] = false;
             } else {
@@ -335,7 +335,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         // propagate visibility to hidden module
         if (hiddenCall != NULL) {
             vislib::Array<int> hiddenSeriesIndices;
-            for (int x = 0; x < (int)this->diagram->GetSeriesCount(); x++) {
+            for (int x = 0; x < (int) this->diagram->GetSeriesCount(); x++) {
                 if (!seriesVisible[x]) {
                     hiddenSeriesIndices.Add(x);
                 }
@@ -344,7 +344,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             (*hiddenCall)(protein_calls::IntSelectionCall::CallForSetSelection);
         }
     }
-    for (int i = (int)sortedSeries.Count() - 1; i >= 0; i--) {
+    for (int i = (int) sortedSeries.Count() - 1; i >= 0; i--) {
         if (!seriesVisible[sortedSeries[i]]) {
             // sortedSeriesInverse[sortedSeries[i]] = -1;
             sortedSeries.RemoveAt(i);
@@ -356,15 +356,15 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     this->calcExtents();
 
     maxY = -FLT_MAX;
-    for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+    for (int i = 0; i < (int) sortedSeries.Count(); i++) {
         float tmpY = diagram->GetSeries(sortedSeries[i])->GetMappable()->GetOrdinateRange().GetSecond();
         if (tmpY > maxY) {
             maxY = tmpY;
         }
     }
 
-    GLuint pathBase = glGenPathsNV((GLsizei)sortedSeries.Count());
-    for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+    GLuint pathBase = glGenPathsNV((GLsizei) sortedSeries.Count());
+    for (int i = 0; i < (int) sortedSeries.Count(); i++) {
         protein_calls::SplitMergeCall::SplitMergeSeries* sms = diagram->GetSeries(sortedSeries[i]);
         protein_calls::SplitMergeCall::SplitMergeMappable* smm = sms->GetMappable();
         int increment = 50;
@@ -408,7 +408,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             closePath(smm, i, cmds, coords, idx, start);
         }
 
-        glPathCommandsNV(pathBase + i, (GLsizei)cmds.Count(), cmds.PeekElements(), (GLsizei)coords.Count(), GL_FLOAT,
+        glPathCommandsNV(pathBase + i, (GLsizei) cmds.Count(), cmds.PeekElements(), (GLsizei) coords.Count(), GL_FLOAT,
             coords.PeekElements());
 
         glStencilFillPathNV(pathBase + i, GL_COUNT_UP_NV, 0x1F);
@@ -418,7 +418,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     glStencilFunc(GL_NOTEQUAL, 0, 0x1F);
     glStencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
 
-    for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+    for (int i = 0; i < (int) sortedSeries.Count(); i++) {
         if (selectedSeries == NULL || *selectedSeries == *diagram->GetSeries(sortedSeries[i])) {
             ::glColor3fv(diagram->GetSeries(sortedSeries[i])->GetColorRGB().PeekComponents());
         } else {
@@ -428,7 +428,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         // glColor3fv(diagram->GetSeries(sortedSeries[i])->GetColorRGB().PeekComponents());
         glCoverFillPathNV(pathBase + i, GL_BOUNDING_BOX_NV);
     }
-    glDeletePathsNV(pathBase, (GLsizei)sortedSeries.Count());
+    glDeletePathsNV(pathBase, (GLsizei) sortedSeries.Count());
 
     // glDisable(GL_STENCIL_TEST);
 
@@ -440,7 +440,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
     // TODO: selection with transitive affection (selected, repeat {affect connected})
 
-    pathBase = glGenPathsNV((GLsizei)diagram->GetTransitionCount());
+    pathBase = glGenPathsNV((GLsizei) diagram->GetTransitionCount());
     vislib::Array<GLubyte> cmds;
     cmds.AssertCapacity(5);
     cmds.Append(GL_MOVE_TO_NV);
@@ -466,7 +466,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
     GLfloat gradient[3][3] = {{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
 
-    for (int i = 0; i < (int)diagram->GetTransitionCount(); i++) {
+    for (int i = 0; i < (int) diagram->GetTransitionCount(); i++) {
         // coords.Clear();
         protein_calls::SplitMergeCall::SplitMergeTransition* smt = diagram->GetTransition(i);
         if (!seriesVisible[smt->SourceSeries()] || !seriesVisible[smt->DestinationSeries()]) {
@@ -516,7 +516,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         coords[14] = srcX;
         coords[15] = srcYBottom;
 
-        glPathCommandsNV(pathBase + counter, (GLsizei)cmds.Count(), cmds.PeekElements(), (GLsizei)coords.Count(),
+        glPathCommandsNV(pathBase + counter, (GLsizei) cmds.Count(), cmds.PeekElements(), (GLsizei) coords.Count(),
             GL_FLOAT, coords.PeekElements());
         glStencilFillPathNV(pathBase + counter, GL_COUNT_UP_NV, 0x1F);
 
@@ -605,7 +605,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     //    glCoverFillPathNV(pathBase + counter, GL_BOUNDING_BOX_NV);
     //    counter++;
     //}
-    glDeletePathsNV(pathBase, (GLsizei)diagram->GetTransitionCount());
+    glDeletePathsNV(pathBase, (GLsizei) diagram->GetTransitionCount());
 
     glPathColorGenNV(GL_PRIMARY_COLOR, GL_NONE, GL_NONE, NULL);
 
@@ -613,7 +613,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
     glStencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
     glColor3fv(this->fgColor.PeekComponents());
 
-    for (int i = 0; i < (int)sortedSeries.Count(); i++) {
+    for (int i = 0; i < (int) sortedSeries.Count(); i++) {
         vislib::StringA theName = diagram->GetSeries(sortedSeries[i])->GetName();
         theName.Append("x");
         GLfloat* kerning = new GLfloat[theName.Length()];
@@ -641,7 +641,7 @@ bool SplitMergeRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
     float decorationDepth = 0.0f;
     if (this->showGuidesParam.Param<param::BoolParam>()->Value()) {
-        for (int i = 0; i < (int)diagram->GetGuideCount(); i++) {
+        for (int i = 0; i < (int) diagram->GetGuideCount(); i++) {
             protein_calls::SplitMergeCall::SplitMergeGuide* g = diagram->GetGuide(i);
             ::glDisable(GL_BLEND);
             ::glDisable(GL_DEPTH_TEST);

--- a/plugins/protein_gl/src/SplitMergeRenderer.h
+++ b/plugins/protein_gl/src/SplitMergeRenderer.h
@@ -163,7 +163,7 @@ private:
             int s1 = (*sortedSeries)[this->index];
             int s2 = (*sortedSeries)[other.index];
             int sameCount = 0;
-            for (int i = 0; i < (int)diagram->GetTransitionCount(); i++) {
+            for (int i = 0; i < (int) diagram->GetTransitionCount(); i++) {
                 protein_calls::SplitMergeCall::SplitMergeTransition* smt = diagram->GetTransition(i);
                 if ((smt->DestinationSeries() == s1 && smt->SourceSeries() == s2) ||
                     (smt->DestinationSeries() == s2 && smt->SourceSeries() == s1)) {

--- a/plugins/protein_gl/src/UncertaintyCartoonRenderer.cpp
+++ b/plugins/protein_gl/src/UncertaintyCartoonRenderer.cpp
@@ -777,7 +777,7 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
 
                     // is the current residue really an aminoacid?
                     if (mol->Residues()[aaIdx]->Identifier() == MolecularDataCall::Residue::AMINOACID)
-                        acid = (MolecularDataCall::AminoAcid*)(mol->Residues()[aaIdx]);
+                        acid = (MolecularDataCall::AminoAcid*) (mol->Residues()[aaIdx]);
                     else
                         continue;
 
@@ -794,8 +794,8 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                     uncIndex = this->synchronizedIndex[aaIdx];
                     for (unsigned int k = 0; k < this->structCount; k++) {
                         calpha.sortedStruct[k] = static_cast<int>(
-                            this->sortedSecStructAssignment[(int)this->currentMethodData][uncIndex][k]);
-                        calpha.unc[k] = this->secStructUncertainty[(int)this->currentMethodData][uncIndex][k];
+                            this->sortedSecStructAssignment[(int) this->currentMethodData][uncIndex][k]);
+                        calpha.unc[k] = this->secStructUncertainty[(int) this->currentMethodData][uncIndex][k];
                         if (this->bFactorAsUncertaintyParam.Param<param::BoolParam>()->Value()) {
                             // calpha.unc[k] = (mol->AtomBFactors()[acid->CAlphaIndex()] -
                             // mol->MinimumBFactor())/(mol->MaximumBFactor() - mol->MinimumBFactor());
@@ -808,10 +808,10 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                             }
                         }
                     }
-                    if (this->currentColoringMode == (int)COLOR_MODE_CHAIN) {
+                    if (this->currentColoringMode == (int) COLOR_MODE_CHAIN) {
                         for (unsigned int k = 0; k < 3; k++)
                             calpha.col[k] = this->chainColors[uncIndex][k];
-                    } else if (this->currentColoringMode == (int)COLOR_MODE_AMINOACID) {
+                    } else if (this->currentColoringMode == (int) COLOR_MODE_AMINOACID) {
                         for (unsigned int k = 0; k < 3; k++)
                             calpha.col[k] = this->aminoAcidColors[uncIndex][k];
                     }
@@ -905,7 +905,7 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
         tubeShader_->setUniform("pipeWidth", this->currentBackboneWidth);
         tubeShader_->setUniform("interpolateColors", this->colorInterpolationParam.Param<param::BoolParam>()->Value());
         glUniform4fv(tubeShader_->getUniformLocation("structCol"), this->structCount,
-            (GLfloat*)this->secStructColor.PeekElements());
+            (GLfloat*) this->secStructColor.PeekElements());
         tubeShader_->setUniform("colorMode", this->currentColoringMode);
         tubeShader_->setUniform("onlyTubes", this->onlyTubesParam.Param<param::BoolParam>()->Value());
         tubeShader_->setUniform("uncVisMode", static_cast<int>(this->currentUncVis));
@@ -960,7 +960,7 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                 if (this->currentOutlineMode == OUTLINE_LINE) {
                     glPolygonMode(GL_BACK, GL_LINE);
                     glEnable(GL_LINE_SMOOTH);
-                    glLineWidth((float)this->currentOutlineScaling);
+                    glLineWidth((float) this->currentOutlineScaling);
                 } else {
                     glPolygonMode(GL_BACK, GL_FILL);
                 }
@@ -978,15 +978,15 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
             // numVert = number of vertices fitting into bufSize
             UINT64 stride = 0; // aminoacid index in mainChain
 
-            for (int i = 0; i < (int)molSizes.size(); i++) { // loop over all secondary structures
+            for (int i = 0; i < (int) molSizes.size(); i++) { // loop over all secondary structures
                 UINT64 vertCounter = 0;
                 while (
                     vertCounter < molSizes[i]) { // loop over all aminoacids inside of one secondary structure - WHY ?
 
                     const char* currVert =
-                        (const char*)(&this->mainChain[(unsigned int)vertCounter +
-                                                       (unsigned int)stride]); // pointer to current vertex data in
-                                                                               // mainChain
+                        (const char*) (&this->mainChain[(unsigned int) vertCounter +
+                                                        (unsigned int) stride]); // pointer to current vertex data in
+                                                                                 // mainChain
 
                     void* mem = static_cast<char*>(this->theSingleMappedMem) +
                                 this->bufSize * this->currBuf; // pointer to the mapped memory - ?
@@ -997,11 +997,11 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                     this->WaitSignal(this->fences[this->currBuf]); // wait for buffer 'currBuf' to be "ready" - ?
 
                     memcpy(mem, whence,
-                        (size_t)vertsThisTime *
+                        (size_t) vertsThisTime *
                             vertStride); // copy data of current vertex data in mainChain to mapped memory - ?
 
                     glFlushMappedNamedBufferRangeEXT(theSingleBuffer, this->bufSize * this->currBuf,
-                        (GLsizeiptr)vertsThisTime * vertStride); // parameter: buffer, offset, length
+                        (GLsizeiptr) vertsThisTime * vertStride); // parameter: buffer, offset, length
 
                     tubeShader_->setUniform("instanceOffset", 0);
 
@@ -1011,7 +1011,7 @@ bool UncertaintyCartoonRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                         GL_PATCH_VERTICES, 1); // set parameter GL_PATCH_VERTICES to 1 (the number of vertices that will
                                                // be used to make up a single patch primitive)
                     glDrawArrays(
-                        GL_PATCHES, 0, (GLsizei)(vertsThisTime - 3)); // draw as many as (vertsThisTime-3) patches
+                        GL_PATCHES, 0, (GLsizei) (vertsThisTime - 3)); // draw as many as (vertsThisTime-3) patches
                     // -3 ? - because the first atom is added 3 times for each different secondary structure ??
                     this->QueueSignal(this->fences[this->currBuf]); // queue signal - tell that mapped memory
                                                                     // 'operations' are done - ?
@@ -1059,7 +1059,7 @@ void UncertaintyCartoonRenderer::GetBytesAndStride(MolecularDataCall& mol, unsig
     vertBytes = 0;
     colBytes = 0;
     // colBytes = vislib::math::Max(colBytes, 3 * 4U);
-    vertBytes = vislib::math::Max(vertBytes, (unsigned int)sizeof(CAlpha));
+    vertBytes = vislib::math::Max(vertBytes, (unsigned int) sizeof(CAlpha));
 
     colStride = 0;
     colStride = (colStride < colBytes) ? (colBytes) : (colStride);

--- a/plugins/protein_gl/src/UncertaintySequenceRenderer.cpp
+++ b/plugins/protein_gl/src/UncertaintySequenceRenderer.cpp
@@ -376,7 +376,7 @@ bool UncertaintySequenceRenderer::create() {
     this->glyphAxis.AssertCapacity(structCount);
     initVec = vislib::math::Vector<float, 2>(0.0f, -0.5f);
     for (unsigned int i = 0; i < structCount; i++) {
-        angle = 2.0f * (float)SEQ_PI / static_cast<float>(structCount) * static_cast<float>(i);
+        angle = 2.0f * (float) SEQ_PI / static_cast<float>(structCount) * static_cast<float>(i);
         if (i == 0) {
             tmpVec = initVec;
         } else {
@@ -437,7 +437,7 @@ void UncertaintySequenceRenderer::calculateGeometryVertices(int samples) {
             case (UncertaintyDataCall::secStructure::H_ALPHA_HELIX):
             case (UncertaintyDataCall::secStructure::G_310_HELIX):
             case (UncertaintyDataCall::secStructure::I_PI_HELIX):
-                offset = flip * (height / 2.0f) + sin(dS * 2.0f * (float)SEQ_PI) * 0.25f;
+                offset = flip * (height / 2.0f) + sin(dS * 2.0f * (float) SEQ_PI) * 0.25f;
                 break;
             case (UncertaintyDataCall::secStructure::B_BRIDGE):
                 offset = ((dS > 1.0f / 7.0f)
@@ -615,7 +615,7 @@ bool UncertaintySequenceRenderer::GetExtents(mmstd_gl::CallRender2DGL& call) {
         // set new row height
         this->rowHeight = 2.0f + static_cast<float>(this->secStructRows);
 
-        unsigned int oldRowHeight = (unsigned int)this->rowHeight;
+        unsigned int oldRowHeight = (unsigned int) this->rowHeight;
 
         this->dataPrepared = this->PrepareData(udc, bs);
 
@@ -806,7 +806,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
     // store current glPolygonMode
     GLuint tmpMode[2];
-    glGetIntegerv(GL_POLYGON_MODE, (GLint*)tmpMode);
+    glGetIntegerv(GL_POLYGON_MODE, (GLint*) tmpMode);
 
     // USE LINE MODE FOR WIREFRAME RENDERING
     // glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
@@ -841,16 +841,16 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             unsigned int sucCnt;
 
             vislib::Array<vislib::math::Vector<float, static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>*
-                secUncertainty = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+                secUncertainty = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
             vislib::Array<vislib::math::Vector<UncertaintyDataCall::secStructure,
                 static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>* sortedUncertainty =
-                &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+                &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
 
             // Draw this unfolded view amino-acid based (and not line based)
             for (unsigned int i = 0; i < this->aminoAcidCount; i++) {
 
                 curCnt = this->diffStrucCount[i];
-                yPosTemp = (float)(this->methodRows - curCnt) / 2.0f;
+                yPosTemp = (float) (this->methodRows - curCnt) / 2.0f;
 
                 for (unsigned int d = 0; d < curCnt; d++) {
 
@@ -860,7 +860,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                                           : (sortedUncertainty->operator[](i)[0]));
                     if (curStr == UncertaintyDataCall::secStructure::E_EXT_STRAND) {
                         if ((i < (this->aminoAcidCount - 1)) &&
-                            (secUncertainty->operator[](i + 1)[(int)UncertaintyDataCall::secStructure::E_EXT_STRAND] >
+                            (secUncertainty->operator[](i + 1)[(int) UncertaintyDataCall::secStructure::E_EXT_STRAND] >
                                 0.0f)) {
                             folStr = UncertaintyDataCall::secStructure::E_EXT_STRAND;
                         }
@@ -892,8 +892,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                 preCnt = (i > 0) ? (this->diffStrucCount[i - 1]) : (curCnt);
                 sucCnt = (i < this->aminoAcidCount - 1) ? (this->diffStrucCount[i + 1]) : (curCnt);
 
-                upBound = -1.0f * (float)(this->methodRows - curCnt) / 2.0f;
-                loBound = upBound - (float)curCnt;
+                upBound = -1.0f * (float) (this->methodRows - curCnt) / 2.0f;
+                loBound = upBound - (float) curCnt;
 
                 if (this->residueFlag[i] == UncertaintyDataCall::addFlags::MISSING) {
                     curCnt = 0;
@@ -908,8 +908,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
                 if (preCnt > curCnt) {
 
-                    upBndPre = -1.0f * (float)(this->methodRows - preCnt) / 2.0f;
-                    loBndPre = upBndPre - (float)preCnt;
+                    upBndPre = -1.0f * (float) (this->methodRows - preCnt) / 2.0f;
+                    loBndPre = upBndPre - (float) preCnt;
 
                     // upper closing brackets
                     GLfloat cpUpClose[4][3] = {{posOffset.X() + 0.5f, -posOffset.Y() + upBound, 0.0f},
@@ -931,8 +931,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                 }
                 if (preCnt < curCnt) {
 
-                    upBndPre = -1.0f * (float)(this->methodRows - preCnt) / 2.0f;
-                    loBndPre = upBndPre - (float)preCnt;
+                    upBndPre = -1.0f * (float) (this->methodRows - preCnt) / 2.0f;
+                    loBndPre = upBndPre - (float) preCnt;
 
                     // upper opening brackets
                     GLfloat cpUpOpen[4][3] = {{posOffset.X() - 0.5f, -posOffset.Y() + upBndPre, 0.0f},
@@ -985,8 +985,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                         glEnd();
                     } else if (sucCnt > curCnt) {
 
-                        upBndPre = -1.0f * (float)(this->methodRows - sucCnt) / 2.0f;
-                        loBndPre = upBndPre - (float)sucCnt;
+                        upBndPre = -1.0f * (float) (this->methodRows - sucCnt) / 2.0f;
+                        loBndPre = upBndPre - (float) sucCnt;
 
                         // upper opening brackets
                         GLfloat cpUpOpen[4][3] = {{posOffset.X() + 0.5f, -posOffset.Y() + upBound, 0.0f},
@@ -1009,8 +1009,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     }
                     if (sucCnt < curCnt) {
 
-                        upBndPre = -1.0f * (float)(this->methodRows - sucCnt) / 2.0f;
-                        loBndPre = upBndPre - (float)sucCnt;
+                        upBndPre = -1.0f * (float) (this->methodRows - sucCnt) / 2.0f;
+                        loBndPre = upBndPre - (float) sucCnt;
 
                         // upper closing brackets
                         GLfloat cpUpClose[4][3] = {{posOffset.X() + 1.5f, -posOffset.Y() + upBndPre, 0.0f},
@@ -1066,8 +1066,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     // draw geometry twice at line endings
                     if (i == this->aminoAcidCount - 1) {
 
-                        upBound = -1.0f * (float)(this->methodRows - curCnt) / 2.0f;
-                        loBound = upBound - (float)curCnt;
+                        upBound = -1.0f * (float) (this->methodRows - curCnt) / 2.0f;
+                        loBound = upBound - (float) curCnt;
 
                         glBegin(GL_LINES);
                         glVertex3f(posOffset.X() + 1.0f, -posOffset.Y() + upBound, 0.5f);
@@ -1075,8 +1075,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                         glEnd();
                     } else if ((i > 0) && (i % this->resCols == (this->resCols - 1))) {
 
-                        upBndPre = -1.0f * (float)(this->methodRows - sucCnt) / 2.0f;
-                        loBndPre = upBndPre - (float)sucCnt;
+                        upBndPre = -1.0f * (float) (this->methodRows - sucCnt) / 2.0f;
+                        loBndPre = upBndPre - (float) sucCnt;
 
                         if (sucCnt != curCnt) {
                             upBound = (upBound > upBndPre) ? (upBound) : (upBndPre - off);
@@ -1094,7 +1094,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
 
             // draw uncertainty
-            yPos += (float)this->methodRows;
+            yPos += (float) this->methodRows;
             if (this->toggleUncertaintyParam.Param<param::BoolParam>()->Value()) {
                 float col;
                 glBegin(GL_QUADS);
@@ -1118,10 +1118,10 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         } else if (this->currentViewMode == VIEWMODE_UNFOLDED_SEQUENCE) { // UNFOLDED UNCERTAINTY LINE VIEW
 
             vislib::Array<vislib::math::Vector<float, static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>*
-                secUncertainty = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+                secUncertainty = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
             vislib::Array<vislib::math::Vector<UncertaintyDataCall::secStructure,
                 static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>* sortedUncertainty =
-                &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+                &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
 
             vislib::math::Vector<float, 2> posOffset;
 
@@ -1141,12 +1141,12 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             }
 
             if (uncRowFlag) {
-                upBound = std::ceil((float)this->methodRows / 2.0f) + 0.5f;
-                loBound = std::floor((float)this->methodRows / 2.0f) - 0.5f;
+                upBound = std::ceil((float) this->methodRows / 2.0f) + 0.5f;
+                loBound = std::floor((float) this->methodRows / 2.0f) - 0.5f;
                 offset = 1.0f;
             } else {
-                upBound = (float)this->methodRows / 2.0f;
-                loBound = (float)this->methodRows / 2.0f;
+                upBound = (float) this->methodRows / 2.0f;
+                loBound = (float) this->methodRows / 2.0f;
             }
 
             //draw geometry tiles for secondary structure
@@ -1157,7 +1157,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             //STRIDE
             if (this->toggleStrideParam.Param<param::BoolParam>()->Value()) {
                 for (unsigned int i = 0; i < this->aminoAcidCount; i++) {
-                    if (secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]] < 1.0f) {
+                    if (secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]] < 1.0f) {
                         tmpMethod = static_cast<unsigned int>(UncertaintyDataCall::assMethod::STRIDE);
                         this->DrawSecStructGeometryTiles(this->sortedSecStructAssignment[tmpMethod][i][0],
                             ((i < (this->aminoAcidCount - 1)) ? (this->sortedSecStructAssignment[tmpMethod][i + 1][0])
@@ -1174,7 +1174,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             // DSSP
             if (this->toggleDsspParam.Param<param::BoolParam>()->Value()) {
                 for (unsigned int i = 0; i < this->aminoAcidCount; i++) {
-                    if (secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]] < 1.0f) {
+                    if (secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]] < 1.0f) {
                         tmpMethod = static_cast<unsigned int>(UncertaintyDataCall::assMethod::DSSP);
                         this->DrawSecStructGeometryTiles(this->sortedSecStructAssignment[tmpMethod][i][0],
                             ((i < (this->aminoAcidCount - 1)) ? (this->sortedSecStructAssignment[tmpMethod][i + 1][0])
@@ -1191,7 +1191,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             // PDB
             if (this->togglePdbParam.Param<param::BoolParam>()->Value()) {
                 for (unsigned int i = 0; i < this->aminoAcidCount; i++) {
-                    if (secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]] < 1.0f) {
+                    if (secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]] < 1.0f) {
                         tmpMethod = static_cast<unsigned int>(UncertaintyDataCall::assMethod::PDB);
                         this->DrawSecStructGeometryTiles(this->sortedSecStructAssignment[tmpMethod][i][0],
                             ((i < (this->aminoAcidCount - 1)) ? (this->sortedSecStructAssignment[tmpMethod][i + 1][0])
@@ -1208,7 +1208,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             // PROSIGN
             if (this->toggleProsignParam.Param<param::BoolParam>()->Value()) {
                 for (unsigned int i = 0; i < this->aminoAcidCount; i++) {
-                    if (secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]] < 1.0f) {
+                    if (secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]] < 1.0f) {
                         tmpMethod = static_cast<unsigned int>(UncertaintyDataCall::assMethod::PROSIGN);
                         this->DrawSecStructGeometryTiles(this->sortedSecStructAssignment[tmpMethod][i][0],
                             ((i < (this->aminoAcidCount - 1)) ? (this->sortedSecStructAssignment[tmpMethod][i + 1][0])
@@ -1241,12 +1241,12 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                 posOffset.SetX(this->vertices[2 * i]);
                 posOffset.SetY(this->vertices[2 * i + 1] + upBound);
 
-                uncCur = secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]];
+                uncCur = secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]];
                 if (this->residueFlag[i] == UncertaintyDataCall::addFlags::MISSING) {
                     uncCur = 1.0f;
                 }
                 if (i > 0) {
-                    uncPre = secUncertainty->operator[](i - 1)[(int)sortedUncertainty->operator[](i - 1)[0]];
+                    uncPre = secUncertainty->operator[](i - 1)[(int) sortedUncertainty->operator[](i - 1)[0]];
                     if (this->residueFlag[i - 1] == UncertaintyDataCall::addFlags::MISSING) {
                         uncPre = 1.0f;
                     }
@@ -1254,7 +1254,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     uncPre = uncCur;
                 }
                 if (i < this->aminoAcidCount - 1) {
-                    uncSuc = secUncertainty->operator[](i + 1)[(int)sortedUncertainty->operator[](i + 1)[0]];
+                    uncSuc = secUncertainty->operator[](i + 1)[(int) sortedUncertainty->operator[](i + 1)[0]];
                     if (this->residueFlag[i + 1] == UncertaintyDataCall::addFlags::MISSING) {
                         uncSuc = 1.0f;
                     }
@@ -1424,7 +1424,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
             }
 
             // draw uncertainty
-            yPos += (float)this->methodRows;
+            yPos += (float) this->methodRows;
             if (this->toggleUncertaintyParam.Param<param::BoolParam>()->Value()) {
                 float col;
                 glBegin(GL_QUADS);
@@ -1512,7 +1512,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                 break;
                             }
                             this->DrawThresholdEnergyValueTiles(tmpStruct, this->residueFlag[i], this->vertices[i * 2],
-                                (this->vertices[i * 2 + 1] + yPos + (float)j), this->strideStructThreshold[i][j], min,
+                                (this->vertices[i * 2 + 1] + yPos + (float) j), this->strideStructThreshold[i][j], min,
                                 max, threshold);
                         }
                     }
@@ -1542,7 +1542,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     for (unsigned int j = 0; j < this->dsspThresholdCount; j++) {
                         if ((this->dsspStructEnergy[i][j] < 1.0E38f) && (this->dsspStructEnergy[i][j] != 0.0f)) {
                             this->DrawThresholdEnergyValueTiles(tmpStruct, this->residueFlag[i], this->vertices[i * 2],
-                                (this->vertices[i * 2 + 1] + yPos + (float)j), this->dsspStructEnergy[i][j], min, max,
+                                (this->vertices[i * 2 + 1] + yPos + (float) j), this->dsspStructEnergy[i][j], min, max,
                                 threshold);
                         }
                     }
@@ -1611,7 +1611,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             }
 
                             this->DrawThresholdEnergyValueTiles(tmpStruct, this->residueFlag[i], this->vertices[i * 2],
-                                this->vertices[i * 2 + 1] + yPos + (float)j, this->prosignStructThreshold[i][j], min,
+                                this->vertices[i * 2 + 1] + yPos + (float) j, this->prosignStructThreshold[i][j], min,
                                 max, threshold, true);
                         }
                     }
@@ -1795,7 +1795,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         glColor3fv(fgColor);
         glEnable(GL_VERTEX_ARRAY);
         glVertexPointer(2, GL_FLOAT, 0, this->chainSeparatorVertices.PeekElements());
-        glDrawArrays(GL_LINES, 0, (GLsizei)this->chainSeparatorVertices.Count() / 2);
+        glDrawArrays(GL_LINES, 0, (GLsizei) this->chainSeparatorVertices.Count() / 2);
         glDisable(GL_VERTEX_ARRAY);
 
         // draw legend/key
@@ -1883,7 +1883,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     else if (this->currentViewMode == VIEWMODE_UNFOLDED_SEQUENCE) {
 
                         float yPosTemp = yPos + 0.5f;
-                        float upBound = std::ceil((float)this->methodRows / 2.0f) + 0.5f;
+                        float upBound = std::ceil((float) this->methodRows / 2.0f) + 0.5f;
 
                         bool uncRowFlag = false;
                         if (this->toggleUncertainStructParam.Param<param::BoolParam>()->Value()) {
@@ -1948,7 +1948,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                         ////////////////////////////////////////////////
 
 
-                        yPos += (float)this->methodRows;
+                        yPos += (float) this->methodRows;
 
                         if (this->toggleUncertaintyParam.Param<param::BoolParam>()->Value()) {
                             tmpStr = "Uncertainty";
@@ -2025,7 +2025,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                     -(static_cast<float>(i) * this->rowHeight + yPos + float(j)), wordlength, 1.0f,
                                     fontSize, true, tmpStr, vislib::graphics::AbstractFont::ALIGN_LEFT_MIDDLE);
                             }
-                            yPos += (float)this->strideThresholdCount;
+                            yPos += (float) this->strideThresholdCount;
                         }
                         if (this->toggleDsspParam.Param<param::BoolParam>()->Value()) {
                             tmpStr = "DSSP";
@@ -2053,7 +2053,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                     -(static_cast<float>(i) * this->rowHeight + yPos + float(j)), wordlength, 1.0f,
                                     fontSize, true, tmpStr, vislib::graphics::AbstractFont::ALIGN_LEFT_MIDDLE);
                             }
-                            yPos += (float)this->dsspThresholdCount;
+                            yPos += (float) this->dsspThresholdCount;
                         }
                         if (this->togglePdbParam.Param<param::BoolParam>()->Value()) {
                             tmpStr = this->pdbLegend;
@@ -2095,7 +2095,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                     -(static_cast<float>(i) * this->rowHeight + yPos + float(j)), wordlength, 1.0f,
                                     fontSize, true, tmpStr, vislib::graphics::AbstractFont::ALIGN_LEFT_MIDDLE);
                             }
-                            yPos += (float)this->prosignThresholdCount;
+                            yPos += (float) this->prosignThresholdCount;
                         }
 
                         ////////////////////////////////////////////////
@@ -2210,7 +2210,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
         // render mouse hover
         if ((this->mousePos.X() > -1.0f) && (this->mousePos.X() < static_cast<float>(this->resCols)) &&
             (this->mousePos.Y() > 0.0f) && (this->mousePos.Y() < static_cast<float>(this->resRows + 1)) &&
-            (this->mousePosResIdx > -1) && (this->mousePosResIdx < (int)this->aminoAcidCount)) {
+            (this->mousePosResIdx > -1) && (this->mousePosResIdx < (int) this->aminoAcidCount)) {
 
             glColor3f(1.0f, 0.75f, 0.0f);
             glBegin(GL_LINE_STRIP);
@@ -2234,19 +2234,19 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
                         unsigned int curCnt = this->diffStrucCount[mousePosResIdx];
 
-                        start = ((float)(this->methodRows - curCnt) / 2.0f) * perCentRow;
+                        start = ((float) (this->methodRows - curCnt) / 2.0f) * perCentRow;
                         for (unsigned int m = 0; m < curCnt; m++) {
 
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
 
                                 UncertaintyDataCall::secStructure assignment = this->sortedSecStructAssignment[(
-                                    int)UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][m];
+                                    int) UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][m];
 
                                 tmpStr = "Methods:    ";
                                 unsigned int cnt = 0;
                                 for (int n = 0; n < UncertaintyDataCall::assMethod::NOM - 1;
                                      n++) { // without UNCERTAINTY
-                                    if (this->secStructUncertainty[n][mousePosResIdx][(int)assignment] >
+                                    if (this->secStructUncertainty[n][mousePosResIdx][(int) assignment] >
                                         SEQ_FLOAT_EPS) {
                                         if (cnt > 0) {
                                             tmpStr.Append(", ");
@@ -2273,8 +2273,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                 }
 
                                 tmpStr2.Format("Structure:  %s - %.2f %% ",
-                                    this->secStructDescription[(int)assignment].PeekBuffer(),
-                                    this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY]
+                                    this->secStructDescription[(int) assignment].PeekBuffer(),
+                                    this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY]
                                                               [mousePosResIdx][assignment] *
                                         100.0f);
 
@@ -2283,7 +2283,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
 
                             start += perCentRow;
                         }
-                        start += ((float)(this->methodRows - curCnt) / 2.0f) * perCentRow;
+                        start += ((float) (this->methodRows - curCnt) / 2.0f) * perCentRow;
 
                         if (this->toggleUncertaintyParam.Param<param::BoolParam>()->Value()) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING &&
@@ -2316,7 +2316,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                     // UNFOLDED UNCERTAINTY LINE VIEW
                     else if (this->currentViewMode == VIEWMODE_UNFOLDED_SEQUENCE) {
 
-                        float startUnc = (std::ceil((float)this->methodRows / 2.0f) - 0.5f) * perCentRow;
+                        float startUnc = (std::ceil((float) this->methodRows / 2.0f) - 0.5f) * perCentRow;
 
                         bool uncRowFlag = false;
                         if (this->toggleUncertainStructParam.Param<param::BoolParam>()->Value()) {
@@ -2327,7 +2327,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                      i < static_cast<unsigned int>(UncertaintyDataCall::secStructure::NOE); i++) {
                                     if (this->secStructUncertainty[(int)
                                                 UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][(
-                                            int)this->sortedSecStructAssignment[(int)
+                                            int) this->sortedSecStructAssignment[(int)
                                                 UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]] >
                                         0.0f) {
                                         if (i > 0) {
@@ -2335,12 +2335,12 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                         }
                                         tmpStr3.Format(" %s: %.2f %% ",
                                             this
-                                                ->secStructDescription[(int)this->sortedSecStructAssignment[(
-                                                    int)UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]]
+                                                ->secStructDescription[(int) this->sortedSecStructAssignment[(int)
+                                                        UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]]
                                                 .PeekBuffer(),
                                             this->secStructUncertainty[(int)
                                                     UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][(
-                                                int)this->sortedSecStructAssignment[(int)
+                                                int) this->sortedSecStructAssignment[(int)
                                                     UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]] *
                                                 100.0f);
                                         tmpStr2.Append(tmpStr3);
@@ -2359,13 +2359,13 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                 tmpStr2.Format("%s: %.3f %%",
                                     this
                                         ->secStructDescription[(
-                                            int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::STRIDE]
-                                                                               [mousePosResIdx][0]]
+                                            int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::STRIDE]
+                                                                                [mousePosResIdx][0]]
                                         .PeekBuffer(),
                                     this->secStructUncertainty[(int)
                                             UncertaintyDataCall::assMethod::STRIDE][mousePosResIdx][(
-                                        int)this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::STRIDE]
-                                                                           [mousePosResIdx][0]] *
+                                        int) this->sortedSecStructAssignment[(int)
+                                            UncertaintyDataCall::assMethod::STRIDE][mousePosResIdx][0]] *
                                         100.0f);
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
@@ -2378,8 +2378,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "DSSP:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::DSSP]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::DSSP]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2391,8 +2391,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "PDB:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PDB]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PDB]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2404,8 +2404,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "Prosign:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PROSIGN]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PROSIGN]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2455,13 +2455,13 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                 tmpStr2.Format("%s: %.3f %%",
                                     this
                                         ->secStructDescription[(
-                                            int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::STRIDE]
-                                                                               [mousePosResIdx][0]]
+                                            int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::STRIDE]
+                                                                                [mousePosResIdx][0]]
                                         .PeekBuffer(),
                                     this->secStructUncertainty[(int)
                                             UncertaintyDataCall::assMethod::STRIDE][mousePosResIdx][(
-                                        int)this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::STRIDE]
-                                                                           [mousePosResIdx][0]] *
+                                        int) this->sortedSecStructAssignment[(int)
+                                            UncertaintyDataCall::assMethod::STRIDE][mousePosResIdx][0]] *
                                         100.0f);
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
@@ -2525,8 +2525,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "DSSP:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::DSSP]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::DSSP]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2562,8 +2562,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "PDB:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PDB]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PDB]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2572,8 +2572,8 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                             if (this->residueFlag[mousePosResIdx] != UncertaintyDataCall::addFlags::MISSING) {
                                 tmpStr = "Prosign:";
                                 tmpStr2 = this->secStructDescription[(
-                                    int)this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PROSIGN]
-                                                                       [mousePosResIdx][0]];
+                                    int) this->sortedSecStructAssignment[UncertaintyDataCall::assMethod::PROSIGN]
+                                                                        [mousePosResIdx][0]];
                                 this->RenderToolTip(start, start + perCentRow, tmpStr, tmpStr2, bgColor, fgColor);
                             }
                             start += perCentRow;
@@ -2640,7 +2640,7 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                      i < static_cast<unsigned int>(UncertaintyDataCall::secStructure::NOE); i++) {
                                     if (this->secStructUncertainty[(int)
                                                 UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][(
-                                            int)this->sortedSecStructAssignment[(int)
+                                            int) this->sortedSecStructAssignment[(int)
                                                 UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]] >
                                         0.0f) {
                                         if (i > 0) {
@@ -2648,12 +2648,12 @@ bool UncertaintySequenceRenderer::Render(mmstd_gl::CallRender2DGL& call) {
                                         }
                                         tmpStr3.Format(" %s: %.2f %% ",
                                             this
-                                                ->secStructDescription[(int)this->sortedSecStructAssignment[(
-                                                    int)UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]]
+                                                ->secStructDescription[(int) this->sortedSecStructAssignment[(int)
+                                                        UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]]
                                                 .PeekBuffer(),
                                             this->secStructUncertainty[(int)
                                                     UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][(
-                                                int)this->sortedSecStructAssignment[(int)
+                                                int) this->sortedSecStructAssignment[(int)
                                                     UncertaintyDataCall::assMethod::UNCERTAINTY][mousePosResIdx][i]] *
                                                 100.0f);
                                         tmpStr2.Append(tmpStr3);
@@ -2761,10 +2761,10 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
     vislib::math::Vector<unsigned int, structCount> lastSortedStructBT;
 
     vislib::Array<vislib::math::Vector<float, static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>*
-        secUncertainty = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+        secUncertainty = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
     vislib::Array<vislib::math::Vector<UncertaintyDataCall::secStructure,
         static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>* sortedUncertainty =
-        &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+        &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
 
     //glDisable(GL_DEPTH_TEST); // disabled depth test is necessary because of geometry overlay drawing
 
@@ -2783,7 +2783,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
             posOffset.SetX(this->vertices[2 * i]);
             posOffset.SetY(this->vertices[2 * i + 1] + yPos + 1.0f);
 
-            sMax = (unsigned int)sortedUncertainty->operator[](i)[0];
+            sMax = (unsigned int) sortedUncertainty->operator[](i)[0];
             uMax = secUncertainty->operator[](i)[sMax];
 
             // CERTAIN amino-acids
@@ -2823,9 +2823,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                         posOffset.SetY(posOffset.Y() - 0.5f);
                         // check if end of strand is an arrow (the arrows vertices are stored in BRIDGE )
                         if (i < this->aminoAcidCount - 1) {
-                            if ((sMax == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                (sMax != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                sMax = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                            if ((sMax == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                (sMax != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                sMax = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                             }
                         }
                         glBegin(GL_TRIANGLE_STRIP);
@@ -2845,7 +2845,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                     (this->currentUncertainStructGeometry == UNCERTAIN_STRUCT_STAT_VERTI)) {
 
                     if (i > 0) {
-                        if (secUncertainty->operator[](i - 1)[(int)sortedUncertainty->operator[](i - 1)[0]] == 1.0f) {
+                        if (secUncertainty->operator[](i - 1)[(int) sortedUncertainty->operator[](i - 1)[0]] == 1.0f) {
                             for (unsigned int j = 0; j < structCount; j++) {
                                 lastSortedStructBT[j] = sMax;
                             }
@@ -2859,7 +2859,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                     }
                     // copy data to sortedStruct
                     for (unsigned int j = 0; j < structCount; j++) {
-                        sortedStructBT[j] = (unsigned int)sortedUncertainty->operator[](i)[j];
+                        sortedStructBT[j] = (unsigned int) sortedUncertainty->operator[](i)[j];
                     }
                     // search for structure type matching the last sorted
                     for (unsigned int j = 0; j < structCount; j++) {     // lastSortedStruct
@@ -2880,7 +2880,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                     //assign structure type for left side from previous amino-acid
                     if (i > 0) {
-                        if (secUncertainty->operator[](i - 1)[(int)sortedUncertainty->operator[](i - 1)[0]] == 1.0f) {
+                        if (secUncertainty->operator[](i - 1)[(int) sortedUncertainty->operator[](i - 1)[0]] == 1.0f) {
                             sLeft = sortedUncertainty->operator[](i - 1)[0];
                         } else {
                             for (unsigned int j = 0; j < structCount; j++) {
@@ -2907,7 +2907,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                     // copy data to sortedStruct
                     for (unsigned int j = 0; j < structCount; j++) {
-                        sortedStructLR[j] = (unsigned int)sortedUncertainty->operator[](i)[j];
+                        sortedStructLR[j] = (unsigned int) sortedUncertainty->operator[](i)[j];
                     }
                     // search for structure type matching on the left and right side
                     for (unsigned int j = 0; j < structCount; j++) {
@@ -2949,17 +2949,18 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                     glUniformMatrix4fv(
                         this->shader->getUniformLocation("MVP"), 1, GL_FALSE, modelViewProjMatrix.PeekComponents());
-                    glUniform2fv(this->shader->getUniformLocation("worldPos"), 1, (GLfloat*)posOffset.PeekComponents());
+                    glUniform2fv(
+                        this->shader->getUniformLocation("worldPos"), 1, (GLfloat*) posOffset.PeekComponents());
                     glUniform4fv(
                         this->shader->getUniformLocation("structCol"), structCount, &this->secStructColor.front().x);
                     glUniform1iv(this->shader->getUniformLocation("sortedStruct"), structCount,
-                        (GLint*)sortedStructLR.PeekComponents());
+                        (GLint*) sortedStructLR.PeekComponents());
                     glUniform1fv(this->shader->getUniformLocation("structUnc"), structCount,
-                        (GLfloat*)secUncertainty->operator[](i).PeekComponents());
+                        (GLfloat*) secUncertainty->operator[](i).PeekComponents());
                     glUniform1f(
                         this->shader->getUniformLocation("gradientInt"), this->currentUncertainGardientInterval);
                     glUniform1i(
-                        this->shader->getUniformLocation("colorInterpol"), (int)this->currentUncertainColorInterpol);
+                        this->shader->getUniformLocation("colorInterpol"), (int) this->currentUncertainColorInterpol);
 
                     glBegin(GL_QUADS);
 
@@ -3026,20 +3027,20 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                     glBegin(GL_TRIANGLE_FAN);
 
-                    uMax = secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[0]];
+                    uMax = secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[0]];
 
                     // first vertex is center of fan
-                    glColor3fv(&this->secStructColor[(unsigned int)UncertaintyDataCall::secStructure::NOTDEFINED].x);
+                    glColor3fv(&this->secStructColor[(unsigned int) UncertaintyDataCall::secStructure::NOTDEFINED].x);
                     glVertex2f(posOffset.X(), -posOffset.Y());
 
                     for (unsigned int j = 0; j < this->glyphAxis.Count(); j++) {
-                        glColor3fv(&this->secStructColor[(unsigned int)sortedUncertainty->operator[](i)[j]].x);
-                        uTemp = secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[j]] / uMax;
+                        glColor3fv(&this->secStructColor[(unsigned int) sortedUncertainty->operator[](i)[j]].x);
+                        uTemp = secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[j]] / uMax;
                         posTemp = posOffset + (this->glyphAxis[j] * uTemp);
                         glVertex2f(posTemp.X(), -(posTemp.Y()));
                     }
                     // second vertex of fan once more
-                    glColor3fv(&this->secStructColor[(unsigned int)sortedUncertainty->operator[](i)[0]].x);
+                    glColor3fv(&this->secStructColor[(unsigned int) sortedUncertainty->operator[](i)[0]].x);
                     uTemp = 1.0f;
                     posTemp = posOffset + (this->glyphAxis[0] * uTemp);
                     glVertex2f(posTemp.X(), -(posTemp.Y()));
@@ -3072,7 +3073,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                     // get the number off structures with uncertainty greater 0
                     diffStruct = 0;
                     for (unsigned int k = 0; k < structCount; k++) {
-                        if (secUncertainty->operator[](i)[(int)sortedUncertainty->operator[](i)[k]] > 0.0f)
+                        if (secUncertainty->operator[](i)[(int) sortedUncertainty->operator[](i)[k]] > 0.0f)
                             diffStruct++;
                     }
 
@@ -3085,7 +3086,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                             tDelta = 0.0f;
                             for (unsigned int k = 0; k < diffStruct; k++) {
 
-                                sTemp = (unsigned int)sortedUncertainty->operator[](i)[k];
+                                sTemp = (unsigned int) sortedUncertainty->operator[](i)[k];
                                 uTemp = secUncertainty->operator[](i)[sTemp];
 
                                 if ((tDelta <= timer) && (timer <= (tDelta + uTemp))) {
@@ -3095,9 +3096,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                     }
                                     // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                                     if (i < this->aminoAcidCount - 1) {
-                                        if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                            (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                            sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                        if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                            (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                            sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                         }
                                     }
                                     posTemp = this->secStructVertices[sTemp][j];
@@ -3105,9 +3106,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                         (1.0f - (timer - tDelta) / uTemp) * this->secStructVertices[sTemp][j].Y());
 
                                     if (k == diffStruct - 1) {
-                                        sTemp = (unsigned int)sortedUncertainty->operator[](i)[0];
+                                        sTemp = (unsigned int) sortedUncertainty->operator[](i)[0];
                                     } else {
-                                        sTemp = (unsigned int)sortedUncertainty->operator[](i)[k + 1];
+                                        sTemp = (unsigned int) sortedUncertainty->operator[](i)[k + 1];
                                     }
                                     if (this->currentUncertainStructColor == UNCERTAIN_STRUCT_COLORED) {
                                         colTemp = colTemp + ((timer - tDelta) / uTemp) * (this->secStructColor[sTemp]);
@@ -3115,9 +3116,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                     }
                                     // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                                     if (i < this->aminoAcidCount - 1) {
-                                        if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                            (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                            sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                        if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                            (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                            sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                         }
                                     }
                                     posTemp.SetY(posTemp.Y() +
@@ -3135,7 +3136,7 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                 if ((static_cast<float>(k) * tDelta <= timer) &&
                                     (timer <= (static_cast<float>(k) * tDelta + tDelta))) {
 
-                                    sTemp = (unsigned int)sortedUncertainty->operator[](i)[k];
+                                    sTemp = (unsigned int) sortedUncertainty->operator[](i)[k];
                                     uTemp = secUncertainty->operator[](i)[sTemp];
 
                                     if (this->currentUncertainStructColor == UNCERTAIN_STRUCT_COLORED) {
@@ -3144,9 +3145,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                     }
                                     // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                                     if (i < this->aminoAcidCount - 1) {
-                                        if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                            (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                            sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                        if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                            (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                            sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                         }
                                     }
                                     posTemp = this->secStructVertices[sTemp][j];
@@ -3162,9 +3163,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
 
                                     if (k == diffStruct - 1)
-                                        sTemp = (unsigned int)sortedUncertainty->operator[](i)[0];
+                                        sTemp = (unsigned int) sortedUncertainty->operator[](i)[0];
                                     else
-                                        sTemp = (unsigned int)sortedUncertainty->operator[](i)[k + 1];
+                                        sTemp = (unsigned int) sortedUncertainty->operator[](i)[k + 1];
 
                                     uTemp = secUncertainty->operator[](i)[sTemp];
 
@@ -3175,9 +3176,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                                     }
                                     // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                                     if (i < this->aminoAcidCount - 1) {
-                                        if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                            (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                            sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                        if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                            (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                            sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                         }
                                     }
 
@@ -3212,9 +3213,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                             // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                             if (i < this->aminoAcidCount - 1) {
-                                if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                    (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                    sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                    (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                    sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                 }
                             }
                             for (unsigned int k = 0; k < this->secStructVertices[sTemp].Count(); k++) {
@@ -3243,9 +3244,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                             // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                             if (i < this->aminoAcidCount - 1) {
-                                if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                    (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                    sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                    (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                    sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                 }
                             }
                             for (unsigned int k = 0; k < this->secStructVertices[sTemp].Count(); k++) {
@@ -3284,17 +3285,17 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
                         glUniformMatrix4fv(
                             this->shader->getUniformLocation("MVP"), 1, GL_FALSE, modelViewProjMatrix.PeekComponents());
                         glUniform2fv(
-                            this->shader->getUniformLocation("worldPos"), 1, (GLfloat*)posOffset.PeekComponents());
+                            this->shader->getUniformLocation("worldPos"), 1, (GLfloat*) posOffset.PeekComponents());
                         glUniform4fv(this->shader->getUniformLocation("structCol"), structCount,
-                            (GLfloat*)&this->secStructColor.front().x);
+                            (GLfloat*) &this->secStructColor.front().x);
                         glUniform1iv(this->shader->getUniformLocation("sortedStruct"), structCount,
-                            (GLint*)sortedStructLR.PeekComponents());
+                            (GLint*) sortedStructLR.PeekComponents());
                         glUniform1fv(this->shader->getUniformLocation("structUnc"), structCount,
-                            (GLfloat*)secUncertainty->operator[](i).PeekComponents());
+                            (GLfloat*) secUncertainty->operator[](i).PeekComponents());
                         glUniform1f(
                             this->shader->getUniformLocation("gradientInt"), this->currentUncertainGardientInterval);
                         glUniform1i(this->shader->getUniformLocation("colorInterpol"),
-                            (int)this->currentUncertainColorInterpol);
+                            (int) this->currentUncertainColorInterpol);
                     }
 
                     posOffset.SetY(posOffset.Y() - 0.5f);
@@ -3310,9 +3311,9 @@ void UncertaintySequenceRenderer::RenderUncertainty(float yPos, float fgColor[4]
 
                             // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
                             if (i < this->aminoAcidCount - 1) {
-                                if ((sTemp == (unsigned int)UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
-                                    (sTemp != (unsigned int)sortedUncertainty->operator[](i + 1)[0])) {
-                                    sTemp = (unsigned int)UncertaintyDataCall::secStructure::B_BRIDGE;
+                                if ((sTemp == (unsigned int) UncertaintyDataCall::secStructure::E_EXT_STRAND) &&
+                                    (sTemp != (unsigned int) sortedUncertainty->operator[](i + 1)[0])) {
+                                    sTemp = (unsigned int) UncertaintyDataCall::secStructure::B_BRIDGE;
                                 }
                             }
                             posTemp.SetY(posTemp.Y() + uTemp * this->secStructVertices[sTemp][j].Y());
@@ -3385,15 +3386,15 @@ void UncertaintySequenceRenderer::DrawSecStructGeometryTiles(UncertaintyDataCall
 
     // ignore as missing flagged amino-acids and NOTDEFINED secondary structure types
     if ((f != UncertaintyDataCall::addFlags::MISSING) && (cur != UncertaintyDataCall::secStructure::NOTDEFINED)) {
-        glColor3fv(&this->secStructColor[(int)cur].x);
+        glColor3fv(&this->secStructColor[(int) cur].x);
         // check if end of strand is an arrow (the arrow vertices ae stored in BRIDGE)
         if ((curTemp == UncertaintyDataCall::secStructure::E_EXT_STRAND) && (curTemp != fol)) {
             curTemp = UncertaintyDataCall::secStructure::B_BRIDGE;
         }
         glBegin(GL_TRIANGLE_STRIP);
-        for (unsigned int i = 0; i < this->secStructVertices[(int)curTemp].Count(); i++) {
-            glVertex2f(x + this->secStructVertices[(int)curTemp][i].X(),
-                -(y + 0.5f + this->secStructVertices[(int)curTemp][i].Y()));
+        for (unsigned int i = 0; i < this->secStructVertices[(int) curTemp].Count(); i++) {
+            glVertex2f(x + this->secStructVertices[(int) curTemp][i].X(),
+                -(y + 0.5f + this->secStructVertices[(int) curTemp][i].Y()));
         }
         glEnd();
     }
@@ -3414,7 +3415,7 @@ void UncertaintySequenceRenderer::DrawSecStructTextureTiles(UncertaintyDataCall:
         glColor4fv(bgColor);
         this->markerTextures[0]->Bind();
     } else {
-        glColor3fv(&this->secStructColor[(int)cur].x);
+        glColor3fv(&this->secStructColor[(int) cur].x);
         switch (cur) {
         case (UncertaintyDataCall::secStructure::H_ALPHA_HELIX):
             if (pre != cur) {
@@ -3516,7 +3517,7 @@ bool UncertaintySequenceRenderer::MouseEvent(float x, float y, core::view::Mouse
             this->selection[this->mousePosResIdx] = this->initialClickSelection;
             consumeEvent = true;
         } else {
-            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int)this->aminoAcidCount) {
+            if (this->mousePosResIdx > -1 && this->mousePosResIdx < (int) this->aminoAcidCount) {
                 this->selection[this->mousePosResIdx] = !this->selection[this->mousePosResIdx];
             }
         }
@@ -3826,10 +3827,10 @@ bool UncertaintySequenceRenderer::PrepareData(UncertaintyDataCall* udc, BindingS
     if (this->currentViewMode == VIEWMODE_UNFOLDED_AMINOACID) {
 
         vislib::Array<vislib::math::Vector<float, static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>*
-            secUncertainty = &this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+            secUncertainty = &this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
         vislib::Array<vislib::math::Vector<UncertaintyDataCall::secStructure,
             static_cast<int>(UncertaintyDataCall::secStructure::NOE)>>* sortedUncertainty =
-            &this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY];
+            &this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY];
 
         // Bestimme die unterschiedlichen Strukturtypen mit u > 0 für alle Amino-Säuren
         for (unsigned int aa = 0; aa < this->aminoAcidCount; aa++) {
@@ -3837,7 +3838,7 @@ bool UncertaintySequenceRenderer::PrepareData(UncertaintyDataCall* udc, BindingS
             this->diffStrucCount.Add(0);
             if (this->residueFlag[aa] != UncertaintyDataCall::addFlags::MISSING) {
                 for (unsigned int k = 0; k < UncertaintyDataCall::secStructure::NOE; k++) {
-                    if (secUncertainty->operator[](aa)[(int)sortedUncertainty->operator[](aa)[k]] > 0.0f)
+                    if (secUncertainty->operator[](aa)[(int) sortedUncertainty->operator[](aa)[k]] > 0.0f)
                         this->diffStrucCount.Last()++;
                 }
             }
@@ -3857,10 +3858,10 @@ bool UncertaintySequenceRenderer::PrepareData(UncertaintyDataCall* udc, BindingS
         for (unsigned int aa = 0; aa < this->aminoAcidCount; aa++) {
 
             if (this->residueFlag[aa] != UncertaintyDataCall::addFlags::MISSING) {
-                aaCur = this->secStructUncertainty[(int)UncertaintyDataCall::assMethod::UNCERTAINTY][aa][(
-                    int)this->sortedSecStructAssignment[(int)UncertaintyDataCall::assMethod::UNCERTAINTY][aa][0]];
+                aaCur = this->secStructUncertainty[(int) UncertaintyDataCall::assMethod::UNCERTAINTY][aa][(
+                    int) this->sortedSecStructAssignment[(int) UncertaintyDataCall::assMethod::UNCERTAINTY][aa][0]];
 
-                float offset = (float)this->secStructRows;
+                float offset = (float) this->secStructRows;
 
                 if (aaCur < 1.0f) {
                     this->aminoacidSeparatorVertices.Add(this->vertices[aa * 2]);

--- a/plugins/protein_gl/src/slicing.cpp
+++ b/plugins/protein_gl/src/slicing.cpp
@@ -46,7 +46,7 @@ int ViewSlicing::setupSlicing(float* mvMatrix, float sampDist, float* extents) {
     float v[3];
 
     _sampDist = sampDist;
-    memcpy((void*)_m, (void*)mvMatrix, 16 * sizeof(float));
+    memcpy((void*) _m, (void*) mvMatrix, 16 * sizeof(float));
     _ext[0] = xMax = 0.5f * extents[0];
     _ext[1] = yMax = 0.5f * extents[1];
     _ext[2] = zMax = 0.5f * extents[2];
@@ -108,7 +108,7 @@ int ViewSlicing::setupSlicing(float* mvMatrix, float sampDist, float* extents) {
 
     _d *= 2.0;
 
-    _numSlices = (int)(_d / _sampDist) + 1;
+    _numSlices = (int) (_d / _sampDist) + 1;
     return _numSlices;
 }
 
@@ -119,7 +119,7 @@ void ViewSlicing::drawSlice(int slice) {
     char edgeCode[12] = {cubeEdges[0], cubeEdges[1], cubeEdges[2], cubeEdges[3], cubeEdges[4], cubeEdges[5],
         cubeEdges[6], cubeEdges[7], cubeEdges[8], cubeEdges[9], cubeEdges[10], cubeEdges[11]};
     float d = -0.5f * _d + (slice + 0.5f) * _d / _numSlices;
-    char actEdge = (char)0xff;
+    char actEdge = (char) 0xff;
     int numIntersect = 0, oldInt;
     int idx;
     int tmp[6];
@@ -181,7 +181,7 @@ void ViewSlicing::drawSlice(int slice) {
         for (int i = 0; i < 12; ++i) {
             for (int j = i + 1; j < 12; ++j) {
                 if (validHit[i] && validHit[j]) {
-                    if (pointCmp(_p[i], _p[j], (float)VS_EPS)) {
+                    if (pointCmp(_p[i], _p[j], (float) VS_EPS)) {
                         validHit[j] = 0;
                         numIntersect--;
                         edgeCode[i] |= edgeCode[j];
@@ -320,9 +320,9 @@ void ViewSlicing::setupSingleSlice(double* viewVec, float* ext) {
         viewVec[0] = viewVec[1] = viewVec[2] = 0.0;
     }
 
-    _v[0] = (float)viewVec[0];
-    _v[1] = (float)viewVec[1];
-    _v[2] = (float)viewVec[2];
+    _v[0] = (float) viewVec[0];
+    _v[1] = (float) viewVec[1];
+    _v[2] = (float) viewVec[2];
 
     v[0] = fabs(_v[0]);
     v[1] = fabs(_v[1]);
@@ -343,7 +343,7 @@ void ViewSlicing::drawSingleSlice(float dist) {
     char validHit[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     char edgeCode[12] = {cubeEdges[0], cubeEdges[1], cubeEdges[2], cubeEdges[3], cubeEdges[4], cubeEdges[5],
         cubeEdges[6], cubeEdges[7], cubeEdges[8], cubeEdges[9], cubeEdges[10], cubeEdges[11]};
-    char actEdge = (char)0xff;
+    char actEdge = (char) 0xff;
     int numIntersect = 0, oldInt;
     int idx;
     int tmp[6];
@@ -409,7 +409,7 @@ void ViewSlicing::drawSingleSlice(float dist) {
     for (int i = 0; i < 12; ++i) {
         for (int j = i + 1; j < 12; ++j) {
             if (validHit[i] && validHit[j]) {
-                if (pointCmp(_p[i], _p[j], (float)VS_EPS)) {
+                if (pointCmp(_p[i], _p[j], (float) VS_EPS)) {
                     validHit[j] = 0;
                     numIntersect--;
                     edgeCode[i] |= edgeCode[j];

--- a/plugins/pwdemos_gl/src/CrystalStructureVolumeRenderer.cpp
+++ b/plugins/pwdemos_gl/src/CrystalStructureVolumeRenderer.cpp
@@ -626,9 +626,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
         gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
         gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-        gridDim[0] = (int)ceil(gridXAxis[0] / this->densGridSpacing);
-        gridDim[1] = (int)ceil(gridYAxis[1] / this->densGridSpacing);
-        gridDim[2] = (int)ceil(gridZAxis[2] / this->densGridSpacing);
+        gridDim[0] = (int) ceil(gridXAxis[0] / this->densGridSpacing);
+        gridDim[1] = (int) ceil(gridYAxis[1] / this->densGridSpacing);
+        gridDim[2] = (int) ceil(gridZAxis[2] / this->densGridSpacing);
         gridXAxis[0] = (gridDim[0] - 1) * this->densGridSpacing;
         gridYAxis[1] = (gridDim[1] - 1) * this->densGridSpacing;
         gridZAxis[2] = (gridDim[2] - 1) * this->densGridSpacing;
@@ -753,7 +753,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         //        printf("Vectors contained in density tex %u\n", dipole_cnt);
 
         // Compute uniform grid containing density map of the vectors
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
         int rc = cqs->calc_map(static_cast<long>(gridPos.Count() / 4), gridPos.PeekElements(), gridCol.PeekElements(),
             true, // Use 'color' array
@@ -774,7 +774,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcDensityTex(
         // Setup texture
 
         this->uniGridDensity.MemCpyFromDevice(cqs->getMap());
-        this->uniGridColor.MemCpyFromDevice((float3*)cqs->getColorMap());
+        this->uniGridColor.MemCpyFromDevice((float3*) cqs->getColorMap());
 
         /*for(int x = 0; x < gridDim.X(); x++) {
             for(int y = 0; y < gridDim.Y(); y++) {
@@ -854,9 +854,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -883,10 +883,10 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
     // Allocate device memory if necessary
 
     if (this->gridCurlD == NULL) {
-        checkCudaErrors(cudaMalloc((void**)&this->gridCurlD, sizeof(float) * nVoxels * 3));
+        checkCudaErrors(cudaMalloc((void**) &this->gridCurlD, sizeof(float) * nVoxels * 3));
     }
     if (this->gridCurlMagD == NULL) {
-        checkCudaErrors(cudaMalloc((void**)&this->gridCurlMagD, sizeof(float) * nVoxels));
+        checkCudaErrors(cudaMalloc((void**) &this->gridCurlMagD, sizeof(float) * nVoxels));
     }
 
     // Copy grid parameters to constant device memory
@@ -924,7 +924,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcMagCurlTex() {
 
     // Compute curl magnitude
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
     cudaErr = protein_cuda::CudaGetCurlMagnitude(
         cqs->getColorMap(), this->gridCurlD, this->gridCurlMagD, nVoxels, this->gridSpacing);
@@ -1005,9 +1005,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -1077,7 +1077,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
 
     // Compute uniform grid (vector field and density map)
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
     int rc = cqs->calc_map(dataCnt, &gridDataPos[0], &gridData[0],
         true, // Use seperate 'color' array
         gridOrg.PeekComponents(), gridDim.PeekComponents(),
@@ -1096,7 +1096,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::CalcUniGrid(
 
     // Copy data from device to host
 
-    this->uniGridVecField.MemCpyFromDevice((float3*)(cqs->getColorMap()));
+    this->uniGridVecField.MemCpyFromDevice((float3*) (cqs->getColorMap()));
 
     // DEBUG
     /*for(int x = 0; x < this->uniGridVecField.GetGridDim().X(); x++) {
@@ -1251,7 +1251,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::create(void) {
     using namespace vislib_gl::graphics::gl;
 
     // Init random number generator
-    srand((unsigned)time(0));
+    srand((unsigned) time(0));
 
     // Create quicksurf object
     if (!this->cudaqsurf) {
@@ -1440,9 +1440,9 @@ void protein_cuda::CrystalStructureVolumeRenderer::FilterVecField(
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -1602,7 +1602,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::InitLIC() {
     for (int x = 0; x < this->licRandBuffSize; x++) {
         for (int y = 0; y < this->licRandBuffSize; y++) {
             for (int z = 0; z < this->licRandBuffSize; z++) {
-                float randVal = (float)rand() / float(RAND_MAX);
+                float randVal = (float) rand() / float(RAND_MAX);
                 /*if(randVal > 0.5f)
                     this->licRandBuff.SetAt(x, y, z, 1.0f);
                 else
@@ -1656,7 +1656,7 @@ void protein_cuda::CrystalStructureVolumeRenderer::release(void) {
     this->rcShaderDebug.Release();
     this->pplShader.Release();
     if (this->cudaqsurf != NULL) {
-        CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+        CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
         delete cqs;
     }
 }
@@ -1948,9 +1948,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::Render(core::Call& call) {
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->gridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->gridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->gridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->gridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->gridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->gridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->gridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->gridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->gridSpacing;
@@ -2837,9 +2837,9 @@ bool protein_cuda::CrystalStructureVolumeRenderer::RenderIsoSurfMC() {
     gridXAxis[0] = gridMaxCoord[0] - gridMinCoord[0];
     gridYAxis[1] = gridMaxCoord[1] - gridMinCoord[1];
     gridZAxis[2] = gridMaxCoord[2] - gridMinCoord[2];
-    gridDim[0] = (int)ceil(gridXAxis[0] / this->densGridSpacing);
-    gridDim[1] = (int)ceil(gridYAxis[1] / this->densGridSpacing);
-    gridDim[2] = (int)ceil(gridZAxis[2] / this->densGridSpacing);
+    gridDim[0] = (int) ceil(gridXAxis[0] / this->densGridSpacing);
+    gridDim[1] = (int) ceil(gridYAxis[1] / this->densGridSpacing);
+    gridDim[2] = (int) ceil(gridZAxis[2] / this->densGridSpacing);
     gridXAxis[0] = (gridDim[0] - 1) * this->densGridSpacing;
     gridYAxis[1] = (gridDim[1] - 1) * this->densGridSpacing;
     gridZAxis[2] = (gridDim[2] - 1) * this->densGridSpacing;
@@ -2902,14 +2902,14 @@ bool protein_cuda::CrystalStructureVolumeRenderer::RenderIsoSurfMC() {
         if (this->mcNormOut != NULL)
             delete[] this->mcNormOut;
         // Allocate memory
-        checkCudaErrors(cudaMalloc((void**)&this->mcVertOut_D, nVerticesMC * sizeof(float3)));
-        checkCudaErrors(cudaMalloc((void**)&this->mcNormOut_D, nVerticesMC * sizeof(float3)));
+        checkCudaErrors(cudaMalloc((void**) &this->mcVertOut_D, nVerticesMC * sizeof(float3)));
+        checkCudaErrors(cudaMalloc((void**) &this->mcNormOut_D, nVerticesMC * sizeof(float3)));
         this->mcVertOut = new float[nVerticesMC * 3];
         this->mcNormOut = new float[nVerticesMC * 3];
         printf("(Re)allocating of memory done.");
     }
 
-    CUDAQuickSurf* cqs = (CUDAQuickSurf*)this->cudaqsurf;
+    CUDAQuickSurf* cqs = (CUDAQuickSurf*) this->cudaqsurf;
 
     // Setup
     if (!this->cudaMC->Initialize(gridDimAlt)) {
@@ -3289,7 +3289,7 @@ bool protein_cuda::CrystalStructureVolumeRenderer::SetupAtomColors(const protein
 
     this->atomColor.SetCount(dc->GetAtomCnt() * 3);
 #pragma omp parallel for
-    for (int at = 0; at < (int)dc->GetAtomCnt(); at++) {
+    for (int at = 0; at < (int) dc->GetAtomCnt(); at++) {
         if (dc->GetAtomType()[at] == protein_calls::CrystalStructureDataCall::BA) { // Green
             this->atomColor[at * 3 + 0] = 0.0f;
             this->atomColor[at * 3 + 1] = 0.6f;

--- a/plugins/pwdemos_gl/src/QuartzRenderer.cpp
+++ b/plugins/pwdemos_gl/src/QuartzRenderer.cpp
@@ -327,9 +327,9 @@ bool QuartzRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                     ::glBindBuffer(GL_ARRAY_BUFFER, vbo);
                     ::glBufferData(GL_ARRAY_BUFFER, list.Count() * 8 * sizeof(float), list.Data(), GL_STATIC_DRAW);
                     ::glEnableVertexAttribArray(0);
-                    ::glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0);
+                    ::glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*) 0);
                     ::glEnableVertexAttribArray(1);
-                    ::glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)16);
+                    ::glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*) 16);
 
                     //::glVertexPointer(4, GL_FLOAT, 8 * sizeof(float), list.Data());
                     //::glTexCoordPointer(4, GL_FLOAT, 8 * sizeof(float), list.Data() + 4);

--- a/plugins/pwdemos_gl/src/QuartzTexRenderer.cpp
+++ b/plugins/pwdemos_gl/src/QuartzTexRenderer.cpp
@@ -310,9 +310,9 @@ bool QuartzTexRenderer::Render(mmstd_gl::CallRender3DGL& call) {
                     ::glBindBuffer(GL_ARRAY_BUFFER, vbo);
                     ::glBufferData(GL_ARRAY_BUFFER, list.Count() * 8 * sizeof(float), list.Data(), GL_STATIC_DRAW);
                     ::glEnableVertexAttribArray(0);
-                    ::glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0);
+                    ::glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*) 0);
                     ::glEnableVertexAttribArray(1);
-                    ::glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)16);
+                    ::glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*) 16);
 
                     //::glVertexPointer(4, GL_FLOAT, 8 * sizeof(float), list.Data());
                     //::glTexCoordPointer(4, GL_FLOAT, 8 * sizeof(float), list.Data() + 4);

--- a/plugins/remote/src/FBOCommFabric.cpp
+++ b/plugins/remote/src/FBOCommFabric.cpp
@@ -30,7 +30,7 @@ bool megamol::remote::MPICommFabric::Bind(std::string const& address) {
 bool megamol::remote::MPICommFabric::Send(std::vector<char> const& buf, send_type const type) {
 #ifdef MEGAMOL_USE_MPI
     // TODO this is wrong. mpiprovider gives you the correct comm
-    auto status = MPI_Send((void*)buf.data(), buf.size(), MPI_CHAR, target_rank_, 0, MPI_COMM_WORLD);
+    auto status = MPI_Send((void*) buf.data(), buf.size(), MPI_CHAR, target_rank_, 0, MPI_COMM_WORLD);
     return status == MPI_SUCCESS;
 #else
     return false;

--- a/plugins/test_gl/src/rendering/SRTest.cpp
+++ b/plugins/test_gl/src/rendering/SRTest.cpp
@@ -709,7 +709,7 @@ void megamol::test_gl::rendering::SRTest::loadData(geocalls::MultiParticleDataCa
 
         if (mode == upload_mode::BUFFER_ARRAY) {
             auto& bufA = data_.bufArray[pl_idx];
-            bufA.SetDataWithSize(positions.data(), 16, 16, parts.GetCount(), (GLuint)(2 * 1024 * 1024 * 1024 - 1));
+            bufA.SetDataWithSize(positions.data(), 16, 16, parts.GetCount(), (GLuint) (2 * 1024 * 1024 * 1024 - 1));
         }
     }
 }

--- a/plugins/trisoup_gl/src/volumetrics/TetraVoxelizer.cpp
+++ b/plugins/trisoup_gl/src/volumetrics/TetraVoxelizer.cpp
@@ -1001,7 +1001,7 @@ DWORD TetraVoxelizer::Run(void* userData) {
         UINT64 numParticles = ps.GetCount();
         unsigned int stride = ps.GetVertexDataStride();
         geocalls::MultiParticleDataCall::Particles::VertexDataType dataType = ps.GetVertexDataType();
-        unsigned char* vertexData = (unsigned char*)ps.GetVertexData();
+        unsigned char* vertexData = (unsigned char*) ps.GetVertexData();
         switch (dataType) {
         case geocalls::MultiParticleDataCall::Particles::VERTDATA_NONE:
             continue;
@@ -1035,7 +1035,7 @@ DWORD TetraVoxelizer::Run(void* userData) {
         UINT64 numParticles = ps.GetCount();
         unsigned int stride = ps.GetVertexDataStride();
         geocalls::MultiParticleDataCall::Particles::VertexDataType dataType = ps.GetVertexDataType();
-        unsigned char* vertexData = (unsigned char*)ps.GetVertexData();
+        unsigned char* vertexData = (unsigned char*) ps.GetVertexData();
         switch (dataType) {
         case geocalls::MultiParticleDataCall::Particles::VERTDATA_NONE:
             continue;
@@ -1050,9 +1050,9 @@ DWORD TetraVoxelizer::Run(void* userData) {
             return -2;
         }
         for (UINT64 l = 0; l < numParticles; l++) {
-            vislib::math::ShallowPoint<float, 3> sp((float*)&vertexData[(vertFloatSize + stride) * l]);
+            vislib::math::ShallowPoint<float, 3> sp((float*) &vertexData[(vertFloatSize + stride) * l]);
             if (dataType == geocalls::MultiParticleDataCall::Particles::VERTDATA_FLOAT_XYZR) {
-                currRad = (float)vertexData[(vertFloatSize + stride) * l + 3 * sizeof(float)];
+                currRad = (float) vertexData[(vertFloatSize + stride) * l + 3 * sizeof(float)];
                 currRad *= sjd->RadMult;
             }
             if (Centroid.Distance(sp) > currRad + distOffset) {

--- a/plugins/trisoup_gl/src/volumetrics/VoluMetricJob.cpp
+++ b/plugins/trisoup_gl/src/volumetrics/VoluMetricJob.cpp
@@ -204,10 +204,10 @@ DWORD VoluMetricJob::Run(void* userData) {
                 geocalls::MultiParticleDataCall::Particles::VERTDATA_FLOAT_XYZR) {
                 UINT64 numParticles = datacall->AccessParticles(partListI).GetCount();
                 unsigned int stride = datacall->AccessParticles(partListI).GetVertexDataStride();
-                unsigned char* vertexData = (unsigned char*)datacall->AccessParticles(partListI).GetVertexData();
+                unsigned char* vertexData = (unsigned char*) datacall->AccessParticles(partListI).GetVertexData();
                 for (UINT64 l = 0; l < numParticles; l++) {
-                    vislib::math::ShallowPoint<float, 3> sp((float*)&vertexData[(4 * sizeof(float) + stride) * l]);
-                    float currRad = (float)vertexData[(4 * sizeof(float) + stride) * l + 3];
+                    vislib::math::ShallowPoint<float, 3> sp((float*) &vertexData[(4 * sizeof(float) + stride) * l]);
+                    float currRad = (float) vertexData[(4 * sizeof(float) + stride) * l + 3];
                     if (currRad > MaxRad) {
                         MaxRad = currRad;
                     }
@@ -243,9 +243,9 @@ DWORD VoluMetricJob::Run(void* userData) {
 
         int subVolCells = this->subVolumeResolutionSlot.Param<megamol::core::param::IntParam>()->Value();
 #if 1 // ndef _DEBUG
-        int resX = (int)((trisoup::volumetrics::VoxelizerFloat)b.Width() / cellSize) + 2;
-        int resY = (int)((trisoup::volumetrics::VoxelizerFloat)b.Height() / cellSize) + 2;
-        int resZ = (int)((trisoup::volumetrics::VoxelizerFloat)b.Depth() / cellSize) + 2;
+        int resX = (int) ((trisoup::volumetrics::VoxelizerFloat) b.Width() / cellSize) + 2;
+        int resY = (int) ((trisoup::volumetrics::VoxelizerFloat) b.Height() / cellSize) + 2;
+        int resZ = (int) ((trisoup::volumetrics::VoxelizerFloat) b.Depth() / cellSize) + 2;
         b.SetWidth(resX * cellSize);
         b.SetHeight(resY * cellSize);
         b.SetDepth(resZ * cellSize);
@@ -259,9 +259,9 @@ DWORD VoluMetricJob::Run(void* userData) {
 
         while (divX == 1 && divY == 1 && divZ == 1) {
             subVolCells /= 2;
-            divX = (int)ceil((trisoup::volumetrics::VoxelizerFloat)resX / subVolCells);
-            divY = (int)ceil((trisoup::volumetrics::VoxelizerFloat)resY / subVolCells);
-            divZ = (int)ceil((trisoup::volumetrics::VoxelizerFloat)resZ / subVolCells);
+            divX = (int) ceil((trisoup::volumetrics::VoxelizerFloat) resX / subVolCells);
+            divY = (int) ceil((trisoup::volumetrics::VoxelizerFloat) resY / subVolCells);
+            divZ = (int) ceil((trisoup::volumetrics::VoxelizerFloat) resZ / subVolCells);
         }
 #else
         divX = 1;
@@ -271,7 +271,7 @@ DWORD VoluMetricJob::Run(void* userData) {
         int resX = subVolCells + 2;
         int resY = subVolCells + 2;
         int resZ = subVolCells + 2;
-        cellSize = (trisoup::volumetrics::VoxelizerFloat)b.Width() / subVolCells /*resX*/;
+        cellSize = (trisoup::volumetrics::VoxelizerFloat) b.Width() / subVolCells /*resX*/;
 #endif
 
         vertSize += bboxBytes * divX * divY * divZ;
@@ -314,7 +314,7 @@ DWORD VoluMetricJob::Run(void* userData) {
                     sjd->parent = this;
                     sjd->datacall = datacall;
                     sjd->Bounds = bx;
-                    sjd->CellSize = (trisoup::volumetrics::VoxelizerFloat)MinRad *
+                    sjd->CellSize = (trisoup::volumetrics::VoxelizerFloat) MinRad *
                                     this->cellSizeRatioSlot.Param<megamol::core::param::FloatParam>()->Value();
                     sjd->resX = restX;
                     sjd->resY = restY;

--- a/plugins/volume/datraw/include/datRaw_half.h
+++ b/plugins/volume/datraw/include/datRaw_half.h
@@ -53,7 +53,7 @@ extern __inline__ DR_HALF floatToHalf(DR_FLOAT val) INLINE_ATTRIB;
 */
 
 extern __inline__ float halfToFloat(DR_HALF val) {
-    const DR_INT h = 0x0 | (DR_UINT)val;
+    const DR_INT h = 0x0 | (DR_UINT) val;
     const DR_INT h_m = h & 0x3ff;
     const DR_INT h_e = (h >> 10) & 0x1f;
     const DR_INT h_s = (h >> 15) & 0x1;
@@ -69,7 +69,7 @@ extern __inline__ float halfToFloat(DR_HALF val) {
     } else if (h_e == 0 && h_m != 0) {
         /* denorm -- denorm half will fit in non-denorm float */
         const float half_denorm = (1.0f / 16384.0f); /* 2^-14 */
-        float mantissa = ((float)h_m) / 1024.0f;
+        float mantissa = ((float) h_m) / 1024.0f;
         float sgn = h_s ? -1.0f : 1.0f;
         return sgn * mantissa * half_denorm;
     } else if ((h_e == 31) && (h_m == 0)) {
@@ -86,12 +86,12 @@ extern __inline__ float halfToFloat(DR_HALF val) {
     }
     result = (h_s << 31) | (f_e << 23) | f_m;
 
-    pfresult = (float*)&result;
+    pfresult = (float*) &result;
     return *pfresult;
 }
 
 extern __inline__ DR_HALF floatToHalf(float val) {
-    const DR_INT* pf = (DR_INT*)&val;
+    const DR_INT* pf = (DR_INT*) &val;
     const DR_INT f = *pf;
     const DR_INT f_m = f & 0x7fffff;
     const DR_INT f_e = (f >> 23) & 0xff;
@@ -126,7 +126,7 @@ extern __inline__ DR_HALF floatToHalf(float val) {
         if (new_exp < -14) {
             /* this maps to a denorm */
             /* h_e = 0; already set */
-            DR_UINT exp_val = (DR_UINT)(-14 - new_exp); /* 2^-exp_val */
+            DR_UINT exp_val = (DR_UINT) (-14 - new_exp); /* 2^-exp_val */
             switch (exp_val) {
             case 0:
                 datRaw_logError("logical error in denorm creation!\n");

--- a/plugins/volume/src/VolumetricDataSource.cpp
+++ b/plugins/volume/src/VolumetricDataSource.cpp
@@ -534,7 +534,7 @@ bool megamol::volume::VolumetricDataSource::onGetData(core::Call& call) {
 
                     /* Request follow-up frames. */
                     for (size_t i = 1; (i < this->metadata.NumberOfFrames) && (i < this->buffers.Count() - 1); ++i) {
-                        unsigned int frameID = (c.FrameID() + i) % (unsigned int)this->metadata.NumberOfFrames;
+                        unsigned int frameID = (c.FrameID() + i) % (unsigned int) this->metadata.NumberOfFrames;
                         if (this->bufferForFrameIDUnsafe(frameID) < 0) {
                             BufferSlot* bs = nullptr;
                             if (!unusedBuffers.IsEmpty()) {
@@ -623,7 +623,7 @@ bool megamol::volume::VolumetricDataSource::onGetData(core::Call& call) {
 
                     for (size_t i = loadStart; i < dst.Count(); ++i) {
                         size_t idx = i % dst.Count();
-                        this->buffers[idx]->FrameID = c.FrameID() + (unsigned int)i;
+                        this->buffers[idx]->FrameID = c.FrameID() + (unsigned int) i;
                         this->buffers[idx]->Buffer.AssertSize(frameSize);
                         this->buffers[idx]->status.store(BUFFER_STATUS_READY);
                         dst[i] = this->buffers[idx]->Buffer.At(0);
@@ -742,7 +742,7 @@ bool megamol::volume::VolumetricDataSource::onGetExtents(core::Call& call) {
          */
 
         /* Complete request. */
-        c.SetExtent((unsigned int)this->metadata.NumberOfFrames, this->metadata.Origin[0], this->metadata.Origin[1],
+        c.SetExtent((unsigned int) this->metadata.NumberOfFrames, this->metadata.Origin[0], this->metadata.Origin[1],
             this->metadata.Origin[2], this->metadata.Extents[0] + this->metadata.Origin[0],
             this->metadata.Extents[1] + this->metadata.Origin[1], this->metadata.Extents[2] + this->metadata.Origin[2]);
 

--- a/vislib/include/vislib/assert.h
+++ b/vislib/include/vislib/assert.h
@@ -18,7 +18,7 @@
 #if (defined(DEBUG) || defined(_DEBUG))
 #define ASSERT(exp) assert(exp)
 #else
-#define ASSERT(exp) ((void)0)
+#define ASSERT(exp) ((void) 0)
 #endif /* (defined(DEBUG) || defined(_DEBUG)) */
 #endif /* ASSERT */
 

--- a/vislib/include/vislib/graphics/ColourHSVf.h
+++ b/vislib/include/vislib/graphics/ColourHSVf.h
@@ -100,9 +100,9 @@ public:
      */
     inline void SetH(float h) {
         h /= 360.0;
-        h -= (long)h; // ]1 .. -1[
+        h -= (long) h; // ]1 .. -1[
         h += 1.0f;
-        h -= (long)h; // ]1 .. 0]
+        h -= (long) h; // ]1 .. 0]
         this->comp[0] = h * 360.0f;
     }
 

--- a/vislib/include/vislib/math/AbstractMatrix.h
+++ b/vislib/include/vislib/math/AbstractMatrix.h
@@ -177,7 +177,7 @@ unsigned int AbstractMatrix<T, D, L, S>::FindEigenvalues(
  */
 template<class T, unsigned int D, MatrixLayout L, class S>
 T AbstractMatrix<T, D, L, S>::Determinant() const {
-#define A(r, c) a[(r)*D + (c)]
+#define A(r, c) a[(r) *D + (c)]
     double a[D * D];              // input matrix for algorithm
     double f;                     // Multiplication factor.
     double max;                   // Row pivotising.

--- a/vislib/include/vislib/math/AbstractMatrixImpl.h
+++ b/vislib/include/vislib/math/AbstractMatrixImpl.h
@@ -778,7 +778,7 @@ Vector<T, D> AbstractMatrixImpl<T, D, L, S, C>::GetRow(const int row) const {
 template<class T, unsigned int D, MatrixLayout L, class S,
     template<class Tc, unsigned int Dc, MatrixLayout Lc, class Sc> class C>
 bool AbstractMatrixImpl<T, D, L, S, C>::Invert() {
-#define A(r, c) a[(r)*2 * D + (c)]
+#define A(r, c) a[(r) *2 * D + (c)]
     double a[2 * D * D]; // input matrix for algorithm
     double f;            // Multiplication factor.
     double max;          // Row pivotising.
@@ -1265,7 +1265,7 @@ T& AbstractMatrixImpl<T, D, L, S, C>::operator()(const int row, const int col) {
  */
 template<class T, unsigned int D, MatrixLayout L, class S,
     template<class Tc, unsigned int Dc, MatrixLayout Lc, class Sc> class C>
-const unsigned int AbstractMatrixImpl<T, D, L, S, C>::CNT_COMPONENTS = D* D;
+const unsigned int AbstractMatrixImpl<T, D, L, S, C>::CNT_COMPONENTS = D * D;
 
 
 /*
@@ -1382,7 +1382,7 @@ unsigned int AbstractMatrixImpl<T, D, L, S, C>::findEigenvaluesSym(
     if (((outEigenvalues == NULL) && (outEigenvectors == NULL)) || (size == 0))
         return 0;
 
-#define A(r, c) a[(r)*D + (c)]
+#define A(r, c) a[(r) *D + (c)]
     double a[D * D]; // input matrix for algorithm
     double d[D];     // diagonal elements
     double e[D];     // off-diagonal elements

--- a/vislib/include/vislib/memutils.h
+++ b/vislib/include/vislib/memutils.h
@@ -19,7 +19,7 @@
 #ifdef __cplusplus
 #define NULL (0)
 #else
-#define NULL ((void*)0)
+#define NULL ((void*) 0)
 #endif /* __cplusplus */
 #endif /* NULL */
 
@@ -42,7 +42,7 @@
 #ifndef ARY_SAFE_DELETE
 #define ARY_SAFE_DELETE(ptr) \
     if ((ptr) != NULL) {     \
-        delete[](ptr);       \
+        delete[] (ptr);      \
         (ptr) = NULL;        \
     }
 #endif /* !ARY_SAFE_DELETE */

--- a/vislib/include/vislib/sys/sysfunctions.h
+++ b/vislib/include/vislib/sys/sysfunctions.h
@@ -71,9 +71,9 @@ enum TextFileFormatBOM {
  */
 #ifndef CONTAINING_RECORD
 #ifdef _WIN32
-#define CONTAINING_RECORD(address, type, field) ((type*)((PCHAR)(address) - (ULONG_PTR)(&((type*)0)->field)))
+#define CONTAINING_RECORD(address, type, field) ((type*) ((PCHAR) (address) - (ULONG_PTR) (&((type*) 0)->field)))
 #else /* _WIN32 */
-#define CONTAINING_RECORD(address, type, field) ((type*)((PCHAR)(address) - ((ULONG_PTR)(&((type*)4)->field) - 4)))
+#define CONTAINING_RECORD(address, type, field) ((type*) ((PCHAR) (address) - ((ULONG_PTR) (&((type*) 4)->field) - 4)))
 #endif /* _WIN32 */
 #endif /* CONTAINING_RECORD */
 #define CONTAINING_STRUCT(address, type, field) CONTAINING_RECORD(address, type, field)

--- a/vislib/src/MD5HashProvider.cpp
+++ b/vislib/src/MD5HashProvider.cpp
@@ -72,29 +72,29 @@ static const unsigned char PADDING[64] = {0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  * FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4. Rotation is
  * separate from addition to prevent recomputation.
  */
-#define FF(a, b, c, d, x, s, ac)                      \
-    {                                                 \
-        (a) += F((b), (c), (d)) + (x) + (UINT32)(ac); \
-        (a) = ROTATE_LEFT((a), (s));                  \
-        (a) += (b);                                   \
+#define FF(a, b, c, d, x, s, ac)                       \
+    {                                                  \
+        (a) += F((b), (c), (d)) + (x) + (UINT32) (ac); \
+        (a) = ROTATE_LEFT((a), (s));                   \
+        (a) += (b);                                    \
     }
-#define GG(a, b, c, d, x, s, ac)                      \
-    {                                                 \
-        (a) += G((b), (c), (d)) + (x) + (UINT32)(ac); \
-        (a) = ROTATE_LEFT((a), (s));                  \
-        (a) += (b);                                   \
+#define GG(a, b, c, d, x, s, ac)                       \
+    {                                                  \
+        (a) += G((b), (c), (d)) + (x) + (UINT32) (ac); \
+        (a) = ROTATE_LEFT((a), (s));                   \
+        (a) += (b);                                    \
     }
-#define HH(a, b, c, d, x, s, ac)                      \
-    {                                                 \
-        (a) += H((b), (c), (d)) + (x) + (UINT32)(ac); \
-        (a) = ROTATE_LEFT((a), (s));                  \
-        (a) += (b);                                   \
+#define HH(a, b, c, d, x, s, ac)                       \
+    {                                                  \
+        (a) += H((b), (c), (d)) + (x) + (UINT32) (ac); \
+        (a) = ROTATE_LEFT((a), (s));                   \
+        (a) += (b);                                    \
     }
-#define II(a, b, c, d, x, s, ac)                      \
-    {                                                 \
-        (a) += I((b), (c), (d)) + (x) + (UINT32)(ac); \
-        (a) = ROTATE_LEFT((a), (s));                  \
-        (a) += (b);                                   \
+#define II(a, b, c, d, x, s, ac)                       \
+    {                                                  \
+        (a) += I((b), (c), (d)) + (x) + (UINT32) (ac); \
+        (a) = ROTATE_LEFT((a), (s));                   \
+        (a) += (b);                                    \
     }
 
 

--- a/vislib/src/VersionNumber.cpp
+++ b/vislib/src/VersionNumber.cpp
@@ -82,7 +82,7 @@ unsigned int vislib::VersionNumber::Parse(const char* verStr) {
                     this->minorNumber = value;
                     break;
                 case 3:
-                    this->revisionNumber = (const char*)value;
+                    this->revisionNumber = (const char*) value;
                     break;
                 }
                 retval++;
@@ -143,7 +143,7 @@ unsigned int vislib::VersionNumber::Parse(const wchar_t* verStr) {
                     this->minorNumber = value;
                     break;
                 case 3:
-                    this->revisionNumber = (const char*)value;
+                    this->revisionNumber = (const char*) value;
                     break;
                 }
                 retval++;

--- a/vislib/src/sys/MemmappedFile.cpp
+++ b/vislib/src/sys/MemmappedFile.cpp
@@ -442,7 +442,7 @@ vislib::sys::File::FileSize vislib::sys::MemmappedFile::Read(void* outBuf, const
             this->mappedData = this->SafeMapView();
         }
         dataLeft = bufS;
-        bufferPos = (char*)outBuf;
+        bufferPos = (char*) outBuf;
         while (dataLeft > 0) {
             // BUG: what happens if reading more data than available and the view
             // has been resized to smaller than viewSize because the file is shorter?

--- a/vislib_gl/src/graphics/gl/OutlineFont.cpp
+++ b/vislib_gl/src/graphics/gl/OutlineFont.cpp
@@ -525,12 +525,12 @@ int* OutlineFont::buildUpGlyphRun(const char* txtutf8, float maxWidth) const {
         }
 
         // select glyph
-        idx = this->data.glyphIndex[idx * 16 + ((unsigned char)txtutf8[i] % 0x10)];
+        idx = this->data.glyphIndex[idx * 16 + ((unsigned char) txtutf8[i] % 0x10)];
         if (idx == 0)
             continue; // glyph not found
         if (idx > 0) {
             // second part of byte
-            idx = this->data.glyphIndex[idx * 16 + ((unsigned char)txtutf8[i] / 0x10)];
+            idx = this->data.glyphIndex[idx * 16 + ((unsigned char) txtutf8[i] / 0x10)];
             if (idx == 0)
                 continue; // glyph not found
             if (idx > 0)

--- a/vislib_gl/src/graphics/gl/glfunctions.cpp
+++ b/vislib_gl/src/graphics/gl/glfunctions.cpp
@@ -187,7 +187,7 @@ const vislib::VersionNumber& vislib_gl::graphics::gl::GLVersion() {
             minor = vislib::CharTraitsA::ParseInt(verStr);
         }
 
-        number.Set(major, minor, (const char*)release);
+        number.Set(major, minor, (const char*) release);
     }
     return number;
 }


### PR DESCRIPTION
## Summary of Changes
- Update clang-format to version 16 (current VS default)
- Update deprecated rules, min version of rules file is now 14
- We can now switch to `SpaceAfterCStyleCast: true`, we initially used false because of inconsistent behavior of clang-format-12