### PR TITLE
Update Build Environment to 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.24...3.29 FATAL_ERROR)
 
 # Vcpkg setup
-set(MEGAMOL_VCPKG_VERSION "2024.07.12") # Update default-registry baseline in vcpkg.json when changing!
+set(MEGAMOL_VCPKG_VERSION "2026.06.01") # Update default-registry baseline in vcpkg.json when changing!
 
 include(cmake/megamol_vcpkg_setup.cmake)
 include(cmake/megamol_feature_option.cmake)

--- a/cmake/vcpkg_ports/imgui-software-renderer/portfile.cmake
+++ b/cmake/vcpkg_ports/imgui-software-renderer/portfile.cmake
@@ -2,9 +2,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO emilk/imgui_software_renderer
-    REF b5ae63a9e42eccf7db3bf64696761a53424c53dd
-    SHA512 ab318b6aed050c1869dd71e467b2830ce031bb35a8310320b51c92a1fe47c13472000b078bb8cae5b251275ba383a297246c7d589fc24d171ebb6b4bb18a9cf1
+    REPO geringsj/imgui_software_renderer
+    REF e0c04666616da4738e0e0e3ced7aaa9fd5d47aa2
+    SHA512     a68938b7a8697cb3bb677ae458998a81ff8f11331a370369908d3d3d39ccec101d278d39dd8ebfe7d36afd72e70b99cefbcb206058717c16eebd97a2c0130721
     HEAD_REF master
     PATCHES
       fix-include.patch

--- a/cmake/vcpkg_ports/imgui-software-renderer/vcpkg.json
+++ b/cmake/vcpkg_ports/imgui-software-renderer/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "imgui-software-renderer",
   "version-date": "2018-07-12",
   "description": "A Software Renderer for Dear ImGui",
-  "homepage": "https://github.com/emilk/imgui_software_renderer",
+  "homepage": "https://github.com/geringsj/imgui_software_renderer",
   "dependencies": [
     "imgui",
     {

--- a/cmake/vcpkg_ports/imgui-tex-inspect/portfile.cmake
+++ b/cmake/vcpkg_ports/imgui-tex-inspect/portfile.cmake
@@ -2,9 +2,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO andyborrell/imgui_tex_inspect
-    REF ccff03b844cc9845cc3e3c6ef69026fe7051d330 # https://github.com/andyborrell/imgui_tex_inspect/pull/3
-    SHA512 16e73a68bb8c4473bb8b3b1ddbab62453b36f4e4d0deb5f62c209c7b05bbe12173420dee8441e3d1ab9cec25f6dd77f8f4039c1a6f91fe972c88e5c21cfa634f
+    REPO geringsj/imgui_tex_inspect
+    REF c93070751658aad8223ac13bacc0397184bb993a # based on https://github.com/andyborrell/imgui_tex_inspect/pull/3
+    SHA512 ce8a998fd1137c941ca456457041d3a60e858515ba95100e59205737ef1ec5522bbd586d57f75938802db09c7703cb06954ae0cb2643fe82e032b7f8d316ecfe
     HEAD_REF main
     PATCHES
         imgui-changes.patch

--- a/cmake/vcpkg_ports/imgui-tex-inspect/vcpkg.json
+++ b/cmake/vcpkg_ports/imgui-tex-inspect/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "imgui-tex-inspect",
   "version-date": "2022-09-15",
   "description": "A texture inspector tool for Dear ImGui",
-  "homepage": "https://github.com/andyborrell/imgui_tex_inspect",
+  "homepage": "https://github.com/geringsj/imgui_tex_inspect",
   "license": "MIT",
   "dependencies": [
     "imgui",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(${PROJECT_NAME}
     OpenMP::OpenMP_CXX
     TBB::tbb
     imgui::imgui
-    sol2
   PRIVATE
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/frontend/main/src/CLIConfigParsing.cpp
+++ b/frontend/main/src/CLIConfigParsing.cpp
@@ -554,7 +554,7 @@ static void vr_service_handler(
 
         exit("vr service cli option needs to be one of the following: " +
              std::accumulate(options.begin(), options.end(), std::string{},
-                 [](auto const& a, auto const& b) { return a + "  " + b.first; }));
+                 [](auto const& a, auto const& b) { return a + "  " + b.first; }) + ", but has: " + string);
     };
 
     config.vr_mode = match(string);

--- a/frontend/services/CMakeLists.txt
+++ b/frontend/services/CMakeLists.txt
@@ -190,7 +190,7 @@ target_link_libraries(${PROJECT_NAME}
     implot::implot
     libzmq
     cppzmq
-    sol2)
+  )
 target_compile_definitions(${PROJECT_NAME}
   PUBLIC
     SOL_ALL_SAFETIES_ON=1)

--- a/frontend/services/gui/3rd/imgui_canvas.cpp
+++ b/frontend/services/gui/3rd/imgui_canvas.cpp
@@ -129,6 +129,8 @@ bool ImGuiEx::Canvas::Begin(ImGuiID id, const ImVec2& size)
     // Record cursor max to prevent scrollbars from appearing.
     m_WindowCursorMaxBackup = ImGui::GetCurrentWindow()->DC.CursorMaxPos;
 
+    ImGui::SetNextItemAllowOverlap();
+
     EnterLocalSpace();
 
     // Emit dummy widget matching bounds of the canvas.
@@ -161,8 +163,6 @@ void ImGuiEx::Canvas::End()
     LeaveLocalSpace();
 
     ImGui::GetCurrentWindow()->DC.CursorMaxPos = m_WindowCursorMaxBackup;
-
-    ImGui::SetItemAllowOverlap();
 
     // Emit dummy widget matching bounds of the canvas.
     ImGui::SetCursorScreenPos(m_WidgetPosition);

--- a/frontend/services/gui/src/GUIManager.cpp
+++ b/frontend/services/gui/src/GUIManager.cpp
@@ -441,9 +441,9 @@ bool GUIManager::OnKey(core::view::Key key, core::view::KeyAction action, core::
     auto imgui_key_index = gui_utils::GlfwKeyToImGuiKey(key);
     io.AddKeyEvent(imgui_key_index, (core::view::KeyAction::PRESS == action));
 
-    io.AddKeyEvent(ImGuiKey_ModCtrl, (mods.equals(megamol::frontend_resources::Modifier::CTRL)));
-    io.AddKeyEvent(ImGuiKey_ModShift, (mods.equals(megamol::frontend_resources::Modifier::SHIFT)));
-    io.AddKeyEvent(ImGuiKey_ModAlt, (mods.equals(megamol::frontend_resources::Modifier::ALT)));
+    io.AddKeyEvent(ImGuiMod_Ctrl, (mods.equals(megamol::frontend_resources::Modifier::CTRL)));
+    io.AddKeyEvent(ImGuiMod_Shift, (mods.equals(megamol::frontend_resources::Modifier::SHIFT)));
+    io.AddKeyEvent(ImGuiMod_Alt, (mods.equals(megamol::frontend_resources::Modifier::ALT)));
 
     // Pass NUM 'Enter' as alternative for 'Return' to ImGui
     if (imgui_key_index == ImGuiKey_KeypadEnter) {
@@ -467,7 +467,6 @@ bool GUIManager::OnChar(unsigned int codePoint) {
     ImGui::SetCurrentContext(this->imgui_context);
 
     ImGuiIO& io = ImGui::GetIO();
-    io.ClearInputCharacters();
     if (codePoint > 0 && codePoint < 0x10000) {
         io.AddInputCharacter((unsigned short) codePoint);
     }
@@ -507,9 +506,9 @@ bool GUIManager::OnMouseButton(
     auto buttonIndex = static_cast<size_t>(button);
     ImGuiIO& io = ImGui::GetIO();
 
-    io.AddKeyEvent(ImGuiKey_ModCtrl, (mods.equals(megamol::frontend_resources::Modifier::CTRL)));
-    io.AddKeyEvent(ImGuiKey_ModShift, (mods.equals(megamol::frontend_resources::Modifier::SHIFT)));
-    io.AddKeyEvent(ImGuiKey_ModAlt, (mods.equals(megamol::frontend_resources::Modifier::ALT)));
+    io.AddKeyEvent(ImGuiMod_Ctrl, (mods.equals(megamol::frontend_resources::Modifier::CTRL)));
+    io.AddKeyEvent(ImGuiMod_Shift, (mods.equals(megamol::frontend_resources::Modifier::SHIFT)));
+    io.AddKeyEvent(ImGuiMod_Alt, (mods.equals(megamol::frontend_resources::Modifier::ALT)));
 
     io.AddMouseButtonEvent(buttonIndex, down);
 
@@ -629,7 +628,6 @@ bool GUIManager::create_context() {
         ImGuiIO& current_io = ImGui::GetIO();
         font_atlas = current_io.Fonts;
         default_font = current_io.FontDefault;
-        ImGui::GetCurrentContext()->FontAtlasOwnedByContext = false;
     }
 
     // Create ImGui context ---------------------------------------------------
@@ -724,7 +722,6 @@ bool GUIManager::destroy_context() {
                 // Shutdown API only if only one context is left
                 this->render_backend.ShutdownBackend();
                 // Last context should delete font atlas
-                ImGui::GetCurrentContext()->FontAtlasOwnedByContext = true;
             }
 
             if (this->implot_context != nullptr) {

--- a/frontend/services/gui/src/graph/Call.cpp
+++ b/frontend/services/gui/src/graph/Call.cpp
@@ -290,9 +290,9 @@ void megamol::gui::Call::Draw(megamol::gui::PresentPhase phase, megamol::gui::Gr
 
                         // Button
                         ImGui::SetCursorScreenPos(call_rect_min);
-                        ImGui::SetItemAllowOverlap();
+                        ImGui::SetNextItemAllowOverlap();
                         ImGui::InvisibleButton(button_label.c_str(), rect_size, ImGuiButtonFlags_NoSetKeyOwner);
-                        ImGui::SetItemAllowOverlap();
+                        ImGui::SetNextItemAllowOverlap();
 
                         /// Draw simple line if zooming is too small for nice bezier curves.
                         auto mouse_pos = ImGui::GetMousePos();

--- a/frontend/services/gui/src/graph/CallSlot.cpp
+++ b/frontend/services/gui/src/graph/CallSlot.cpp
@@ -318,10 +318,10 @@ void megamol::gui::CallSlot::Draw(PresentPhase phase, megamol::gui::GraphItemsSt
 
             // Button
             ImGui::SetCursorScreenPos(slot_position - ImVec2(radius, radius));
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             ImGui::InvisibleButton(
                 button_label.c_str(), ImVec2(radius * 2.0f, radius * 2.0f), ImGuiButtonFlags_NoSetKeyOwner);
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             if (ImGui::IsItemActivated()) {
                 state.interact.button_active_uid = this->uid;
             }

--- a/frontend/services/gui/src/graph/Graph.cpp
+++ b/frontend/services/gui/src/graph/Graph.cpp
@@ -2107,7 +2107,7 @@ void megamol::gui::Graph::draw_menu(GraphState_t& state) {
     auto button_size = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
 
     float child_height = ImGui::GetFrameHeightWithSpacing();
-    auto child_flags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NavFlattened | ImGuiWindowFlags_MenuBar;
+    auto child_flags = ImGuiWindowFlags_NoMove | ImGuiChildFlags_NavFlattened | ImGuiWindowFlags_MenuBar;
     ImGui::BeginChild("graph_menu", ImVec2(0.0f, child_height), false, child_flags);
 
     ImGui::BeginMenuBar();
@@ -2569,7 +2569,7 @@ void megamol::gui::Graph::draw_parameters(ImVec2 position, ImVec2 size) {
 
     float search_child_height = ImGui::GetFrameHeightWithSpacing() * 3.5f;
     child_flags =
-        ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NavFlattened;
+        ImGuiChildFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_NoScrollbar | ImGuiChildFlags_NavFlattened;
     ImGui::BeginChild("parameter_search_child", ImVec2(size.x, search_child_height), false, child_flags);
 
     ImGui::TextUnformatted("Parameters");
@@ -2595,8 +2595,8 @@ void megamol::gui::Graph::draw_parameters(ImVec2 position, ImVec2 size) {
 
     // ------------------------------------------------------------------------
 
-    child_flags = ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NavFlattened |
-                  ImGuiWindowFlags_AlwaysUseWindowPadding;
+    child_flags = ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiChildFlags_NavFlattened |
+                  ImGuiChildFlags_AlwaysUseWindowPadding;
     ImGui::BeginChild("parameter_param_frame_child", ImVec2(size.x, 0.0f), false, child_flags);
 
     if (!this->gui_graph_state.interact.modules_selected_uids.empty()) {
@@ -3294,7 +3294,7 @@ void megamol::gui::Graph::draw_profiling(ImVec2 position, ImVec2 size) {
     ImGui::SetNextWindowPos(position);
 
     float child_height = ImGui::GetFrameHeightWithSpacing();
-    auto child_flags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NavFlattened | ImGuiWindowFlags_MenuBar;
+    auto child_flags = ImGuiWindowFlags_NoMove | ImGuiChildFlags_NavFlattened | ImGuiWindowFlags_MenuBar;
     ImGui::BeginChild("profiling_menu", ImVec2(size.x, child_height), false, child_flags);
 
     ImGui::BeginMenuBar();

--- a/frontend/services/gui/src/graph/Group.cpp
+++ b/frontend/services/gui/src/graph/Group.cpp
@@ -420,9 +420,9 @@ void megamol::gui::Group::Draw(megamol::gui::PresentPhase phase, GraphItemsState
             // Button
             std::string button_label = "group_" + std::to_string(this->uid);
             ImGui::SetCursorScreenPos(group_rect_min);
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             ImGui::InvisibleButton(button_label.c_str(), group_size, ImGuiButtonFlags_NoSetKeyOwner);
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             if (ImGui::IsItemActivated()) {
                 state.interact.button_active_uid = this->uid;
             }

--- a/frontend/services/gui/src/graph/InterfaceSlot.cpp
+++ b/frontend/services/gui/src/graph/InterfaceSlot.cpp
@@ -282,10 +282,10 @@ void megamol::gui::InterfaceSlot::Draw(PresentPhase phase, megamol::gui::GraphIt
 
             // Button
             ImGui::SetCursorScreenPos(actual_position - ImVec2(radius, radius));
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             ImGui::InvisibleButton(
                 button_label.c_str(), ImVec2(radius * 2.0f, radius * 2.0f), ImGuiButtonFlags_NoSetKeyOwner);
-            ImGui::SetItemAllowOverlap();
+            ImGui::SetNextItemAllowOverlap();
             if (ImGui::IsItemActivated()) {
                 state.interact.button_active_uid = this->uid;
             }

--- a/frontend/services/gui/src/graph/Module.cpp
+++ b/frontend/services/gui/src/graph/Module.cpp
@@ -241,9 +241,9 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
 
                 // Button
                 ImGui::SetCursorScreenPos(module_rect_min);
-                ImGui::SetItemAllowOverlap();
+                ImGui::SetNextItemAllowOverlap();
                 ImGui::InvisibleButton(button_label.c_str(), module_size, ImGuiButtonFlags_NoSetKeyOwner);
-                ImGui::SetItemAllowOverlap();
+                ImGui::SetNextItemAllowOverlap();
                 if (this->gui_set_active || ImGui::IsItemActivated()) {
                     state.interact.button_active_uid = this->uid;
                     this->gui_set_active = false;
@@ -480,7 +480,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                                 state.interact.module_graphentry_changed = vislib::math::Ternary::TRI_FALSE;
                             }
                         }
-                        ImGui::SetItemAllowOverlap();
+                        ImGui::SetNextItemAllowOverlap();
                         if (this->gui_hovered) {
                             std::string tooltip_label;
                             if (is_graph_entry) {
@@ -515,7 +515,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                                 state.interact.module_param_child_position = ImVec2(-1.0f, -1.0f);
                             }
                         }
-                        ImGui::SetItemAllowOverlap();
+                        ImGui::SetNextItemAllowOverlap();
                         if (this->gui_hovered) {
                             ImGui::PushFont(state.canvas.gui_font_ptr);
                             this->gui_other_item_hovered |= this->gui_tooltip.ToolTip("Parameters");
@@ -544,7 +544,7 @@ void megamol::gui::Module::Draw(megamol::gui::PresentPhase phase, megamol::gui::
                                 state.interact.profiling_show = true;
                             }
                         }
-                        ImGui::SetItemAllowOverlap();
+                        ImGui::SetNextItemAllowOverlap();
                         if (this->gui_hovered) {
                             ImGui::PushFont(state.canvas.gui_font_ptr);
                             this->gui_other_item_hovered |= this->gui_tooltip.ToolTip("Profiling");

--- a/frontend/services/gui/src/gui_render_backend.cpp
+++ b/frontend/services/gui/src/gui_render_backend.cpp
@@ -273,7 +273,8 @@ bool megamol::gui::gui_render_backend::CreateFontsTexture() {
     }
 #ifdef MEGAMOL_USE_OPENGL
     case (GUIRenderBackend::OPEN_GL): {
-        return ImGui_ImplOpenGL3_CreateFontsTexture();
+        // font textures created and handled by imgui automatically 
+        return true;
     } break;
 #endif // MEGAMOL_USE_OPENGL
     case (GUIRenderBackend::CPU): {

--- a/frontend/services/gui/src/widgets/DefaultStyle.h
+++ b/frontend/services/gui/src/widgets/DefaultStyle.h
@@ -44,7 +44,7 @@ inline void DefaultStyle() {
     style.LogSliderDeadzone = 4.0f;
     style.TabRounding = 4.0f;
     style.TabBorderSize = 0.0f;
-    style.TabMinWidthForCloseButton = 0.0f;
+    style.TabCloseButtonMinWidthUnselected = 0.0f;
     style.ColorButtonPosition = ImGuiDir_Right;
     style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
     style.SelectableTextAlign = ImVec2(0.0f, 0.0f);

--- a/frontend/services/gui/src/widgets/ImageWidget.h
+++ b/frontend/services/gui/src/widgets/ImageWidget.h
@@ -103,10 +103,10 @@ private:
         return (this->toggle_tex_ptr->getName() != 0); // OpenGL texture id
     }
     ImTextureID getImTextureID() const {
-        return reinterpret_cast<ImTextureID>(static_cast<uint64_t>(this->tex_ptr->getName()));
+        return static_cast<ImTextureID>(static_cast<uint64_t>(this->tex_ptr->getName()));
     }
     ImTextureID getToggleImTextureID() const {
-        return reinterpret_cast<ImTextureID>(static_cast<uint64_t>(this->toggle_tex_ptr->getName()));
+        return static_cast<ImTextureID>(static_cast<uint64_t>(this->toggle_tex_ptr->getName()));
     }
 
 #else

--- a/frontend/services/gui/src/windows/AnimationEditor.cpp
+++ b/frontend/services/gui/src/windows/AnimationEditor.cpp
@@ -818,7 +818,7 @@ void AnimationEditor::DrawParams() {
         for (int32_t a = 0; a < allAnimations.size(); ++a) {
             ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_SpanFullWidth |
                                        ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_FramePadding |
-                                       ImGuiTreeNodeFlags_AllowItemOverlap;
+                                       ImGuiTreeNodeFlags_AllowOverlap;
             if (selectedAnimation == a) {
                 flags |= ImGuiTreeNodeFlags_Selected;
             }
@@ -1250,9 +1250,9 @@ void AnimationEditor::DrawCurves() {
             } else {
                 factor = 0.8f * std::abs(gui_mouse_wheel);
             }
-            if (ImGui::IsKeyDown(ImGuiKey_ModShift)) {
+            if (ImGui::IsKeyDown(ImGuiMod_Shift)) {
                 custom_zoom.y *= factor;
-            } else if (ImGui::IsKeyDown(ImGuiKey_ModCtrl)) {
+            } else if (ImGui::IsKeyDown(ImGuiMod_Ctrl)) {
                 custom_zoom.x *= factor;
             } else {
                 custom_zoom *= factor;

--- a/frontend/services/gui/src/windows/Configurator.cpp
+++ b/frontend/services/gui/src/windows/Configurator.cpp
@@ -380,7 +380,7 @@ void megamol::gui::Configurator::draw_window_module_list(float width, float heig
     ImGui::BeginGroup();
 
     const float search_child_height = ImGui::GetFrameHeightWithSpacing() * 2.5f;
-    auto child_flags = ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_NoScrollbar;
+    auto child_flags = ImGuiChildFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_NoScrollbar;
     ImGui::BeginChild("module_search_child_window", ImVec2(width, search_child_height), false, child_flags);
 
     ImGui::TextUnformatted("Available Modules");

--- a/frontend/services/gui/src/windows/LogConsole.cpp
+++ b/frontend/services/gui/src/windows/LogConsole.cpp
@@ -347,7 +347,7 @@ bool megamol::gui::LogConsole::Draw() {
     ImGui::BeginChild("log_messages",
         ImVec2(0.0f,
             ImGui::GetWindowHeight() - (3.0f * ImGui::GetFrameHeightWithSpacing()) - (3.0f * style.FramePadding.y)),
-        ImGuiChildFlags_Border, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysVerticalScrollbar);
+        ImGuiChildFlags_Borders, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysVerticalScrollbar);
 
     auto message_count = 0ull;
     if (this->win_log_level != megamol::core::utility::log::Log::log_level::none) {

--- a/plugins/infovis/CMakeLists.txt
+++ b/plugins/infovis/CMakeLists.txt
@@ -12,14 +12,14 @@ megamol_plugin(infovis
 if (infovis_PLUGIN_ENABLED)
   find_package(Eigen3 CONFIG REQUIRED)
   find_package(bhtsne CONFIG REQUIRED)
-  find_package(ltla_umappp CONFIG REQUIRED)
+  find_package(libscran_umappp CONFIG REQUIRED)
   find_path(DELAUNATOR_CPP_INCLUDE_DIRS "delaunator.hpp")
 
   target_link_libraries(infovis
     PRIVATE
       Eigen3::Eigen
       bhtsne::bhtsne
-      ltla::umappp)
+      libscran::umappp)
   target_include_directories(infovis
     PRIVATE
       ${DELAUNATOR_CPP_INCLUDE_DIRS})

--- a/plugins/infovis/src/UMAProjection.cpp
+++ b/plugins/infovis/src/UMAProjection.cpp
@@ -8,7 +8,7 @@
 
 #include <sstream>
 
-#include <umappp/Umap.hpp>
+#include <umappp/umappp.hpp>
 
 #include "datatools/table/TableDataCall.h"
 #include "mmcore/param/BoolParam.h"
@@ -19,7 +19,46 @@
 using namespace megamol;
 using namespace megamol::infovis;
 
-using Umap = umappp::Umap<double>;
+namespace {
+    /// Taken from 
+    /// https://github.com/libscran/umappp/blob/4a0ff313f967c794bbfe292891677b4847d94447/include/umappp/Umap.hpp
+    /// After this commit the Umap class and Defaults struct have been removed
+    struct UmapDefaults {
+        using Float = double;
+
+        static constexpr Float local_connectivity = 1.0;
+
+        static constexpr Float bandwidth = 1;
+
+        static constexpr Float mix_ratio = 1;
+
+        static constexpr Float spread = 1;
+
+        static constexpr Float min_dist = 0.01;
+
+        static constexpr Float a = 0;
+
+        static constexpr Float b = 0;
+
+        static constexpr Float repulsion_strength = 1;
+
+        //static constexpr InitMethod initialize = SPECTRAL;
+
+        static constexpr int num_epochs = -1;
+
+        static constexpr Float learning_rate = 1; 
+
+        static constexpr Float negative_sample_rate = 5;
+
+        static constexpr int num_neighbors = 15;
+
+        static constexpr uint64_t seed = 1234567890;
+
+        static constexpr int num_threads = 1;
+
+        static constexpr int parallel_optimization = false;
+    };
+}
 
 UMAProjection::UMAProjection()
         : megamol::core::Module()
@@ -85,40 +124,42 @@ UMAProjection::UMAProjection()
     nDimsSlot << new ::megamol::core::param::IntParam(2);
     this->MakeSlotAvailable(&nDimsSlot);
 
-    randomSeedSlot << new ::megamol::core::param::IntParam(Umap::Defaults::seed);
+    randomSeedSlot << new ::megamol::core::param::IntParam(UmapDefaults::seed);
     this->MakeSlotAvailable(&randomSeedSlot);
 
-    nEpochsSlot << new ::megamol::core::param::IntParam(Umap::Defaults::num_epochs);
+    nEpochsSlot << new ::megamol::core::param::IntParam(UmapDefaults::num_epochs);
     this->MakeSlotAvailable(&nEpochsSlot);
 
-    learningRateSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::learning_rate);
+    learningRateSlot << new ::megamol::core::param::FloatParam(UmapDefaults::learning_rate);
     this->MakeSlotAvailable(&learningRateSlot);
 
-    localConnectivitySlot << new ::megamol::core::param::FloatParam(Umap::Defaults::local_connectivity);
+    localConnectivitySlot << new ::megamol::core::param::FloatParam(UmapDefaults::local_connectivity);
     this->MakeSlotAvailable(&localConnectivitySlot);
 
-    bandwidthSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::bandwidth);
+    bandwidthSlot << new ::megamol::core::param::FloatParam(UmapDefaults::bandwidth);
     this->MakeSlotAvailable(&bandwidthSlot);
 
 
-    mixRatioSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::mix_ratio);
+    mixRatioSlot << new ::megamol::core::param::FloatParam(UmapDefaults::mix_ratio);
     this->MakeSlotAvailable(&mixRatioSlot);
 
-    spreadSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::spread);
+    spreadSlot << new ::megamol::core::param::FloatParam(UmapDefaults::spread);
     this->MakeSlotAvailable(&spreadSlot);
 
-    minDistSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::min_dist);
+    minDistSlot << new ::megamol::core::param::FloatParam(UmapDefaults::min_dist);
     this->MakeSlotAvailable(&minDistSlot);
 
-    aSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::a);
+    aSlot << new ::megamol::core::param::FloatParam(UmapDefaults::a);
     this->MakeSlotAvailable(&aSlot);
 
-    bSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::b);
+    bSlot << new ::megamol::core::param::FloatParam(UmapDefaults::b);
     this->MakeSlotAvailable(&bSlot);
 
-    repulsionStrengthSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::repulsion_strength);
+    repulsionStrengthSlot << new ::megamol::core::param::FloatParam(UmapDefaults::repulsion_strength);
     this->MakeSlotAvailable(&repulsionStrengthSlot);
 
+    // problem: enum changed to
+    // enum InitializeMethod : char { SPECTRAL, RANDOM, NONE };
     initializeSlot << new ::megamol::core::param::EnumParam(0);
     initializeSlot.Param<param::EnumParam>()->SetTypePair(0, "spectral (fallback: random)");
     initializeSlot.Param<param::EnumParam>()->SetTypePair(1, "spectral (fallback: existing)");
@@ -126,10 +167,10 @@ UMAProjection::UMAProjection()
     //initializeSlot.Param<param::EnumParam>()->SetTypePair(3, "existing");
     this->MakeSlotAvailable(&initializeSlot);
 
-    negativeSampleRateSlot << new ::megamol::core::param::FloatParam(Umap::Defaults::negative_sample_rate);
+    negativeSampleRateSlot << new ::megamol::core::param::FloatParam(UmapDefaults::negative_sample_rate);
     this->MakeSlotAvailable(&negativeSampleRateSlot);
 
-    nNeighborsSlot << new ::megamol::core::param::IntParam(Umap::Defaults::num_neighbors);
+    nNeighborsSlot << new ::megamol::core::param::IntParam(UmapDefaults::num_neighbors);
     this->MakeSlotAvailable(&nNeighborsSlot);
 }
 
@@ -253,24 +294,45 @@ bool megamol::infovis::UMAProjection::project(megamol::datatools::table::TableDa
     std::vector<double> embeddingData(nDims * obsCount, 0.0);
 
     // Run UMAP algorithm.
-    Umap umap;
-    umap.set_seed(randomSeed);
-    umap.set_num_epochs(nEpochs);
-    umap.set_learning_rate(learningRate);
-    umap.set_local_connectivity(localConnectivity);
-    umap.set_bandwidth(bandwidth);
-    umap.set_mix_ratio(mixRatio);
-    umap.set_spread(spread);
-    umap.set_min_dist(minDist);
-    umap.set_a(a);
-    umap.set_b(b);
-    umap.set_repulsion_strength(repulsionStrength);
-    umap.set_initialize(static_cast<umappp::InitMethod>(initialize));
-    umap.set_negative_sample_rate(negativeSampleRate);
-    umap.set_num_neighbors(nNeighbors);
-    auto status = umap.run(dimCount, obsCount, inputData.data(), nDims, embeddingData.data(), 0);
+    umappp::Options opt;
+    opt.optimize_seed = randomSeed;
+    opt.num_epochs = nEpochs;
+    opt.learning_rate = learningRate;
+    opt.local_connectivity = localConnectivity;
+    opt.bandwidth = bandwidth;
+    opt.mix_ratio = mixRatio;
+    opt.spread = spread;
+    opt.min_dist = minDist;
+    opt.a = a;
+    opt.b = b;
+    opt.repulsion_strength = repulsionStrength;
+    opt.negative_sample_rate = negativeSampleRate;
+    opt.num_neighbors = nNeighbors;
+
+    opt.initialize_method = static_cast<umappp::InitializeMethod>(initialize);
+
+    knncolle::VptreeBuilder<int, double, double> vp_builder(
+        std::make_shared<knncolle::EuclideanDistance<double, double> >()
+    );
+
+    auto status = umappp::initialize(
+        dimCount, 
+        (int)obsCount, 
+        inputData.data(), 
+        vp_builder, 
+        nDims, 
+        embeddingData.data(), 
+        opt);
+
+    status.run(embeddingData.data());
+
     megamol::core::utility::log::Log::DefaultLog.WriteInfo(_T("Epoch %d of %d; a: %lf b: %lf, obs: %d\n"),
-        status.epoch(), status.num_epochs(), status.rparams.a, status.rparams.b, status.nobs());
+        status.epoch(), 
+        status.num_epochs(), 
+        opt.a.value(), 
+        opt.b.value(), 
+        status.num_observations()
+    );
 
     // Search extreme values.
     std::vector<double> minimas(nDims, 0.0);

--- a/plugins/mmstd_gl/3rd/ImGuiTexInspect/DemoSnippets.h
+++ b/plugins/mmstd_gl/3rd/ImGuiTexInspect/DemoSnippets.h
@@ -7,7 +7,7 @@ namespace ImGuiTexInspect {
 // Source: https://github.com/andyborrell/imgui_tex_inspect/blob/80ffc679e8f3f477d861d7a806e072098e94158c/imgui_tex_inspect_demo.h#L8-L12
 struct Texture
 {
-    void* texture;
+    ImTextureID texture;
     ImVec2 size;
 };
 

--- a/plugins/mmstd_gl/src/special/TextureInspector.cpp
+++ b/plugins/mmstd_gl/src/special/TextureInspector.cpp
@@ -110,7 +110,7 @@ void TextureInspector::ShowWindow() {
             SetFlag(flags_, ImGuiTexInspect::InspectorFlags_FlipY);
 
         // Call function to render currently example scene
-        (*(scenes[selected_scene].draw_fn))({tex_.texture, ImVec2{tex_.x, tex_.y}}, flags_);
+        (*(scenes[selected_scene].draw_fn))({reinterpret_cast<ImTextureID>(tex_.texture), ImVec2{tex_.x, tex_.y}}, flags_);
 
         ImGui::Separator();
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "1de2026f28ead93ff1773e6e680387643e914ea1"
+      "baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075"
     }
   },
   "name": "megamol",
@@ -41,7 +41,7 @@
       "platform": "!windows"
     },
     "libpng",
-    "ltla-umappp",
+    "libscran-umappp",
     "lua",
     "mmpld-io",
     "nanoflann",


### PR DESCRIPTION
These commits update the vcpkg dependencies and some of our portfiles to run successfully in 2026. 

After the vcpkg update I had to update use of ImGui to the latest version. Updating ImGui mostly meant updating a few outdated enum values to new, semantically equivalent ones. 
The only case of ImGui API change that had semantic changes was the replacement of `ImGui::SetItemAllowOverlap();` (referring to the previous item) by `ImGui::SetNextItemAllowOverlap();` (referring to the next item). I replaced the old function with the new one, but did not think too much about the semantic implications to the GUI items built by the GUI service. On short testing I did not notice usability problems.

Besides ImGui API changes I had to update the ImGui TexInspector. The TexInspector repository is abandoned by now and I put the TexInspector update to the latest ImGui in a new fork.

Lastly, the umappp library used in the infovis UMAPProjection had API changes from a class-based interface to a free-function based API, which were mostly straight forward to update and did not seem to introduce semantic changes.

Tested compilation on Windows 11 using VS Code and the Visual Studio 2022 Community Toolchain.

## Summary of Changes
- Updated the build environment to 2026, along with code updates for API changes in libraries

## References and Context
MegaMol build system was a few years behind, so that relevant versions of dependencies in vcpkg were not available anymore, or had API changes in their latest releases that broke our build.

## Test Instructions
Do a fresh clone of MegaMol and compile the build2026 branch.